### PR TITLE
Parametrize X end flange to allow arbitrary flange sizes (MK2)

### DIFF
--- a/Printed-Parts/scad/x-end.scad
+++ b/Printed-Parts/scad/x-end.scad
@@ -10,6 +10,8 @@ use <polyholes.scad>
 
 // Parameters 
 rod_distance = 45; // Distance between vertical rods
+tr_hole = 13.2; // Diameter of hole for threaded rod (mm). For 22mm flange, this is 10.5mm
+tr_nut_distance = 19; // Distance between anchors of threaded rod (mm). For 22mm flange, this is 16mm
 
 module x_end_base(){
 // Main block
@@ -52,16 +54,16 @@ translate(v=[-15,-41.5,rod_distance+6]) rotate(a=[-90,0,0]) pushfit_rod(7.8,50);
 
 // TR Nut trap
    // Hole for the nut
-    translate(v=[0,-17, -1]) poly_cylinder(h = 9.01, r = 6.6, $fn = 25);
+    translate(v=[0,-17, -1]) poly_cylinder(h = 9.01, r = tr_hole/2, $fn = 25);
 
 // Screw holes for TR nut
-    translate(v=[0,-17, 0]) rotate([0, 0, -135]) translate([0, 9.5, -1]) cylinder(h = 10, r = 1.55, $fn=25);
-    translate(v=[0,-17, 0]) rotate([0, 0, -135]) translate([0, -9.5, -1]) cylinder(h = 10, r = 1.55, $fn=25);
+    translate(v=[0,-17, 0]) rotate([0, 0, -135]) translate([0, tr_nut_distance/2, -1]) cylinder(h = 10, r = 1.55, $fn=25);
+    translate(v=[0,-17, 0]) rotate([0, 0, -135]) translate([0, -tr_nut_distance/2, -1]) cylinder(h = 10, r = 1.55, $fn=25);
 
 // Nut traps for TR nut screws
-    translate(v=[0,-17, 0]) rotate([0, 0, -135]) translate([0, 9.5, 6]) rotate([0, 0, 0])cylinder(h = 3, r = 3.3, $fn=6);
+    translate(v=[0,-17, 0]) rotate([0, 0, -135]) translate([0, tr_nut_distance/2, 6]) rotate([0, 0, 0])cylinder(h = 3, r = 3.3, $fn=6);
 
-    translate(v=[0,-17, 0]) rotate([0, 0, -135]) translate([0, -9.5, 6]) rotate([0, 0, 30])cylinder(h = 3, r = 3.2, $fn=6);
+    translate(v=[0,-17, 0]) rotate([0, 0, -135]) translate([0, -tr_nut_distance/2, 6]) rotate([0, 0, 30])cylinder(h = 3, r = 3.2, $fn=6);
     translate([-5.5,-17.2,6]) rotate([0,0,30]) cube([5,5,3]);
     translate([-0,-17.2,6]) rotate([0,0,60]) cube([5,10,3]);
 }

--- a/Printed-Parts/scad/x-end.scad
+++ b/Printed-Parts/scad/x-end.scad
@@ -7,7 +7,9 @@
 
 use <bearing.scad>
 use <polyholes.scad>
-rod_distance = 45;
+
+// Parameters 
+rod_distance = 45; // Distance between vertical rods
 
 module x_end_base(){
 // Main block


### PR DESCRIPTION
This pull request allows for threaded rod flange nuts of different sizes to be inserted by simply changing one parameter. The default for 25mm nuts remains, but it also allows for easily switching to 22mm nuts.

tarek : )
