### PR TITLE
Fix so that belt holders get their reinforcement cuts.

### DIFF
--- a/Printed-Parts/scad/y-belt-holder.scad
+++ b/Printed-Parts/scad/y-belt-holder.scad
@@ -7,9 +7,15 @@
 
 module main_body()
 {
-translate([-1, -1, -1 ]) cube([ 30, 27, 15 ]);
-translate([-10, 16, -1 ]) cube([ 50.5, 10, 15 ]);
-translate([-10, 23, -1 ]) cube([ 52, 3, 15 ]);
+difference() {
+    union() {
+        translate([-1, -1, -1 ]) cube([ 30, 27, 15 ]);
+        translate([-10, 16, -1 ]) cube([ 50.5, 10, 15 ]);
+        translate([-10, 23, -1 ]) cube([ 52, 3, 15 ]);
+    }
+    translate([ 16, 18, 2 ]) cylinder( h = 16, r = 7.2, $fn=30 );  // upper belt space cutaway
+translate([ 12, 5, 2 ]) cylinder( h = 16, r = 7.2, $fn=30 );  // lower belt space cutaway
+    }
 }
 
 module belt_holders()
@@ -41,19 +47,18 @@ module screws()
     translate([35.5, 15, 4.5 ]) cube([ 6, 7, 6 ]);
 }
 
-belt_holders();
 
 difference()
 {
-main_body();
+union() {
+    main_body();
+    belt_holders();
+}
     
-translate([ 16, 18, 2 ]) cylinder( h = 16, r = 7.2, $fn=30 );  // upper belt space cutaway
-translate([ 12, 5, 2 ]) cylinder( h = 16, r = 7.2, $fn=30 );  // lower belt space cutaway
-
 translate([-20, 9, 2]) cube([ 28, 2.1, 16 ]); 
-rotate([0,0,40]) translate([11, 1, 2 ]) cube([ 10, 4, 16 ]);     
+rotate([0,0,40]) translate([11, 1, 2 ]) cube([ 8, 4, 16 ]);     
     
-translate([10, 7, 2 ]) cube([ 32, 2.1, 16 ]); 
+translate([16, 7, 2 ]) cube([ 16, 2.1, 16 ]); 
     
 translate([16, 8, 11 ]) rotate([45,0,0]) cube([ 15, 5, 5 ]);     
 translate([-2, 10, 11 ]) rotate([45,0,0]) cube([ 10, 5, 5 ]);     

--- a/Printed-Parts/stl/y-belt-holder.stl
+++ b/Printed-Parts/stl/y-belt-holder.stl
@@ -1,2160 +1,4 @@
 solid OpenSCAD_Model
-  facet normal 0.994522 0.10453 0
-    outer loop
-      vertex 19.5 18 11
-      vertex 19.4235 18.7277 2
-      vertex 19.4235 18.7277 11
-    endloop
-  endfacet
-  facet normal 0.994522 0.10453 0
-    outer loop
-      vertex 19.4235 18.7277 2
-      vertex 19.5 18 11
-      vertex 19.5 18 2
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 16.3658 21.4808 2
-      vertex 15.6341 21.4808 11
-      vertex 16.3658 21.4808 11
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.6341 21.4808 11
-      vertex 16.3658 21.4808 2
-      vertex 15.6341 21.4808 2
-    endloop
-  endfacet
-  facet normal -0.587786 -0.809017 0
-    outer loop
-      vertex 13.658 15.399 2
-      vertex 14.25 14.9689 11
-      vertex 13.658 15.399 11
-    endloop
-  endfacet
-  facet normal -0.587786 -0.809017 -0
-    outer loop
-      vertex 14.25 14.9689 11
-      vertex 13.658 15.399 2
-      vertex 14.25 14.9689 2
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 -0
-    outer loop
-      vertex 18.342 20.601 2
-      vertex 17.75 21.0311 11
-      vertex 18.342 20.601 11
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 0
-    outer loop
-      vertex 17.75 21.0311 11
-      vertex 18.342 20.601 2
-      vertex 17.75 21.0311 2
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 13.1684 20.0572 2
-      vertex 13.658 20.601 11
-      vertex 13.658 20.601 2
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 13.658 20.601 11
-      vertex 13.1684 20.0572 2
-      vertex 13.1684 20.0572 11
-    endloop
-  endfacet
-  facet normal -0.406735 0.913546 0
-    outer loop
-      vertex 14.9184 21.3287 2
-      vertex 14.25 21.0311 11
-      vertex 14.9184 21.3287 11
-    endloop
-  endfacet
-  facet normal -0.406735 0.913546 0
-    outer loop
-      vertex 14.25 21.0311 11
-      vertex 14.9184 21.3287 2
-      vertex 14.25 21.0311 2
-    endloop
-  endfacet
-  facet normal 0.743146 -0.66913 0
-    outer loop
-      vertex 18.342 15.399 11
-      vertex 18.8316 15.9428 2
-      vertex 18.8316 15.9428 11
-    endloop
-  endfacet
-  facet normal 0.743146 -0.66913 0
-    outer loop
-      vertex 18.8316 15.9428 2
-      vertex 18.342 15.399 11
-      vertex 18.342 15.399 2
-    endloop
-  endfacet
-  facet normal 0.866025 0.5 0
-    outer loop
-      vertex 19.1974 19.4236 11
-      vertex 18.8316 20.0572 2
-      vertex 18.8316 20.0572 11
-    endloop
-  endfacet
-  facet normal 0.866025 0.5 0
-    outer loop
-      vertex 18.8316 20.0572 2
-      vertex 19.1974 19.4236 11
-      vertex 19.1974 19.4236 2
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 19.4235 18.7277 11
-      vertex 19.1974 19.4236 2
-      vertex 19.1974 19.4236 11
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 19.1974 19.4236 2
-      vertex 19.4235 18.7277 11
-      vertex 19.4235 18.7277 2
-    endloop
-  endfacet
-  facet normal 0.743146 0.66913 0
-    outer loop
-      vertex 18.8316 20.0572 11
-      vertex 18.342 20.601 2
-      vertex 18.342 20.601 11
-    endloop
-  endfacet
-  facet normal 0.743146 0.66913 0
-    outer loop
-      vertex 18.342 20.601 2
-      vertex 18.8316 20.0572 11
-      vertex 18.8316 20.0572 2
-    endloop
-  endfacet
-  facet normal 0.207913 0.978147 -0
-    outer loop
-      vertex 17.0816 21.3287 2
-      vertex 16.3658 21.4808 11
-      vertex 17.0816 21.3287 11
-    endloop
-  endfacet
-  facet normal 0.207913 0.978147 0
-    outer loop
-      vertex 16.3658 21.4808 11
-      vertex 17.0816 21.3287 2
-      vertex 16.3658 21.4808 2
-    endloop
-  endfacet
-  facet normal 0.406734 0.913546 -0
-    outer loop
-      vertex 17.75 21.0311 2
-      vertex 17.0816 21.3287 11
-      vertex 17.75 21.0311 11
-    endloop
-  endfacet
-  facet normal 0.406734 0.913546 0
-    outer loop
-      vertex 17.0816 21.3287 11
-      vertex 17.75 21.0311 2
-      vertex 17.0816 21.3287 2
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex 12.5765 18.7277 2
-      vertex 12.8026 19.4236 11
-      vertex 12.8026 19.4236 2
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex 12.8026 19.4236 11
-      vertex 12.5765 18.7277 2
-      vertex 12.5765 18.7277 11
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14 18 0
-      vertex 18 18.3 0
-      vertex 18 18 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 18 18.3 0
-      vertex 14 18 0
-      vertex 14 18.3 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.5 16 0
-      vertex 16.5 16.3 0
-      vertex 16.5 16 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.5 16.3 0
-      vertex 15.5 16 0
-      vertex 15.5 16.3 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.5 20 0
-      vertex 16.5 20.3 0
-      vertex 16.5 20 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 16.5 20.3 0
-      vertex 15.5 20 0
-      vertex 15.5 20.3 0
-    endloop
-  endfacet
-  facet normal -0.866026 0.499999 0
-    outer loop
-      vertex 12.8026 19.4236 2
-      vertex 13.1684 20.0572 11
-      vertex 13.1684 20.0572 2
-    endloop
-  endfacet
-  facet normal -0.866026 0.499999 0
-    outer loop
-      vertex 13.1684 20.0572 11
-      vertex 12.8026 19.4236 2
-      vertex 12.8026 19.4236 11
-    endloop
-  endfacet
-  facet normal -0.994522 0.104528 0
-    outer loop
-      vertex 12.5 18 2
-      vertex 12.5765 18.7277 11
-      vertex 12.5765 18.7277 2
-    endloop
-  endfacet
-  facet normal -0.994522 0.104528 0
-    outer loop
-      vertex 12.5765 18.7277 11
-      vertex 12.5 18 2
-      vertex 12.5 18 11
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 14.25 21.0311 2
-      vertex 13.658 20.601 11
-      vertex 14.25 21.0311 11
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 13.658 20.601 11
-      vertex 14.25 21.0311 2
-      vertex 13.658 20.601 2
-    endloop
-  endfacet
-  facet normal -0.207913 0.978147 0
-    outer loop
-      vertex 15.6341 21.4808 2
-      vertex 14.9184 21.3287 11
-      vertex 15.6341 21.4808 11
-    endloop
-  endfacet
-  facet normal -0.207913 0.978147 0
-    outer loop
-      vertex 14.9184 21.3287 11
-      vertex 15.6341 21.4808 2
-      vertex 14.9184 21.3287 2
-    endloop
-  endfacet
-  facet normal 0.994522 -0.10453 0
-    outer loop
-      vertex 19.4235 17.2723 11
-      vertex 19.5 18 2
-      vertex 19.5 18 11
-    endloop
-  endfacet
-  facet normal 0.994522 -0.10453 0
-    outer loop
-      vertex 19.5 18 2
-      vertex 19.4235 17.2723 11
-      vertex 19.4235 17.2723 2
-    endloop
-  endfacet
-  facet normal 0.207912 -0.978147 0
-    outer loop
-      vertex 16.3658 14.5192 2
-      vertex 17.0816 14.6713 11
-      vertex 16.3658 14.5192 11
-    endloop
-  endfacet
-  facet normal 0.207912 -0.978147 0
-    outer loop
-      vertex 17.0816 14.6713 11
-      vertex 16.3658 14.5192 2
-      vertex 17.0816 14.6713 2
-    endloop
-  endfacet
-  facet normal 0.587786 -0.809017 0
-    outer loop
-      vertex 17.75 14.9689 2
-      vertex 18.342 15.399 11
-      vertex 17.75 14.9689 11
-    endloop
-  endfacet
-  facet normal 0.587786 -0.809017 0
-    outer loop
-      vertex 18.342 15.399 11
-      vertex 17.75 14.9689 2
-      vertex 18.342 15.399 2
-    endloop
-  endfacet
-  facet normal -0.406736 -0.913546 0
-    outer loop
-      vertex 14.25 14.9689 2
-      vertex 14.9184 14.6713 11
-      vertex 14.25 14.9689 11
-    endloop
-  endfacet
-  facet normal -0.406736 -0.913546 -0
-    outer loop
-      vertex 14.9184 14.6713 11
-      vertex 14.25 14.9689 2
-      vertex 14.9184 14.6713 2
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 15.6341 14.5192 2
-      vertex 16.3658 14.5192 11
-      vertex 15.6341 14.5192 11
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 16.3658 14.5192 11
-      vertex 15.6341 14.5192 2
-      vertex 16.3658 14.5192 2
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 13.658 15.399 2
-      vertex 13.1684 15.9428 11
-      vertex 13.1684 15.9428 2
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 13.1684 15.9428 11
-      vertex 13.658 15.399 2
-      vertex 13.658 15.399 11
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 12.8026 16.5764 2
-      vertex 12.5765 17.2723 11
-      vertex 12.5765 17.2723 2
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 12.5765 17.2723 11
-      vertex 12.8026 16.5764 2
-      vertex 12.8026 16.5764 11
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 12.5765 17.2723 2
-      vertex 12.5 18 11
-      vertex 12.5 18 2
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 12.5 18 11
-      vertex 12.5765 17.2723 2
-      vertex 12.5765 17.2723 11
-    endloop
-  endfacet
-  facet normal 0.406735 -0.913546 0
-    outer loop
-      vertex 17.0816 14.6713 2
-      vertex 17.75 14.9689 11
-      vertex 17.0816 14.6713 11
-    endloop
-  endfacet
-  facet normal 0.406735 -0.913546 0
-    outer loop
-      vertex 17.75 14.9689 11
-      vertex 17.0816 14.6713 2
-      vertex 17.75 14.9689 2
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309016 0
-    outer loop
-      vertex 19.1974 16.5764 11
-      vertex 19.4235 17.2723 2
-      vertex 19.4235 17.2723 11
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309016 0
-    outer loop
-      vertex 19.4235 17.2723 2
-      vertex 19.1974 16.5764 11
-      vertex 19.1974 16.5764 2
-    endloop
-  endfacet
-  facet normal 0.866025 -0.5 0
-    outer loop
-      vertex 18.8316 15.9428 11
-      vertex 19.1974 16.5764 2
-      vertex 19.1974 16.5764 11
-    endloop
-  endfacet
-  facet normal 0.866025 -0.5 0
-    outer loop
-      vertex 19.1974 16.5764 2
-      vertex 18.8316 15.9428 11
-      vertex 18.8316 15.9428 2
-    endloop
-  endfacet
-  facet normal -0.207912 -0.978147 0
-    outer loop
-      vertex 14.9184 14.6713 2
-      vertex 15.6341 14.5192 11
-      vertex 14.9184 14.6713 11
-    endloop
-  endfacet
-  facet normal -0.207912 -0.978147 -0
-    outer loop
-      vertex 15.6341 14.5192 11
-      vertex 14.9184 14.6713 2
-      vertex 15.6341 14.5192 2
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499999 0
-    outer loop
-      vertex 13.1684 15.9428 2
-      vertex 12.8026 16.5764 11
-      vertex 12.8026 16.5764 2
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499999 0
-    outer loop
-      vertex 12.8026 16.5764 11
-      vertex 13.1684 15.9428 2
-      vertex 13.1684 15.9428 11
-    endloop
-  endfacet
-  facet normal 0.944002 0.0992173 0.314667
-    outer loop
-      vertex 19.5 18 11
-      vertex 18.4454 18.5198 14
-      vertex 18.5 18 14
-    endloop
-  endfacet
-  facet normal 0.944002 0.0992202 0.314667
-    outer loop
-      vertex 19.4235 18.7277 11
-      vertex 18.4454 18.5198 14
-      vertex 19.5 18 11
-    endloop
-  endfacet
-  facet normal -0.944002 -0.0992177 0.314667
-    outer loop
-      vertex 13.5546 17.4802 14
-      vertex 12.5 18 11
-      vertex 12.5765 17.2723 11
-    endloop
-  endfacet
-  facet normal 0.902744 0.293322 0.314667
-    outer loop
-      vertex 19.1974 19.4236 11
-      vertex 18.2839 19.0168 14
-      vertex 18.4454 18.5198 14
-    endloop
-  endfacet
-  facet normal 0 0.949202 0.314667
-    outer loop
-      vertex 16.3658 21.4808 11
-      vertex 15.7387 20.4863 14
-      vertex 16.2613 20.4863 14
-    endloop
-  endfacet
-  facet normal 0 0.949202 0.314667
-    outer loop
-      vertex 15.7387 20.4863 14
-      vertex 16.3658 21.4808 11
-      vertex 15.6341 21.4808 11
-    endloop
-  endfacet
-  facet normal -0.902745 -0.29332 0.314667
-    outer loop
-      vertex 13.5546 17.4802 14
-      vertex 12.8026 16.5764 11
-      vertex 13.7161 16.9832 14
-    endloop
-  endfacet
-  facet normal 0.557929 0.767919 0.314668
-    outer loop
-      vertex 17.75 21.0311 11
-      vertex 17.25 20.1651 14
-      vertex 18.342 20.601 11
-    endloop
-  endfacet
-  facet normal -0.557927 -0.76792 0.314667
-    outer loop
-      vertex 14.75 15.8349 14
-      vertex 13.658 15.399 11
-      vertex 14.25 14.9689 11
-    endloop
-  endfacet
-  facet normal 0 -0.949202 0.314667
-    outer loop
-      vertex 15.6341 14.5192 11
-      vertex 16.2613 15.5137 14
-      vertex 15.7387 15.5137 14
-    endloop
-  endfacet
-  facet normal 0 -0.949202 0.314667
-    outer loop
-      vertex 16.2613 15.5137 14
-      vertex 15.6341 14.5192 11
-      vertex 16.3658 14.5192 11
-    endloop
-  endfacet
-  facet normal 0.705394 -0.63514 0.314668
-    outer loop
-      vertex 18.0225 16.5305 14
-      vertex 17.6728 16.1421 14
-      vertex 18.342 15.399 11
-    endloop
-  endfacet
-  facet normal 0.902744 -0.293322 0.314667
-    outer loop
-      vertex 18.4454 17.4802 14
-      vertex 18.2839 16.9832 14
-      vertex 19.1974 16.5764 11
-    endloop
-  endfacet
-  facet normal 0.902745 -0.293319 0.314667
-    outer loop
-      vertex 19.4235 17.2723 11
-      vertex 18.4454 17.4802 14
-      vertex 19.1974 16.5764 11
-    endloop
-  endfacet
-  facet normal 0.822033 0.474601 0.314667
-    outer loop
-      vertex 18.8316 20.0572 11
-      vertex 18.2839 19.0168 14
-      vertex 19.1974 19.4236 11
-    endloop
-  endfacet
-  facet normal 0.902745 0.29332 0.314667
-    outer loop
-      vertex 19.1974 19.4236 11
-      vertex 18.4454 18.5198 14
-      vertex 19.4235 18.7277 11
-    endloop
-  endfacet
-  facet normal -0.705395 0.63514 0.314667
-    outer loop
-      vertex 13.658 20.601 11
-      vertex 13.1684 20.0572 11
-      vertex 13.9775 19.4695 14
-    endloop
-  endfacet
-  facet normal -0.197352 0.928459 0.314668
-    outer loop
-      vertex 15.6341 21.4808 11
-      vertex 14.9184 21.3287 11
-      vertex 15.2275 20.3776 14
-    endloop
-  endfacet
-  facet normal 0.705395 0.635139 0.314667
-    outer loop
-      vertex 18.342 20.601 11
-      vertex 18.0225 19.4695 14
-      vertex 18.8316 20.0572 11
-    endloop
-  endfacet
-  facet normal 0.386073 0.86714 0.314668
-    outer loop
-      vertex 17.0816 21.3287 11
-      vertex 16.7725 20.3776 14
-      vertex 17.75 21.0311 11
-    endloop
-  endfacet
-  facet normal -0.822033 -0.4746 0.314667
-    outer loop
-      vertex 13.7161 16.9832 14
-      vertex 12.8026 16.5764 11
-      vertex 13.1684 15.9428 11
-    endloop
-  endfacet
-  facet normal -0.902745 -0.29332 0.314667
-    outer loop
-      vertex 13.5546 17.4802 14
-      vertex 12.5765 17.2723 11
-      vertex 12.8026 16.5764 11
-    endloop
-  endfacet
-  facet normal -0.705395 -0.63514 0.314668
-    outer loop
-      vertex 13.9775 16.5305 14
-      vertex 13.1684 15.9428 11
-      vertex 13.658 15.399 11
-    endloop
-  endfacet
-  facet normal -0.386075 -0.867139 0.314667
-    outer loop
-      vertex 15.2275 15.6224 14
-      vertex 14.25 14.9689 11
-      vertex 14.9184 14.6713 11
-    endloop
-  endfacet
-  facet normal 0.197351 -0.92846 0.314667
-    outer loop
-      vertex 16.7725 15.6224 14
-      vertex 16.3658 14.5192 11
-      vertex 17.0816 14.6713 11
-    endloop
-  endfacet
-  facet normal 0.386074 -0.86714 0.314667
-    outer loop
-      vertex 17.25 15.8349 14
-      vertex 16.7725 15.6224 14
-      vertex 17.75 14.9689 11
-    endloop
-  endfacet
-  facet normal 0.386074 -0.86714 0.314667
-    outer loop
-      vertex 17.75 14.9689 11
-      vertex 16.7725 15.6224 14
-      vertex 17.0816 14.6713 11
-    endloop
-  endfacet
-  facet normal 0.557927 -0.76792 0.314667
-    outer loop
-      vertex 18.342 15.399 11
-      vertex 17.25 15.8349 14
-      vertex 17.75 14.9689 11
-    endloop
-  endfacet
-  facet normal 0.705395 -0.635139 0.314668
-    outer loop
-      vertex 18.8316 15.9428 11
-      vertex 18.0225 16.5305 14
-      vertex 18.342 15.399 11
-    endloop
-  endfacet
-  facet normal 0.944002 -0.0992202 0.314667
-    outer loop
-      vertex 19.5 18 11
-      vertex 18.4454 17.4802 14
-      vertex 19.4235 17.2723 11
-    endloop
-  endfacet
-  facet normal 0.944002 -0.0992173 0.314667
-    outer loop
-      vertex 18.5 18 14
-      vertex 18.4454 17.4802 14
-      vertex 19.5 18 11
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4454 18.5198 14
-      vertex 18.4454 17.4802 14
-      vertex 18.5 18 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2839 19.0168 14
-      vertex 18.4454 17.4802 14
-      vertex 18.4454 18.5198 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2839 19.0168 14
-      vertex 18.2839 16.9832 14
-      vertex 18.4454 17.4802 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0225 19.4695 14
-      vertex 18.2839 16.9832 14
-      vertex 18.2839 19.0168 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.0225 19.4695 14
-      vertex 18.0225 16.5305 14
-      vertex 18.2839 16.9832 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6728 19.8579 14
-      vertex 18.0225 16.5305 14
-      vertex 18.0225 19.4695 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.6728 19.8579 14
-      vertex 17.6728 16.1421 14
-      vertex 18.0225 16.5305 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.25 20.1651 14
-      vertex 17.6728 16.1421 14
-      vertex 17.6728 19.8579 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.25 20.1651 14
-      vertex 17.25 15.8349 14
-      vertex 17.6728 16.1421 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.7725 20.3776 14
-      vertex 17.25 15.8349 14
-      vertex 17.25 20.1651 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.7725 20.3776 14
-      vertex 16.7725 15.6224 14
-      vertex 17.25 15.8349 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.2613 20.4863 14
-      vertex 16.7725 15.6224 14
-      vertex 16.7725 20.3776 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.2613 20.4863 14
-      vertex 16.2613 15.5137 14
-      vertex 16.7725 15.6224 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.7387 20.4863 14
-      vertex 16.2613 15.5137 14
-      vertex 16.2613 20.4863 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.7387 20.4863 14
-      vertex 15.7387 15.5137 14
-      vertex 16.2613 15.5137 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.2275 20.3776 14
-      vertex 15.7387 15.5137 14
-      vertex 15.7387 20.4863 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.2275 20.3776 14
-      vertex 15.2275 15.6224 14
-      vertex 15.7387 15.5137 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.75 20.1651 14
-      vertex 15.2275 15.6224 14
-      vertex 15.2275 20.3776 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.75 20.1651 14
-      vertex 14.75 15.8349 14
-      vertex 15.2275 15.6224 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.3272 19.8579 14
-      vertex 14.75 15.8349 14
-      vertex 14.75 20.1651 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3272 19.8579 14
-      vertex 14.3272 16.1421 14
-      vertex 14.75 15.8349 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.9775 19.4695 14
-      vertex 14.3272 16.1421 14
-      vertex 14.3272 19.8579 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.9775 19.4695 14
-      vertex 13.9775 16.5305 14
-      vertex 14.3272 16.1421 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.7161 19.0168 14
-      vertex 13.9775 16.5305 14
-      vertex 13.9775 19.4695 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7161 19.0168 14
-      vertex 13.7161 16.9832 14
-      vertex 13.9775 16.5305 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.5546 18.5198 14
-      vertex 13.7161 16.9832 14
-      vertex 13.7161 19.0168 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.5546 18.5198 14
-      vertex 13.5546 17.4802 14
-      vertex 13.7161 16.9832 14
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 13.5546 17.4802 14
-      vertex 13.5546 18.5198 14
-      vertex 13.5 18 14
-    endloop
-  endfacet
-  facet normal -0.822033 0.474601 0.314667
-    outer loop
-      vertex 13.9775 19.4695 14
-      vertex 13.1684 20.0572 11
-      vertex 13.7161 19.0168 14
-    endloop
-  endfacet
-  facet normal -0.557928 0.767919 0.314668
-    outer loop
-      vertex 14.25 21.0311 11
-      vertex 13.658 20.601 11
-      vertex 14.75 20.1651 14
-    endloop
-  endfacet
-  facet normal -0.386074 0.86714 0.314668
-    outer loop
-      vertex 14.9184 21.3287 11
-      vertex 14.25 21.0311 11
-      vertex 15.2275 20.3776 14
-    endloop
-  endfacet
-  facet normal -0.386076 0.867139 0.314668
-    outer loop
-      vertex 15.2275 20.3776 14
-      vertex 14.25 21.0311 11
-      vertex 14.75 20.1651 14
-    endloop
-  endfacet
-  facet normal 0.822032 0.474602 0.314667
-    outer loop
-      vertex 18.8316 20.0572 11
-      vertex 18.0225 19.4695 14
-      vertex 18.2839 19.0168 14
-    endloop
-  endfacet
-  facet normal 0.705393 0.635142 0.314668
-    outer loop
-      vertex 18.342 20.601 11
-      vertex 17.6728 19.8579 14
-      vertex 18.0225 19.4695 14
-    endloop
-  endfacet
-  facet normal 0.557928 0.767919 0.314668
-    outer loop
-      vertex 18.342 20.601 11
-      vertex 17.25 20.1651 14
-      vertex 17.6728 19.8579 14
-    endloop
-  endfacet
-  facet normal 0.197352 0.928459 0.314668
-    outer loop
-      vertex 17.0816 21.3287 11
-      vertex 16.3658 21.4808 11
-      vertex 16.7725 20.3776 14
-    endloop
-  endfacet
-  facet normal 0.197355 0.928459 0.314667
-    outer loop
-      vertex 16.3658 21.4808 11
-      vertex 16.2613 20.4863 14
-      vertex 16.7725 20.3776 14
-    endloop
-  endfacet
-  facet normal -0.822033 -0.474601 0.314668
-    outer loop
-      vertex 13.7161 16.9832 14
-      vertex 13.1684 15.9428 11
-      vertex 13.9775 16.5305 14
-    endloop
-  endfacet
-  facet normal -0.705394 -0.63514 0.314668
-    outer loop
-      vertex 13.9775 16.5305 14
-      vertex 13.658 15.399 11
-      vertex 14.3272 16.1421 14
-    endloop
-  endfacet
-  facet normal -0.557927 -0.76792 0.314668
-    outer loop
-      vertex 14.3272 16.1421 14
-      vertex 13.658 15.399 11
-      vertex 14.75 15.8349 14
-    endloop
-  endfacet
-  facet normal -0.197351 -0.92846 0.314667
-    outer loop
-      vertex 15.2275 15.6224 14
-      vertex 14.9184 14.6713 11
-      vertex 15.6341 14.5192 11
-    endloop
-  endfacet
-  facet normal -0.197351 -0.92846 0.314667
-    outer loop
-      vertex 15.7387 15.5137 14
-      vertex 15.2275 15.6224 14
-      vertex 15.6341 14.5192 11
-    endloop
-  endfacet
-  facet normal 0.557928 -0.767919 0.314668
-    outer loop
-      vertex 17.6728 16.1421 14
-      vertex 17.25 15.8349 14
-      vertex 18.342 15.399 11
-    endloop
-  endfacet
-  facet normal 0.197351 -0.928459 0.314667
-    outer loop
-      vertex 16.7725 15.6224 14
-      vertex 16.2613 15.5137 14
-      vertex 16.3658 14.5192 11
-    endloop
-  endfacet
-  facet normal 0.822032 -0.474602 0.314668
-    outer loop
-      vertex 18.2839 16.9832 14
-      vertex 18.0225 16.5305 14
-      vertex 18.8316 15.9428 11
-    endloop
-  endfacet
-  facet normal 0.822033 -0.474601 0.314667
-    outer loop
-      vertex 19.1974 16.5764 11
-      vertex 18.2839 16.9832 14
-      vertex 18.8316 15.9428 11
-    endloop
-  endfacet
-  facet normal -0.902744 0.293321 0.314667
-    outer loop
-      vertex 12.8026 19.4236 11
-      vertex 12.5765 18.7277 11
-      vertex 13.5546 18.5198 14
-    endloop
-  endfacet
-  facet normal -0.944002 -0.0992173 0.314667
-    outer loop
-      vertex 13.5 18 14
-      vertex 12.5 18 11
-      vertex 13.5546 17.4802 14
-    endloop
-  endfacet
-  facet normal -0.944002 0.0992177 0.314667
-    outer loop
-      vertex 12.5765 18.7277 11
-      vertex 12.5 18 11
-      vertex 13.5546 18.5198 14
-    endloop
-  endfacet
-  facet normal -0.944002 0.0992173 0.314667
-    outer loop
-      vertex 13.5546 18.5198 14
-      vertex 12.5 18 11
-      vertex 13.5 18 14
-    endloop
-  endfacet
-  facet normal -0.557927 0.767921 0.314668
-    outer loop
-      vertex 14.75 20.1651 14
-      vertex 13.658 20.601 11
-      vertex 14.3272 19.8579 14
-    endloop
-  endfacet
-  facet normal -0.705393 0.635142 0.314668
-    outer loop
-      vertex 14.3272 19.8579 14
-      vertex 13.658 20.601 11
-      vertex 13.9775 19.4695 14
-    endloop
-  endfacet
-  facet normal -0.197354 0.928459 0.314667
-    outer loop
-      vertex 15.6341 21.4808 11
-      vertex 15.2275 20.3776 14
-      vertex 15.7387 20.4863 14
-    endloop
-  endfacet
-  facet normal 0.386074 0.867139 0.314668
-    outer loop
-      vertex 17.75 21.0311 11
-      vertex 16.7725 20.3776 14
-      vertex 17.25 20.1651 14
-    endloop
-  endfacet
-  facet normal -0.386075 -0.867139 0.314668
-    outer loop
-      vertex 14.75 15.8349 14
-      vertex 14.25 14.9689 11
-      vertex 15.2275 15.6224 14
-    endloop
-  endfacet
-  facet normal -0.822033 0.474601 0.314667
-    outer loop
-      vertex 13.1684 20.0572 11
-      vertex 12.8026 19.4236 11
-      vertex 13.7161 19.0168 14
-    endloop
-  endfacet
-  facet normal -0.902745 0.29332 0.314667
-    outer loop
-      vertex 13.7161 19.0168 14
-      vertex 12.8026 19.4236 11
-      vertex 13.5546 18.5198 14
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 15.5 5 11
-      vertex 15.4235 5.72769 2
-      vertex 15.4235 5.72769 11
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 15.4235 5.72769 2
-      vertex 15.5 5 11
-      vertex 15.5 5 2
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 12.3658 8.48083 2
-      vertex 11.6341 8.48083 11
-      vertex 12.3658 8.48083 11
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 11.6341 8.48083 11
-      vertex 12.3658 8.48083 2
-      vertex 11.6341 8.48083 2
-    endloop
-  endfacet
-  facet normal 0.587786 0.809017 -0
-    outer loop
-      vertex 14.342 7.60101 2
-      vertex 13.75 8.03109 11
-      vertex 14.342 7.60101 11
-    endloop
-  endfacet
-  facet normal 0.587786 0.809017 0
-    outer loop
-      vertex 13.75 8.03109 11
-      vertex 14.342 7.60101 2
-      vertex 13.75 8.03109 2
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 9.16844 7.05725 2
-      vertex 9.65804 7.60101 11
-      vertex 9.65804 7.60101 2
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 9.65804 7.60101 11
-      vertex 9.16844 7.05725 2
-      vertex 9.16844 7.05725 11
-    endloop
-  endfacet
-  facet normal -0.406736 0.913546 0
-    outer loop
-      vertex 10.9184 8.3287 2
-      vertex 10.25 8.03109 11
-      vertex 10.9184 8.3287 11
-    endloop
-  endfacet
-  facet normal -0.406736 0.913546 0
-    outer loop
-      vertex 10.25 8.03109 11
-      vertex 10.9184 8.3287 2
-      vertex 10.25 8.03109 2
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499999 0
-    outer loop
-      vertex 14.8316 2.94275 11
-      vertex 15.1974 3.57642 2
-      vertex 15.1974 3.57642 11
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499999 0
-    outer loop
-      vertex 15.1974 3.57642 2
-      vertex 14.8316 2.94275 11
-      vertex 14.8316 2.94275 2
-    endloop
-  endfacet
-  facet normal 0.866026 0.499999 0
-    outer loop
-      vertex 15.1974 6.42358 11
-      vertex 14.8316 7.05725 2
-      vertex 14.8316 7.05725 11
-    endloop
-  endfacet
-  facet normal 0.866026 0.499999 0
-    outer loop
-      vertex 14.8316 7.05725 2
-      vertex 15.1974 6.42358 11
-      vertex 15.1974 6.42358 2
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 15.4235 5.72769 11
-      vertex 15.1974 6.42358 2
-      vertex 15.1974 6.42358 11
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 15.1974 6.42358 2
-      vertex 15.4235 5.72769 11
-      vertex 15.4235 5.72769 2
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 14.8316 7.05725 11
-      vertex 14.342 7.60101 2
-      vertex 14.342 7.60101 11
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 14.342 7.60101 2
-      vertex 14.8316 7.05725 11
-      vertex 14.8316 7.05725 2
-    endloop
-  endfacet
-  facet normal 0.207912 0.978147 -0
-    outer loop
-      vertex 13.0816 8.3287 2
-      vertex 12.3658 8.48083 11
-      vertex 13.0816 8.3287 11
-    endloop
-  endfacet
-  facet normal 0.207912 0.978147 0
-    outer loop
-      vertex 12.3658 8.48083 11
-      vertex 13.0816 8.3287 2
-      vertex 12.3658 8.48083 2
-    endloop
-  endfacet
-  facet normal 0.406736 0.913546 -0
-    outer loop
-      vertex 13.75 8.03109 2
-      vertex 13.0816 8.3287 11
-      vertex 13.75 8.03109 11
-    endloop
-  endfacet
-  facet normal 0.406736 0.913546 0
-    outer loop
-      vertex 13.0816 8.3287 11
-      vertex 13.75 8.03109 2
-      vertex 13.0816 8.3287 2
-    endloop
-  endfacet
-  facet normal -0.951056 0.309017 0
-    outer loop
-      vertex 8.57648 5.72769 2
-      vertex 8.80259 6.42358 11
-      vertex 8.80259 6.42358 2
-    endloop
-  endfacet
-  facet normal -0.951056 0.309017 0
-    outer loop
-      vertex 8.80259 6.42358 11
-      vertex 8.57648 5.72769 2
-      vertex 8.57648 5.72769 11
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 5 0
-      vertex 14 5.3 0
-      vertex 14 5 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14 5.3 0
-      vertex 10 5 0
-      vertex 10 5.3 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.5 3 0
-      vertex 12.5 3.3 0
-      vertex 12.5 3 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.5 3.3 0
-      vertex 11.5 3 0
-      vertex 11.5 3.3 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.5 6.5 0
-      vertex 12.5 6.8 0
-      vertex 12.5 6.5 0
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.5 6.8 0
-      vertex 11.5 6.5 0
-      vertex 11.5 6.8 0
-    endloop
-  endfacet
-  facet normal -0.866026 0.499999 0
-    outer loop
-      vertex 8.80259 6.42358 2
-      vertex 9.16844 7.05725 11
-      vertex 9.16844 7.05725 2
-    endloop
-  endfacet
-  facet normal -0.866026 0.499999 0
-    outer loop
-      vertex 9.16844 7.05725 11
-      vertex 8.80259 6.42358 2
-      vertex 8.80259 6.42358 11
-    endloop
-  endfacet
-  facet normal -0.994522 0.104528 0
-    outer loop
-      vertex 8.5 5 2
-      vertex 8.57648 5.72769 11
-      vertex 8.57648 5.72769 2
-    endloop
-  endfacet
-  facet normal -0.994522 0.104528 0
-    outer loop
-      vertex 8.57648 5.72769 11
-      vertex 8.5 5 2
-      vertex 8.5 5 11
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex 10.25 8.03109 2
-      vertex 9.65804 7.60101 11
-      vertex 10.25 8.03109 11
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex 9.65804 7.60101 11
-      vertex 10.25 8.03109 2
-      vertex 9.65804 7.60101 2
-    endloop
-  endfacet
-  facet normal -0.207912 0.978147 0
-    outer loop
-      vertex 11.6341 8.48083 2
-      vertex 10.9184 8.3287 11
-      vertex 11.6341 8.48083 11
-    endloop
-  endfacet
-  facet normal -0.207912 0.978147 0
-    outer loop
-      vertex 10.9184 8.3287 11
-      vertex 11.6341 8.48083 2
-      vertex 10.9184 8.3287 2
-    endloop
-  endfacet
-  facet normal 0.207912 -0.978147 0
-    outer loop
-      vertex 12.3658 1.51917 2
-      vertex 13.0816 1.6713 11
-      vertex 12.3658 1.51917 11
-    endloop
-  endfacet
-  facet normal 0.207912 -0.978147 0
-    outer loop
-      vertex 13.0816 1.6713 11
-      vertex 12.3658 1.51917 2
-      vertex 13.0816 1.6713 2
-    endloop
-  endfacet
-  facet normal 0.587786 -0.809017 0
-    outer loop
-      vertex 13.75 1.96891 2
-      vertex 14.342 2.39899 11
-      vertex 13.75 1.96891 11
-    endloop
-  endfacet
-  facet normal 0.587786 -0.809017 0
-    outer loop
-      vertex 14.342 2.39899 11
-      vertex 13.75 1.96891 2
-      vertex 14.342 2.39899 2
-    endloop
-  endfacet
-  facet normal -0.406736 -0.913546 0
-    outer loop
-      vertex 10.25 1.96891 2
-      vertex 10.9184 1.6713 11
-      vertex 10.25 1.96891 11
-    endloop
-  endfacet
-  facet normal -0.406736 -0.913546 -0
-    outer loop
-      vertex 10.9184 1.6713 11
-      vertex 10.25 1.96891 2
-      vertex 10.9184 1.6713 2
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 11.6341 1.51917 2
-      vertex 12.3658 1.51917 11
-      vertex 11.6341 1.51917 11
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 12.3658 1.51917 11
-      vertex 11.6341 1.51917 2
-      vertex 12.3658 1.51917 2
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 9.65804 2.39899 2
-      vertex 9.16844 2.94275 11
-      vertex 9.16844 2.94275 2
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 9.16844 2.94275 11
-      vertex 9.65804 2.39899 2
-      vertex 9.65804 2.39899 11
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 8.80259 3.57642 2
-      vertex 8.57648 4.27231 11
-      vertex 8.57648 4.27231 2
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 8.57648 4.27231 11
-      vertex 8.80259 3.57642 2
-      vertex 8.80259 3.57642 11
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 8.57648 4.27231 2
-      vertex 8.5 5 11
-      vertex 8.5 5 2
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 8.5 5 11
-      vertex 8.57648 4.27231 2
-      vertex 8.57648 4.27231 11
-    endloop
-  endfacet
-  facet normal 0.406736 -0.913546 0
-    outer loop
-      vertex 13.0816 1.6713 2
-      vertex 13.75 1.96891 11
-      vertex 13.0816 1.6713 11
-    endloop
-  endfacet
-  facet normal 0.406736 -0.913546 0
-    outer loop
-      vertex 13.75 1.96891 11
-      vertex 13.0816 1.6713 2
-      vertex 13.75 1.96891 2
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 14.342 2.39899 11
-      vertex 14.8316 2.94275 2
-      vertex 14.8316 2.94275 11
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 14.8316 2.94275 2
-      vertex 14.342 2.39899 11
-      vertex 14.342 2.39899 2
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 15.1974 3.57642 11
-      vertex 15.4235 4.27231 2
-      vertex 15.4235 4.27231 11
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 15.4235 4.27231 2
-      vertex 15.1974 3.57642 11
-      vertex 15.1974 3.57642 2
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 15.4235 4.27231 11
-      vertex 15.5 5 2
-      vertex 15.5 5 11
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 15.5 5 2
-      vertex 15.4235 4.27231 11
-      vertex 15.4235 4.27231 2
-    endloop
-  endfacet
-  facet normal -0.207912 -0.978147 0
-    outer loop
-      vertex 10.9184 1.6713 2
-      vertex 11.6341 1.51917 11
-      vertex 10.9184 1.6713 11
-    endloop
-  endfacet
-  facet normal -0.207912 -0.978147 -0
-    outer loop
-      vertex 11.6341 1.51917 11
-      vertex 10.9184 1.6713 2
-      vertex 11.6341 1.51917 2
-    endloop
-  endfacet
-  facet normal -0.587786 -0.809017 0
-    outer loop
-      vertex 9.65804 2.39899 2
-      vertex 10.25 1.96891 11
-      vertex 9.65804 2.39899 11
-    endloop
-  endfacet
-  facet normal -0.587786 -0.809017 -0
-    outer loop
-      vertex 10.25 1.96891 11
-      vertex 9.65804 2.39899 2
-      vertex 10.25 1.96891 2
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499999 0
-    outer loop
-      vertex 9.16844 2.94275 2
-      vertex 8.80259 3.57642 11
-      vertex 8.80259 3.57642 2
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499999 0
-    outer loop
-      vertex 8.80259 3.57642 11
-      vertex 9.16844 2.94275 2
-      vertex 9.16844 2.94275 11
-    endloop
-  endfacet
-  facet normal 0.944002 0.0992191 0.314667
-    outer loop
-      vertex 15.5 5 11
-      vertex 14.4454 5.51978 14
-      vertex 14.5 5 14
-    endloop
-  endfacet
-  facet normal 0.944002 0.0992191 0.314667
-    outer loop
-      vertex 15.4235 5.72769 11
-      vertex 14.4454 5.51978 14
-      vertex 15.5 5 11
-    endloop
-  endfacet
-  facet normal -0.944002 -0.0992177 0.314667
-    outer loop
-      vertex 9.55463 4.48022 14
-      vertex 8.5 5 11
-      vertex 8.57648 4.27231 11
-    endloop
-  endfacet
-  facet normal 0.902744 0.29332 0.314667
-    outer loop
-      vertex 15.1974 6.42358 11
-      vertex 14.2839 6.01684 14
-      vertex 14.4454 5.51978 14
-    endloop
-  endfacet
-  facet normal 0 0.949202 0.314667
-    outer loop
-      vertex 12.3658 8.48083 11
-      vertex 11.7387 7.4863 14
-      vertex 12.2613 7.4863 14
-    endloop
-  endfacet
-  facet normal 0 0.949202 0.314667
-    outer loop
-      vertex 11.7387 7.4863 14
-      vertex 12.3658 8.48083 11
-      vertex 11.6341 8.48083 11
-    endloop
-  endfacet
-  facet normal -0.902744 -0.29332 0.314667
-    outer loop
-      vertex 9.55463 4.48022 14
-      vertex 8.80259 3.57642 11
-      vertex 9.71614 3.98316 14
-    endloop
-  endfacet
-  facet normal 0.557927 0.76792 0.314667
-    outer loop
-      vertex 13.75 8.03109 11
-      vertex 13.25 7.16506 14
-      vertex 14.342 7.60101 11
-    endloop
-  endfacet
-  facet normal -0.557927 -0.76792 0.314667
-    outer loop
-      vertex 10.75 2.83494 14
-      vertex 9.65804 2.39899 11
-      vertex 10.25 1.96891 11
-    endloop
-  endfacet
-  facet normal 0 -0.949202 0.314667
-    outer loop
-      vertex 11.6341 1.51917 11
-      vertex 12.2613 2.51369 14
-      vertex 11.7387 2.51369 14
-    endloop
-  endfacet
-  facet normal 0 -0.949202 0.314667
-    outer loop
-      vertex 12.2613 2.51369 14
-      vertex 11.6341 1.51917 11
-      vertex 12.3658 1.51917 11
-    endloop
-  endfacet
-  facet normal 0.705394 -0.63514 0.314668
-    outer loop
-      vertex 14.0225 3.53054 14
-      vertex 13.6728 3.14214 14
-      vertex 14.342 2.39899 11
-    endloop
-  endfacet
-  facet normal 0.902744 -0.29332 0.314667
-    outer loop
-      vertex 14.4454 4.48022 14
-      vertex 14.2839 3.98316 14
-      vertex 15.1974 3.57642 11
-    endloop
-  endfacet
-  facet normal 0.902745 -0.29332 0.314667
-    outer loop
-      vertex 15.4235 4.27231 11
-      vertex 14.4454 4.48022 14
-      vertex 15.1974 3.57642 11
-    endloop
-  endfacet
-  facet normal 0.822033 0.4746 0.314667
-    outer loop
-      vertex 14.8316 7.05725 11
-      vertex 14.2839 6.01684 14
-      vertex 15.1974 6.42358 11
-    endloop
-  endfacet
-  facet normal 0.902745 0.29332 0.314667
-    outer loop
-      vertex 15.1974 6.42358 11
-      vertex 14.4454 5.51978 14
-      vertex 15.4235 5.72769 11
-    endloop
-  endfacet
-  facet normal -0.705395 0.63514 0.314668
-    outer loop
-      vertex 9.65804 7.60101 11
-      vertex 9.16844 7.05725 11
-      vertex 9.97746 6.46946 14
-    endloop
-  endfacet
-  facet normal -0.944002 0.0992173 0.314667
-    outer loop
-      vertex 9.55463 5.51978 14
-      vertex 8.5 5 11
-      vertex 9.5 5 14
-    endloop
-  endfacet
-  facet normal -0.197351 0.92846 0.314667
-    outer loop
-      vertex 11.6341 8.48083 11
-      vertex 10.9184 8.3287 11
-      vertex 11.2275 7.37764 14
-    endloop
-  endfacet
-  facet normal 0.705395 0.63514 0.314668
-    outer loop
-      vertex 14.342 7.60101 11
-      vertex 14.0225 6.46946 14
-      vertex 14.8316 7.05725 11
-    endloop
-  endfacet
-  facet normal 0.386075 0.867139 0.314667
-    outer loop
-      vertex 13.0816 8.3287 11
-      vertex 12.7725 7.37764 14
-      vertex 13.75 8.03109 11
-    endloop
-  endfacet
-  facet normal -0.822033 -0.4746 0.314667
-    outer loop
-      vertex 9.71614 3.98316 14
-      vertex 8.80259 3.57642 11
-      vertex 9.16844 2.94275 11
-    endloop
-  endfacet
-  facet normal -0.902745 -0.29332 0.314667
-    outer loop
-      vertex 9.55463 4.48022 14
-      vertex 8.57648 4.27231 11
-      vertex 8.80259 3.57642 11
-    endloop
-  endfacet
-  facet normal -0.705395 -0.63514 0.314668
-    outer loop
-      vertex 9.97746 3.53054 14
-      vertex 9.16844 2.94275 11
-      vertex 9.65804 2.39899 11
-    endloop
-  endfacet
-  facet normal -0.386075 -0.867139 0.314667
-    outer loop
-      vertex 11.2275 2.62236 14
-      vertex 10.25 1.96891 11
-      vertex 10.9184 1.6713 11
-    endloop
-  endfacet
-  facet normal 0.197351 -0.92846 0.314667
-    outer loop
-      vertex 12.7725 2.62236 14
-      vertex 12.3658 1.51917 11
-      vertex 13.0816 1.6713 11
-    endloop
-  endfacet
-  facet normal 0.386075 -0.867139 0.314668
-    outer loop
-      vertex 13.25 2.83494 14
-      vertex 12.7725 2.62236 14
-      vertex 13.75 1.96891 11
-    endloop
-  endfacet
-  facet normal 0.386075 -0.867139 0.314667
-    outer loop
-      vertex 13.75 1.96891 11
-      vertex 12.7725 2.62236 14
-      vertex 13.0816 1.6713 11
-    endloop
-  endfacet
-  facet normal 0.557927 -0.76792 0.314667
-    outer loop
-      vertex 14.342 2.39899 11
-      vertex 13.25 2.83494 14
-      vertex 13.75 1.96891 11
-    endloop
-  endfacet
-  facet normal 0.705395 -0.63514 0.314668
-    outer loop
-      vertex 14.8316 2.94275 11
-      vertex 14.0225 3.53054 14
-      vertex 14.342 2.39899 11
-    endloop
-  endfacet
-  facet normal 0.944002 -0.099219 0.314667
-    outer loop
-      vertex 15.5 5 11
-      vertex 14.4454 4.48022 14
-      vertex 15.4235 4.27231 11
-    endloop
-  endfacet
-  facet normal 0.944002 -0.0992189 0.314667
-    outer loop
-      vertex 14.5 5 14
-      vertex 14.4454 4.48022 14
-      vertex 15.5 5 11
-    endloop
-  endfacet
-  facet normal -0.944002 0.0992179 0.314667
-    outer loop
-      vertex 8.57648 5.72769 11
-      vertex 8.5 5 11
-      vertex 9.55463 5.51978 14
-    endloop
-  endfacet
-  facet normal -0.902744 0.29332 0.314667
-    outer loop
-      vertex 9.71614 6.01684 14
-      vertex 8.80259 6.42358 11
-      vertex 9.55463 5.51978 14
-    endloop
-  endfacet
-  facet normal -0.557927 0.767921 0.314668
-    outer loop
-      vertex 10.25 8.03109 11
-      vertex 9.65804 7.60101 11
-      vertex 10.75 7.16506 14
-    endloop
-  endfacet
-  facet normal -0.386075 0.867139 0.314667
-    outer loop
-      vertex 10.9184 8.3287 11
-      vertex 10.25 8.03109 11
-      vertex 11.2275 7.37764 14
-    endloop
-  endfacet
-  facet normal -0.386076 0.867139 0.314668
-    outer loop
-      vertex 11.2275 7.37764 14
-      vertex 10.25 8.03109 11
-      vertex 10.75 7.16506 14
-    endloop
-  endfacet
-  facet normal 0.822033 0.474601 0.314668
-    outer loop
-      vertex 14.8316 7.05725 11
-      vertex 14.0225 6.46946 14
-      vertex 14.2839 6.01684 14
-    endloop
-  endfacet
-  facet normal 0.705394 0.63514 0.314668
-    outer loop
-      vertex 14.342 7.60101 11
-      vertex 13.6728 6.85786 14
-      vertex 14.0225 6.46946 14
-    endloop
-  endfacet
-  facet normal 0.557927 0.76792 0.314668
-    outer loop
-      vertex 14.342 7.60101 11
-      vertex 13.25 7.16506 14
-      vertex 13.6728 6.85786 14
-    endloop
-  endfacet
-  facet normal 0.197351 0.92846 0.314667
-    outer loop
-      vertex 13.0816 8.3287 11
-      vertex 12.3658 8.48083 11
-      vertex 12.7725 7.37764 14
-    endloop
-  endfacet
-  facet normal 0.197351 0.92846 0.314667
-    outer loop
-      vertex 12.3658 8.48083 11
-      vertex 12.2613 7.4863 14
-      vertex 12.7725 7.37764 14
-    endloop
-  endfacet
-  facet normal -0.822033 -0.474601 0.314668
-    outer loop
-      vertex 9.71614 3.98316 14
-      vertex 9.16844 2.94275 11
-      vertex 9.97746 3.53054 14
-    endloop
-  endfacet
-  facet normal -0.705394 -0.63514 0.314668
-    outer loop
-      vertex 9.97746 3.53054 14
-      vertex 9.65804 2.39899 11
-      vertex 10.3272 3.14214 14
-    endloop
-  endfacet
-  facet normal -0.557927 -0.76792 0.314668
-    outer loop
-      vertex 10.3272 3.14214 14
-      vertex 9.65804 2.39899 11
-      vertex 10.75 2.83494 14
-    endloop
-  endfacet
-  facet normal -0.197351 -0.92846 0.314667
-    outer loop
-      vertex 11.2275 2.62236 14
-      vertex 10.9184 1.6713 11
-      vertex 11.6341 1.51917 11
-    endloop
-  endfacet
-  facet normal -0.197351 -0.92846 0.314667
-    outer loop
-      vertex 11.7387 2.51369 14
-      vertex 11.2275 2.62236 14
-      vertex 11.6341 1.51917 11
-    endloop
-  endfacet
-  facet normal 0.557927 -0.76792 0.314668
-    outer loop
-      vertex 13.6728 3.14214 14
-      vertex 13.25 2.83494 14
-      vertex 14.342 2.39899 11
-    endloop
-  endfacet
-  facet normal 0.197351 -0.92846 0.314667
-    outer loop
-      vertex 12.7725 2.62236 14
-      vertex 12.2613 2.51369 14
-      vertex 12.3658 1.51917 11
-    endloop
-  endfacet
-  facet normal 0.822033 -0.474601 0.314668
-    outer loop
-      vertex 14.2839 3.98316 14
-      vertex 14.0225 3.53054 14
-      vertex 14.8316 2.94275 11
-    endloop
-  endfacet
-  facet normal 0.822033 -0.4746 0.314667
-    outer loop
-      vertex 15.1974 3.57642 11
-      vertex 14.2839 3.98316 14
-      vertex 14.8316 2.94275 11
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.4454 5.51978 14
-      vertex 14.4454 4.48022 14
-      vertex 14.5 5 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2839 6.01684 14
-      vertex 14.4454 4.48022 14
-      vertex 14.4454 5.51978 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2839 6.01684 14
-      vertex 14.2839 3.98316 14
-      vertex 14.4454 4.48022 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0225 6.46946 14
-      vertex 14.2839 3.98316 14
-      vertex 14.2839 6.01684 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0225 6.46946 14
-      vertex 14.0225 3.53054 14
-      vertex 14.2839 3.98316 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.6728 6.85786 14
-      vertex 14.0225 3.53054 14
-      vertex 14.0225 6.46946 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.6728 6.85786 14
-      vertex 13.6728 3.14214 14
-      vertex 14.0225 3.53054 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.25 7.16506 14
-      vertex 13.6728 3.14214 14
-      vertex 13.6728 6.85786 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.25 7.16506 14
-      vertex 13.25 2.83494 14
-      vertex 13.6728 3.14214 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7725 7.37764 14
-      vertex 13.25 2.83494 14
-      vertex 13.25 7.16506 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.7725 7.37764 14
-      vertex 12.7725 2.62236 14
-      vertex 13.25 2.83494 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.2613 7.4863 14
-      vertex 12.7725 2.62236 14
-      vertex 12.7725 7.37764 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.2613 7.4863 14
-      vertex 12.2613 2.51369 14
-      vertex 12.7725 2.62236 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.7387 7.4863 14
-      vertex 12.2613 2.51369 14
-      vertex 12.2613 7.4863 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7387 7.4863 14
-      vertex 11.7387 2.51369 14
-      vertex 12.2613 2.51369 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 11.2275 7.37764 14
-      vertex 11.7387 2.51369 14
-      vertex 11.7387 7.4863 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.2275 7.37764 14
-      vertex 11.2275 2.62236 14
-      vertex 11.7387 2.51369 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.75 7.16506 14
-      vertex 11.2275 2.62236 14
-      vertex 11.2275 7.37764 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.75 7.16506 14
-      vertex 10.75 2.83494 14
-      vertex 11.2275 2.62236 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.3272 6.85786 14
-      vertex 10.75 2.83494 14
-      vertex 10.75 7.16506 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.3272 6.85786 14
-      vertex 10.3272 3.14214 14
-      vertex 10.75 2.83494 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.97746 6.46946 14
-      vertex 10.3272 3.14214 14
-      vertex 10.3272 6.85786 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.97746 6.46946 14
-      vertex 9.97746 3.53054 14
-      vertex 10.3272 3.14214 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.71614 6.01684 14
-      vertex 9.97746 3.53054 14
-      vertex 9.97746 6.46946 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.71614 6.01684 14
-      vertex 9.71614 3.98316 14
-      vertex 9.97746 3.53054 14
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 9.55463 5.51978 14
-      vertex 9.71614 3.98316 14
-      vertex 9.71614 6.01684 14
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.55463 5.51978 14
-      vertex 9.55463 4.48022 14
-      vertex 9.71614 3.98316 14
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 9.55463 4.48022 14
-      vertex 9.55463 5.51978 14
-      vertex 9.5 5 14
-    endloop
-  endfacet
-  facet normal -0.944002 -0.0992172 0.314667
-    outer loop
-      vertex 9.5 5 14
-      vertex 8.5 5 11
-      vertex 9.55463 4.48022 14
-    endloop
-  endfacet
-  facet normal -0.822033 0.4746 0.314667
-    outer loop
-      vertex 9.16844 7.05725 11
-      vertex 8.80259 6.42358 11
-      vertex 9.71614 6.01684 14
-    endloop
-  endfacet
-  facet normal -0.902745 0.29332 0.314667
-    outer loop
-      vertex 8.80259 6.42358 11
-      vertex 8.57648 5.72769 11
-      vertex 9.55463 5.51978 14
-    endloop
-  endfacet
-  facet normal -0.557927 0.767921 0.314668
-    outer loop
-      vertex 10.75 7.16506 14
-      vertex 9.65804 7.60101 11
-      vertex 10.3272 6.85786 14
-    endloop
-  endfacet
-  facet normal -0.705394 0.63514 0.314668
-    outer loop
-      vertex 10.3272 6.85786 14
-      vertex 9.65804 7.60101 11
-      vertex 9.97746 6.46946 14
-    endloop
-  endfacet
-  facet normal -0.197351 0.92846 0.314667
-    outer loop
-      vertex 11.6341 8.48083 11
-      vertex 11.2275 7.37764 14
-      vertex 11.7387 7.4863 14
-    endloop
-  endfacet
-  facet normal 0.386075 0.867139 0.314668
-    outer loop
-      vertex 13.75 8.03109 11
-      vertex 12.7725 7.37764 14
-      vertex 13.25 7.16506 14
-    endloop
-  endfacet
-  facet normal -0.386075 -0.867139 0.314668
-    outer loop
-      vertex 10.75 2.83494 14
-      vertex 10.25 1.96891 11
-      vertex 11.2275 2.62236 14
-    endloop
-  endfacet
-  facet normal -0.822033 0.474601 0.314668
-    outer loop
-      vertex 9.97746 6.46946 14
-      vertex 9.16844 7.05725 11
-      vertex 9.71614 6.01684 14
-    endloop
-  endfacet
   facet normal -1 0 0
     outer loop
       vertex -1 16 -1
@@ -2652,6 +496,580 @@ solid OpenSCAD_Model
       vertex 29 0.142136 14
     endloop
   endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.5 26 5.90876
+      vertex -5.5 26 5.9
+      vertex -5.66724 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 35.5 26 5.9
+      vertex 35.3328 26 5.90876
+      vertex 35.5 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 -1
+      vertex 35.3328 26 5.90876
+      vertex 35.5 26 5.9
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 35.3328 26 5.90876
+      vertex 42 26 -1
+      vertex -2.33275 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.33275 26 5.90876
+      vertex -2.5 26 5.9
+      vertex -2.5 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 35.0056 26 9.02169
+      vertex -2.33275 26 9.09123
+      vertex 35.3328 26 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 35.0056 26 9.02169
+      vertex -2.00557 26 9.02169
+      vertex -2.33275 26 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 34.7 26 8.88564
+      vertex -2.00557 26 9.02169
+      vertex 35.0056 26 9.02169
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.7 26 8.88564
+      vertex -1.7 26 8.88564
+      vertex -2.00557 26 9.02169
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 34.4294 26 8.68903
+      vertex -1.7 26 8.88564
+      vertex 34.7 26 8.88564
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.4294 26 8.68903
+      vertex -1.42939 26 8.68903
+      vertex -1.7 26 8.88564
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 34.2056 26 8.44046
+      vertex -1.42939 26 8.68903
+      vertex 34.4294 26 8.68903
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.2056 26 8.44046
+      vertex -1.20557 26 8.44046
+      vertex -1.42939 26 8.68903
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 34.0383 26 8.15078
+      vertex -1.20557 26 8.44046
+      vertex 34.2056 26 8.44046
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.0383 26 8.15078
+      vertex -1.03833 26 8.15078
+      vertex -1.20557 26 8.44046
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 33.935 26 7.83266
+      vertex -1.03833 26 8.15078
+      vertex 34.0383 26 8.15078
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 33.935 26 7.83266
+      vertex -0.934963 26 7.83266
+      vertex -1.03833 26 8.15078
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 33.9 26 7.5
+      vertex -0.934963 26 7.83266
+      vertex 33.935 26 7.83266
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 33.9 26 7.5
+      vertex -0.9 26 7.5
+      vertex -0.934963 26 7.83266
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 33.935 26 7.16734
+      vertex -0.9 26 7.5
+      vertex 33.9 26 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 33.935 26 7.16734
+      vertex -0.934963 26 7.16734
+      vertex -0.9 26 7.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.0383 26 6.84922
+      vertex -0.934963 26 7.16734
+      vertex 33.935 26 7.16734
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.0383 26 6.84922
+      vertex -1.03833 26 6.84922
+      vertex -0.934963 26 7.16734
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.2056 26 6.55954
+      vertex -1.03833 26 6.84922
+      vertex 34.0383 26 6.84922
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.2056 26 6.55954
+      vertex -1.20557 26 6.55954
+      vertex -1.03833 26 6.84922
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.4294 26 6.31097
+      vertex -1.20557 26 6.55954
+      vertex 34.2056 26 6.55954
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.4294 26 6.31097
+      vertex -1.42939 26 6.31097
+      vertex -1.20557 26 6.55954
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.7 26 6.11436
+      vertex -1.42939 26 6.31097
+      vertex 34.4294 26 6.31097
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34.7 26 6.11436
+      vertex -1.7 26 6.11436
+      vertex -1.42939 26 6.31097
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 35.0056 26 5.97831
+      vertex -1.7 26 6.11436
+      vertex 34.7 26 6.11436
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 35.0056 26 5.97831
+      vertex -2.00557 26 5.97831
+      vertex -1.7 26 6.11436
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 35.3328 26 5.90876
+      vertex -2.00557 26 5.97831
+      vertex 35.0056 26 5.97831
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.00557 26 5.97831
+      vertex 35.3328 26 5.90876
+      vertex -2.33275 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 35.3328 26 9.09123
+      vertex 35.5 26 9.1
+      vertex 35.5 26 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 35.5 26 9.1
+      vertex 35.3328 26 9.09123
+      vertex -2.5 26 9.1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.33275 26 9.09123
+      vertex -2.5 26 9.1
+      vertex 35.3328 26 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.5 26 9.1
+      vertex -2.33275 26 9.09123
+      vertex -2.5 26 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 35.5 26 9.1
+      vertex 42 26 14
+      vertex 38.5 26 9.1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex 38.6672 26 9.09123
+      vertex 38.5 26 9.1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex 38.9944 26 9.02169
+      vertex 38.6672 26 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex 39.3 26 8.88564
+      vertex 38.9944 26 9.02169
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex 39.5706 26 8.68903
+      vertex 39.3 26 8.88564
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex 39.7944 26 8.44046
+      vertex 39.5706 26 8.68903
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex 39.9617 26 8.15078
+      vertex 39.7944 26 8.44046
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex 40.065 26 7.83266
+      vertex 39.9617 26 8.15078
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex 40.1 26 7.5
+      vertex 40.065 26 7.83266
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 42 26 -1
+      vertex 40.1 26 7.5
+      vertex 42 26 14
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 38.6672 26 5.90876
+      vertex 38.5 26 5.9
+      vertex 38.5 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 -1
+      vertex 35.5 26 5.9
+      vertex 38.5 26 5.9
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10 26 -1
+      vertex -2.33275 26 5.90876
+      vertex 42 26 -1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.33275 26 5.90876
+      vertex -10 26 -1
+      vertex -2.5 26 5.9
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 38.6672 26 5.90876
+      vertex 42 26 -1
+      vertex 38.5 26 5.9
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 38.9944 26 5.97831
+      vertex 42 26 -1
+      vertex 38.6672 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 39.3 26 6.11436
+      vertex 42 26 -1
+      vertex 38.9944 26 5.97831
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 39.5706 26 6.31097
+      vertex 42 26 -1
+      vertex 39.3 26 6.11436
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 39.7944 26 6.55954
+      vertex 42 26 -1
+      vertex 39.5706 26 6.31097
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 39.9617 26 6.84922
+      vertex 42 26 -1
+      vertex 39.7944 26 6.55954
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 40.065 26 7.16734
+      vertex 42 26 -1
+      vertex 39.9617 26 6.84922
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 40.1 26 7.5
+      vertex 42 26 -1
+      vertex 40.065 26 7.16734
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.5 26 9.1
+      vertex 42 26 14
+      vertex 35.5 26 9.1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 42 26 14
+      vertex -2.5 26 9.1
+      vertex -10 26 14
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -5.5 26 9.1
+      vertex -10 26 14
+      vertex -2.5 26 9.1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.66724 26 9.09123
+      vertex -5.5 26 9.1
+      vertex -5.5 26 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.5 26 9.1
+      vertex -5.66724 26 9.09123
+      vertex -10 26 14
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -5.99443 26 9.02169
+      vertex -10 26 14
+      vertex -5.66724 26 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -6.3 26 8.88564
+      vertex -10 26 14
+      vertex -5.99443 26 9.02169
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -6.57061 26 8.68903
+      vertex -10 26 14
+      vertex -6.3 26 8.88564
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -6.79443 26 8.44046
+      vertex -10 26 14
+      vertex -6.57061 26 8.68903
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -6.96167 26 8.15078
+      vertex -10 26 14
+      vertex -6.79443 26 8.44046
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -7.06504 26 7.83266
+      vertex -10 26 14
+      vertex -6.96167 26 8.15078
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -7.1 26 7.5
+      vertex -10 26 14
+      vertex -7.06504 26 7.83266
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10 26 -1
+      vertex -7.1 26 7.5
+      vertex -7.06504 26 7.16734
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -10 26 -1
+      vertex -7.06504 26 7.16734
+      vertex -6.96167 26 6.84922
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.5 26 5.9
+      vertex -10 26 -1
+      vertex -5.5 26 5.9
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.1 26 7.5
+      vertex -10 26 -1
+      vertex -10 26 14
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.79443 26 6.55954
+      vertex -10 26 -1
+      vertex -6.96167 26 6.84922
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.57061 26 6.31097
+      vertex -10 26 -1
+      vertex -6.79443 26 6.55954
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.3 26 6.11436
+      vertex -10 26 -1
+      vertex -6.57061 26 6.31097
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.99443 26 5.97831
+      vertex -10 26 -1
+      vertex -6.3 26 6.11436
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.66724 26 5.90876
+      vertex -10 26 -1
+      vertex -5.99443 26 5.97831
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.5 26 5.9
+      vertex -10 26 -1
+      vertex -5.66724 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 38.5 26 9.1
+      vertex 38.6672 26 9.09123
+      vertex 38.5 26 9.09123
+    endloop
+  endfacet
   facet normal -0 0 -1
     outer loop
       vertex 29 0.142136 -1
@@ -2764,580 +1182,6 @@ solid OpenSCAD_Model
       vertex 0.142136 -1 -1
     endloop
   endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.5 26 5.90876
-      vertex -5.5 26 5.9
-      vertex -5.66724 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 35.5 26 5.9
-      vertex 35.3328 26 5.90876
-      vertex 35.5 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 -1
-      vertex 35.3328 26 5.90876
-      vertex 35.5 26 5.9
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 35.3328 26 5.90876
-      vertex 42 26 -1
-      vertex -2.33275 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.33275 26 5.90876
-      vertex -2.5 26 5.9
-      vertex -2.5 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 35.0056 26 9.02169
-      vertex -2.33275 26 9.09123
-      vertex 35.3328 26 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 35.0056 26 9.02169
-      vertex -2.00557 26 9.02169
-      vertex -2.33275 26 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 34.7 26 8.88564
-      vertex -2.00557 26 9.02169
-      vertex 35.0056 26 9.02169
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.7 26 8.88564
-      vertex -1.7 26 8.88564
-      vertex -2.00557 26 9.02169
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 34.4294 26 8.68903
-      vertex -1.7 26 8.88564
-      vertex 34.7 26 8.88564
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.4294 26 8.68903
-      vertex -1.42939 26 8.68903
-      vertex -1.7 26 8.88564
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 34.2056 26 8.44046
-      vertex -1.42939 26 8.68903
-      vertex 34.4294 26 8.68903
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.2056 26 8.44046
-      vertex -1.20557 26 8.44046
-      vertex -1.42939 26 8.68903
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 34.0383 26 8.15078
-      vertex -1.20557 26 8.44046
-      vertex 34.2056 26 8.44046
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.0383 26 8.15078
-      vertex -1.03833 26 8.15078
-      vertex -1.20557 26 8.44046
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 33.935 26 7.83266
-      vertex -1.03833 26 8.15078
-      vertex 34.0383 26 8.15078
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 33.935 26 7.83266
-      vertex -0.934963 26 7.83266
-      vertex -1.03833 26 8.15078
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 33.9 26 7.5
-      vertex -0.934963 26 7.83266
-      vertex 33.935 26 7.83266
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 33.9 26 7.5
-      vertex -0.9 26 7.5
-      vertex -0.934963 26 7.83266
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 33.935 26 7.16734
-      vertex -0.9 26 7.5
-      vertex 33.9 26 7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 33.935 26 7.16734
-      vertex -0.934963 26 7.16734
-      vertex -0.9 26 7.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.0383 26 6.84922
-      vertex -0.934963 26 7.16734
-      vertex 33.935 26 7.16734
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.0383 26 6.84922
-      vertex -1.03833 26 6.84922
-      vertex -0.934963 26 7.16734
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.2056 26 6.55954
-      vertex -1.03833 26 6.84922
-      vertex 34.0383 26 6.84922
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.2056 26 6.55954
-      vertex -1.20557 26 6.55954
-      vertex -1.03833 26 6.84922
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.4294 26 6.31097
-      vertex -1.20557 26 6.55954
-      vertex 34.2056 26 6.55954
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.4294 26 6.31097
-      vertex -1.42939 26 6.31097
-      vertex -1.20557 26 6.55954
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.7 26 6.11436
-      vertex -1.42939 26 6.31097
-      vertex 34.4294 26 6.31097
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 34.7 26 6.11436
-      vertex -1.7 26 6.11436
-      vertex -1.42939 26 6.31097
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 35.0056 26 5.97831
-      vertex -1.7 26 6.11436
-      vertex 34.7 26 6.11436
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 35.0056 26 5.97831
-      vertex -2.00557 26 5.97831
-      vertex -1.7 26 6.11436
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 35.3328 26 5.90876
-      vertex -2.00557 26 5.97831
-      vertex 35.0056 26 5.97831
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.00557 26 5.97831
-      vertex 35.3328 26 5.90876
-      vertex -2.33275 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 35.3328 26 9.09123
-      vertex 35.5 26 9.1
-      vertex 35.5 26 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 35.5 26 9.1
-      vertex 35.3328 26 9.09123
-      vertex -2.5 26 9.1
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -2.33275 26 9.09123
-      vertex -2.5 26 9.1
-      vertex 35.3328 26 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.5 26 9.1
-      vertex -2.33275 26 9.09123
-      vertex -2.5 26 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 35.5 26 9.1
-      vertex 42 26 14
-      vertex 38.5 26 9.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex 38.6672 26 9.09123
-      vertex 38.5 26 9.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex 38.9944 26 9.02169
-      vertex 38.6672 26 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex 39.3 26 8.88564
-      vertex 38.9944 26 9.02169
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex 39.5706 26 8.68903
-      vertex 39.3 26 8.88564
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex 39.7944 26 8.44046
-      vertex 39.5706 26 8.68903
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex 39.9617 26 8.15078
-      vertex 39.7944 26 8.44046
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex 40.065 26 7.83266
-      vertex 39.9617 26 8.15078
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex 40.1 26 7.5
-      vertex 40.065 26 7.83266
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 42 26 -1
-      vertex 40.1 26 7.5
-      vertex 42 26 14
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 38.6672 26 5.90876
-      vertex 38.5 26 5.9
-      vertex 38.5 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 -1
-      vertex 35.5 26 5.9
-      vertex 38.5 26 5.9
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10 26 -1
-      vertex -2.33275 26 5.90876
-      vertex 42 26 -1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.33275 26 5.90876
-      vertex -10 26 -1
-      vertex -2.5 26 5.9
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 38.6672 26 5.90876
-      vertex 42 26 -1
-      vertex 38.5 26 5.9
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 38.9944 26 5.97831
-      vertex 42 26 -1
-      vertex 38.6672 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 39.3 26 6.11436
-      vertex 42 26 -1
-      vertex 38.9944 26 5.97831
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 39.5706 26 6.31097
-      vertex 42 26 -1
-      vertex 39.3 26 6.11436
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 39.7944 26 6.55954
-      vertex 42 26 -1
-      vertex 39.5706 26 6.31097
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 39.9617 26 6.84922
-      vertex 42 26 -1
-      vertex 39.7944 26 6.55954
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 40.065 26 7.16734
-      vertex 42 26 -1
-      vertex 39.9617 26 6.84922
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 40.1 26 7.5
-      vertex 42 26 -1
-      vertex 40.065 26 7.16734
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.5 26 9.1
-      vertex 42 26 14
-      vertex 35.5 26 9.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 42 26 14
-      vertex -2.5 26 9.1
-      vertex -10 26 14
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -5.5 26 9.1
-      vertex -10 26 14
-      vertex -2.5 26 9.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.66724 26 9.09123
-      vertex -5.5 26 9.1
-      vertex -5.5 26 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.5 26 9.1
-      vertex -5.66724 26 9.09123
-      vertex -10 26 14
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -5.99443 26 9.02169
-      vertex -10 26 14
-      vertex -5.66724 26 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -6.3 26 8.88564
-      vertex -10 26 14
-      vertex -5.99443 26 9.02169
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -6.57061 26 8.68903
-      vertex -10 26 14
-      vertex -6.3 26 8.88564
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -6.79443 26 8.44046
-      vertex -10 26 14
-      vertex -6.57061 26 8.68903
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -6.96167 26 8.15078
-      vertex -10 26 14
-      vertex -6.79443 26 8.44046
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -7.06504 26 7.83266
-      vertex -10 26 14
-      vertex -6.96167 26 8.15078
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -7.1 26 7.5
-      vertex -10 26 14
-      vertex -7.06504 26 7.83266
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10 26 -1
-      vertex -7.1 26 7.5
-      vertex -7.06504 26 7.16734
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10 26 -1
-      vertex -7.06504 26 7.16734
-      vertex -6.96167 26 6.84922
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.5 26 5.9
-      vertex -10 26 -1
-      vertex -5.5 26 5.9
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.1 26 7.5
-      vertex -10 26 -1
-      vertex -10 26 14
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -6.79443 26 6.55954
-      vertex -10 26 -1
-      vertex -6.96167 26 6.84922
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -6.57061 26 6.31097
-      vertex -10 26 -1
-      vertex -6.79443 26 6.55954
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -6.3 26 6.11436
-      vertex -10 26 -1
-      vertex -6.57061 26 6.31097
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.99443 26 5.97831
-      vertex -10 26 -1
-      vertex -6.3 26 6.11436
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.66724 26 5.90876
-      vertex -10 26 -1
-      vertex -5.99443 26 5.97831
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.5 26 5.9
-      vertex -10 26 -1
-      vertex -5.66724 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 38.5 26 9.1
-      vertex 38.6672 26 9.09123
-      vertex 38.5 26 9.09123
-    endloop
-  endfacet
   facet normal -1 0 0
     outer loop
       vertex -10 16 -1
@@ -3800,3051 +1644,6 @@ solid OpenSCAD_Model
       vertex 42 23 -1
     endloop
   endfacet
-  facet normal -0.994522 0 -0.104528
-    outer loop
-      vertex -0.9 22 7.5
-      vertex -0.934963 26 7.83266
-      vertex -0.9 26 7.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0 -0.104528
-    outer loop
-      vertex -0.934963 26 7.83266
-      vertex -0.9 22 7.5
-      vertex -0.934963 22 7.83266
-    endloop
-  endfacet
-  facet normal -0.951056 0 -0.309018
-    outer loop
-      vertex -0.934963 22 7.83266
-      vertex -1.03833 26 8.15078
-      vertex -0.934963 26 7.83266
-    endloop
-  endfacet
-  facet normal -0.951056 -0 -0.309018
-    outer loop
-      vertex -1.03833 26 8.15078
-      vertex -0.934963 22 7.83266
-      vertex -1.03833 22 8.15078
-    endloop
-  endfacet
-  facet normal -0.587785 0 -0.809017
-    outer loop
-      vertex -1.7 22 8.88564
-      vertex -1.42939 26 8.68903
-      vertex -1.42939 22 8.68903
-    endloop
-  endfacet
-  facet normal -0.587785 0 -0.809017
-    outer loop
-      vertex -1.42939 26 8.68903
-      vertex -1.7 22 8.88564
-      vertex -1.7 26 8.88564
-    endloop
-  endfacet
-  facet normal -0.866027 0 -0.499998
-    outer loop
-      vertex -1.03833 22 8.15078
-      vertex -1.20557 26 8.44046
-      vertex -1.03833 26 8.15078
-    endloop
-  endfacet
-  facet normal -0.866027 -0 -0.499998
-    outer loop
-      vertex -1.20557 26 8.44046
-      vertex -1.03833 22 8.15078
-      vertex -1.20557 22 8.44046
-    endloop
-  endfacet
-  facet normal -0.207909 0 -0.978148
-    outer loop
-      vertex -2.33275 22 9.09123
-      vertex -2.00557 26 9.02169
-      vertex -2.00557 22 9.02169
-    endloop
-  endfacet
-  facet normal -0.207909 0 -0.978148
-    outer loop
-      vertex -2.00557 26 9.02169
-      vertex -2.33275 22 9.09123
-      vertex -2.33275 26 9.09123
-    endloop
-  endfacet
-  facet normal -0.406738 0 -0.913545
-    outer loop
-      vertex -2.00557 22 9.02169
-      vertex -1.7 26 8.88564
-      vertex -1.7 22 8.88564
-    endloop
-  endfacet
-  facet normal -0.406738 0 -0.913545
-    outer loop
-      vertex -1.7 26 8.88564
-      vertex -2.00557 22 9.02169
-      vertex -2.00557 26 9.02169
-    endloop
-  endfacet
-  facet normal -0.994522 0 0.104528
-    outer loop
-      vertex -0.934963 22 7.16734
-      vertex -0.9 26 7.5
-      vertex -0.934963 26 7.16734
-    endloop
-  endfacet
-  facet normal -0.994522 0 0.104528
-    outer loop
-      vertex -0.9 26 7.5
-      vertex -0.934963 22 7.16734
-      vertex -0.9 22 7.5
-    endloop
-  endfacet
-  facet normal -0.207909 0 0.978148
-    outer loop
-      vertex -2.33275 26 5.90876
-      vertex -2.00557 22 5.97831
-      vertex -2.00557 26 5.97831
-    endloop
-  endfacet
-  facet normal -0.207909 0 0.978148
-    outer loop
-      vertex -2.00557 22 5.97831
-      vertex -2.33275 26 5.90876
-      vertex -2.33275 22 5.90876
-    endloop
-  endfacet
-  facet normal -0.587785 0 0.809017
-    outer loop
-      vertex -1.7 26 6.11436
-      vertex -1.42939 22 6.31097
-      vertex -1.42939 26 6.31097
-    endloop
-  endfacet
-  facet normal -0.587785 0 0.809017
-    outer loop
-      vertex -1.42939 22 6.31097
-      vertex -1.7 26 6.11436
-      vertex -1.7 22 6.11436
-    endloop
-  endfacet
-  facet normal -0.743144 0 -0.669132
-    outer loop
-      vertex -1.20557 22 8.44046
-      vertex -1.42939 26 8.68903
-      vertex -1.20557 26 8.44046
-    endloop
-  endfacet
-  facet normal -0.743144 -0 -0.669132
-    outer loop
-      vertex -1.42939 26 8.68903
-      vertex -1.20557 22 8.44046
-      vertex -1.42939 22 8.68903
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.5 22 9.09123
-      vertex -2.33275 26 9.09123
-      vertex -2.33275 22 9.09123
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.33275 26 9.09123
-      vertex -2.5 22 9.09123
-      vertex -2.5 26 9.09123
-    endloop
-  endfacet
-  facet normal -0.743144 0 0.669132
-    outer loop
-      vertex -1.42939 22 6.31097
-      vertex -1.20557 26 6.55954
-      vertex -1.42939 26 6.31097
-    endloop
-  endfacet
-  facet normal -0.743144 0 0.669132
-    outer loop
-      vertex -1.20557 26 6.55954
-      vertex -1.42939 22 6.31097
-      vertex -1.20557 22 6.55954
-    endloop
-  endfacet
-  facet normal -0.866027 0 0.499998
-    outer loop
-      vertex -1.20557 22 6.55954
-      vertex -1.03833 26 6.84922
-      vertex -1.20557 26 6.55954
-    endloop
-  endfacet
-  facet normal -0.866027 0 0.499998
-    outer loop
-      vertex -1.03833 26 6.84922
-      vertex -1.20557 22 6.55954
-      vertex -1.03833 22 6.84922
-    endloop
-  endfacet
-  facet normal -0.406738 0 0.913545
-    outer loop
-      vertex -2.00557 26 5.97831
-      vertex -1.7 22 6.11436
-      vertex -1.7 26 6.11436
-    endloop
-  endfacet
-  facet normal -0.406738 0 0.913545
-    outer loop
-      vertex -1.7 22 6.11436
-      vertex -2.00557 26 5.97831
-      vertex -2.00557 22 5.97831
-    endloop
-  endfacet
-  facet normal -0.951056 0 0.309018
-    outer loop
-      vertex -1.03833 22 6.84922
-      vertex -0.934963 26 7.16734
-      vertex -1.03833 26 6.84922
-    endloop
-  endfacet
-  facet normal -0.951056 0 0.309018
-    outer loop
-      vertex -0.934963 26 7.16734
-      vertex -1.03833 22 6.84922
-      vertex -0.934963 22 7.16734
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -2.5 26 5.90876
-      vertex -2.33275 22 5.90876
-      vertex -2.33275 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.33275 22 5.90876
-      vertex -2.5 26 5.90876
-      vertex -2.5 22 5.90876
-    endloop
-  endfacet
-  facet normal 0.207909 0 -0.978148
-    outer loop
-      vertex -5.99443 22 9.02169
-      vertex -5.66724 26 9.09123
-      vertex -5.66724 22 9.09123
-    endloop
-  endfacet
-  facet normal 0.207909 0 -0.978148
-    outer loop
-      vertex -5.66724 26 9.09123
-      vertex -5.99443 22 9.02169
-      vertex -5.99443 26 9.02169
-    endloop
-  endfacet
-  facet normal 0.743144 0 -0.669132
-    outer loop
-      vertex -6.57061 22 8.68903
-      vertex -6.79443 26 8.44046
-      vertex -6.57061 26 8.68903
-    endloop
-  endfacet
-  facet normal 0.743144 0 -0.669132
-    outer loop
-      vertex -6.79443 26 8.44046
-      vertex -6.57061 22 8.68903
-      vertex -6.79443 22 8.44046
-    endloop
-  endfacet
-  facet normal 0.587785 0 -0.809017
-    outer loop
-      vertex -6.57061 22 8.68903
-      vertex -6.3 26 8.88564
-      vertex -6.3 22 8.88564
-    endloop
-  endfacet
-  facet normal 0.587785 0 -0.809017
-    outer loop
-      vertex -6.3 26 8.88564
-      vertex -6.57061 22 8.68903
-      vertex -6.57061 26 8.68903
-    endloop
-  endfacet
-  facet normal 0.951056 0 -0.309018
-    outer loop
-      vertex -6.96167 22 8.15078
-      vertex -7.06504 26 7.83266
-      vertex -6.96167 26 8.15078
-    endloop
-  endfacet
-  facet normal 0.951056 0 -0.309018
-    outer loop
-      vertex -7.06504 26 7.83266
-      vertex -6.96167 22 8.15078
-      vertex -7.06504 22 7.83266
-    endloop
-  endfacet
-  facet normal 0.866027 0 -0.499998
-    outer loop
-      vertex -6.79443 22 8.44046
-      vertex -6.96167 26 8.15078
-      vertex -6.79443 26 8.44046
-    endloop
-  endfacet
-  facet normal 0.866027 0 -0.499998
-    outer loop
-      vertex -6.96167 26 8.15078
-      vertex -6.79443 22 8.44046
-      vertex -6.96167 22 8.15078
-    endloop
-  endfacet
-  facet normal 0.406738 0 -0.913545
-    outer loop
-      vertex -6.3 22 8.88564
-      vertex -5.99443 26 9.02169
-      vertex -5.99443 22 9.02169
-    endloop
-  endfacet
-  facet normal 0.406738 0 -0.913545
-    outer loop
-      vertex -5.99443 26 9.02169
-      vertex -6.3 22 8.88564
-      vertex -6.3 26 8.88564
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.66724 22 9.09123
-      vertex -5.5 26 9.09123
-      vertex -5.5 22 9.09123
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -5.5 26 9.09123
-      vertex -5.66724 22 9.09123
-      vertex -5.66724 26 9.09123
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104528
-    outer loop
-      vertex -7.06504 22 7.83266
-      vertex -7.1 26 7.5
-      vertex -7.06504 26 7.83266
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104528
-    outer loop
-      vertex -7.1 26 7.5
-      vertex -7.06504 22 7.83266
-      vertex -7.1 22 7.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0 0.104528
-    outer loop
-      vertex -7.1 22 7.5
-      vertex -7.06504 26 7.16734
-      vertex -7.1 26 7.5
-    endloop
-  endfacet
-  facet normal 0.994522 0 0.104528
-    outer loop
-      vertex -7.06504 26 7.16734
-      vertex -7.1 22 7.5
-      vertex -7.06504 22 7.16734
-    endloop
-  endfacet
-  facet normal 0.587785 0 0.809017
-    outer loop
-      vertex -6.57061 26 6.31097
-      vertex -6.3 22 6.11436
-      vertex -6.3 26 6.11436
-    endloop
-  endfacet
-  facet normal 0.587785 0 0.809017
-    outer loop
-      vertex -6.3 22 6.11436
-      vertex -6.57061 26 6.31097
-      vertex -6.57061 22 6.31097
-    endloop
-  endfacet
-  facet normal 0.406738 0 0.913545
-    outer loop
-      vertex -6.3 26 6.11436
-      vertex -5.99443 22 5.97831
-      vertex -5.99443 26 5.97831
-    endloop
-  endfacet
-  facet normal 0.406738 0 0.913545
-    outer loop
-      vertex -5.99443 22 5.97831
-      vertex -6.3 26 6.11436
-      vertex -6.3 22 6.11436
-    endloop
-  endfacet
-  facet normal 0.743144 -0 0.669132
-    outer loop
-      vertex -6.79443 22 6.55954
-      vertex -6.57061 26 6.31097
-      vertex -6.79443 26 6.55954
-    endloop
-  endfacet
-  facet normal 0.743144 0 0.669132
-    outer loop
-      vertex -6.57061 26 6.31097
-      vertex -6.79443 22 6.55954
-      vertex -6.57061 22 6.31097
-    endloop
-  endfacet
-  facet normal 0.866027 -0 0.499998
-    outer loop
-      vertex -6.96167 22 6.84922
-      vertex -6.79443 26 6.55954
-      vertex -6.96167 26 6.84922
-    endloop
-  endfacet
-  facet normal 0.866027 0 0.499998
-    outer loop
-      vertex -6.79443 26 6.55954
-      vertex -6.96167 22 6.84922
-      vertex -6.79443 22 6.55954
-    endloop
-  endfacet
-  facet normal 0.951056 -0 0.309018
-    outer loop
-      vertex -7.06504 22 7.16734
-      vertex -6.96167 26 6.84922
-      vertex -7.06504 26 7.16734
-    endloop
-  endfacet
-  facet normal 0.951056 0 0.309018
-    outer loop
-      vertex -6.96167 26 6.84922
-      vertex -7.06504 22 7.16734
-      vertex -6.96167 22 6.84922
-    endloop
-  endfacet
-  facet normal 0.207909 0 0.978148
-    outer loop
-      vertex -5.99443 26 5.97831
-      vertex -5.66724 22 5.90876
-      vertex -5.66724 26 5.90876
-    endloop
-  endfacet
-  facet normal 0.207909 0 0.978148
-    outer loop
-      vertex -5.66724 22 5.90876
-      vertex -5.99443 26 5.97831
-      vertex -5.99443 22 5.97831
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.66724 26 5.90876
-      vertex -5.5 22 5.90876
-      vertex -5.5 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.5 22 5.90876
-      vertex -5.66724 26 5.90876
-      vertex -5.66724 22 5.90876
-    endloop
-  endfacet
-  facet normal -0.994522 0 -0.104529
-    outer loop
-      vertex 0.5 15 7.5
-      vertex 0.434443 22 8.12373
-      vertex 0.5 22 7.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0 -0.104529
-    outer loop
-      vertex 0.434443 22 8.12373
-      vertex 0.5 15 7.5
-      vertex 0.434443 15 8.12373
-    endloop
-  endfacet
-  facet normal -0.951056 0 -0.309017
-    outer loop
-      vertex 0.434443 15 8.12373
-      vertex 0.240636 22 8.72021
-      vertex 0.434443 22 8.12373
-    endloop
-  endfacet
-  facet normal -0.951056 -0 -0.309017
-    outer loop
-      vertex 0.240636 22 8.72021
-      vertex 0.434443 15 8.12373
-      vertex 0.240636 15 8.72021
-    endloop
-  endfacet
-  facet normal -0.447214 0 0.894427
-    outer loop
-      vertex -0.999999 22 4.90192
-      vertex -1 16 4.90192
-      vertex -0.999999 15 4.90192
-    endloop
-  endfacet
-  facet normal -0.406737 -7.95301e-009 0.913545
-    outer loop
-      vertex -1.57295 22 4.64683
-      vertex -1 16 4.90192
-      vertex -0.999999 22 4.90192
-    endloop
-  endfacet
-  facet normal -0.406737 0 0.913545
-    outer loop
-      vertex -1 16 4.90192
-      vertex -1.57295 22 4.64683
-      vertex -1.57295 16 4.64683
-    endloop
-  endfacet
-  facet normal -0.447214 0 0.894427
-    outer loop
-      vertex -0.999999 15 4.90192
-      vertex -1 16 4.90192
-      vertex -1 15 4.90192
-    endloop
-  endfacet
-  facet normal -0.587786 0 -0.809016
-    outer loop
-      vertex -0.999999 15 10.0981
-      vertex -0.492608 22 9.72943
-      vertex -0.492608 15 9.72943
-    endloop
-  endfacet
-  facet normal -0.587786 0 -0.809016
-    outer loop
-      vertex -0.492608 22 9.72943
-      vertex -0.999999 15 10.0981
-      vertex -0.999999 22 10.0981
-    endloop
-  endfacet
-  facet normal -0.866026 0 -0.499999
-    outer loop
-      vertex 0.240636 15 8.72021
-      vertex -0.0729485 22 9.26336
-      vertex 0.240636 22 8.72021
-    endloop
-  endfacet
-  facet normal -0.866026 -0 -0.499999
-    outer loop
-      vertex -0.0729485 22 9.26336
-      vertex 0.240636 15 8.72021
-      vertex -0.0729485 15 9.26336
-    endloop
-  endfacet
-  facet normal -0.207911 0 -0.978148
-    outer loop
-      vertex -2.18641 16 10.4836
-      vertex -1.57295 22 10.3532
-      vertex -1.57295 16 10.3532
-    endloop
-  endfacet
-  facet normal -0.207911 0 -0.978148
-    outer loop
-      vertex -1.57295 22 10.3532
-      vertex -2.18641 16 10.4836
-      vertex -2.18641 22 10.4836
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1 16 10.0981
-      vertex -0.999999 15 10.0981
-      vertex -1 15 10.0981
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.999999 15 10.0981
-      vertex -1 16 10.0981
-      vertex -0.999999 22 10.0981
-    endloop
-  endfacet
-  facet normal -0.406737 6.46492e-008 -0.913545
-    outer loop
-      vertex -1.57295 16 10.3532
-      vertex -0.999999 22 10.0981
-      vertex -1 16 10.0981
-    endloop
-  endfacet
-  facet normal -0.406737 0 -0.913545
-    outer loop
-      vertex -0.999999 22 10.0981
-      vertex -1.57295 16 10.3532
-      vertex -1.57295 22 10.3532
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.5 22 4.5
-      vertex -2.5 22 4.51643
-      vertex -5.5 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -2.5 22 4.51643
-      vertex -5.5 22 4.5
-      vertex -2.5 22 4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.5 22 5.90876
-      vertex -2.5 22 5.9
-      vertex -2.33275 22 5.90876
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.66724 22 9.09123
-      vertex -5.5 22 10.4836
-      vertex -5.81359 22 10.4836
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.5 22 10.4836
-      vertex -5.5 22 9.1
-      vertex -2.5 22 10.4836
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.66724 22 9.09123
-      vertex -5.81359 22 10.4836
-      vertex -6.42705 22 10.3532
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.5 22 9.1
-      vertex -2.5 22 10.4836
-      vertex -5.5 22 9.1
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.99443 22 9.02169
-      vertex -6.42705 22 10.3532
-      vertex -7 22 10.0981
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.33275 22 9.09123
-      vertex -2.5 22 10.4836
-      vertex -2.5 22 9.1
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -6.3 22 8.88564
-      vertex -7 22 10.0981
-      vertex -7.50739 22 9.72943
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.5 22 10.4836
-      vertex -2.33275 22 9.09123
-      vertex -2.18641 22 10.4836
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -6.57061 22 8.68903
-      vertex -7.50739 22 9.72943
-      vertex -7.92705 22 9.26336
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -2.18641 22 10.4836
-      vertex -2.33275 22 9.09123
-      vertex -1.57295 22 10.3532
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.00557 22 9.02169
-      vertex -1.57295 22 10.3532
-      vertex -2.33275 22 9.09123
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -5.5 22 10.4836
-      vertex -5.66724 22 9.09123
-      vertex -5.5 22 9.1
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -6.42705 22 10.3532
-      vertex -5.99443 22 9.02169
-      vertex -5.66724 22 9.09123
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -7 22 10.0981
-      vertex -6.3 22 8.88564
-      vertex -5.99443 22 9.02169
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -6.79443 22 8.44046
-      vertex -7.92705 22 9.26336
-      vertex -8.24064 22 8.72021
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -7.50739 22 9.72943
-      vertex -6.57061 22 8.68903
-      vertex -6.3 22 8.88564
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -7.92705 22 9.26336
-      vertex -6.79443 22 8.44046
-      vertex -6.57061 22 8.68903
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.24064 22 8.72021
-      vertex -6.96167 22 8.15078
-      vertex -6.79443 22 8.44046
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.43444 22 8.12373
-      vertex -6.96167 22 8.15078
-      vertex -8.24064 22 8.72021
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.43444 22 8.12373
-      vertex -7.06504 22 7.83266
-      vertex -6.96167 22 8.15078
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.5 22 7.5
-      vertex -7.06504 22 7.83266
-      vertex -8.43444 22 8.12373
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.5 22 7.5
-      vertex -7.1 22 7.5
-      vertex -7.06504 22 7.83266
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.5 22 7.5
-      vertex -7.06504 22 7.16734
-      vertex -7.1 22 7.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.43444 22 6.87626
-      vertex -7.06504 22 7.16734
-      vertex -8.5 22 7.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.43444 22 6.87626
-      vertex -6.96167 22 6.84922
-      vertex -7.06504 22 7.16734
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.24064 22 6.27979
-      vertex -6.96167 22 6.84922
-      vertex -8.43444 22 6.87626
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -6.96167 22 6.84922
-      vertex -8.24064 22 6.27979
-      vertex -6.79443 22 6.55954
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -7.92705 22 5.73664
-      vertex -6.79443 22 6.55954
-      vertex -8.24064 22 6.27979
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -6.79443 22 6.55954
-      vertex -7.92705 22 5.73664
-      vertex -6.57061 22 6.31097
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -7.50739 22 5.27057
-      vertex -6.57061 22 6.31097
-      vertex -7.92705 22 5.73664
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -6.57061 22 6.31097
-      vertex -7.50739 22 5.27057
-      vertex -6.3 22 6.11436
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.66724 22 5.90876
-      vertex -5.5 22 5.9
-      vertex -5.5 22 5.90876
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -6.42705 22 4.64683
-      vertex -5.99443 22 5.97831
-      vertex -7 22 4.90192
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -6.3 22 6.11436
-      vertex -7 22 4.90192
-      vertex -5.99443 22 5.97831
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -7 22 4.90192
-      vertex -6.3 22 6.11436
-      vertex -7.50739 22 5.27057
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.5 22 10.4836
-      vertex -2.5 22 10.5
-      vertex -5.5 22 10.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -2.5 22 10.5
-      vertex -5.5 22 10.4836
-      vertex -2.5 22 10.4836
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -1.57295 22 10.3532
-      vertex -2.00557 22 9.02169
-      vertex -0.999999 22 10.0981
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.33275 22 9.09123
-      vertex -2.5 22 9.1
-      vertex -2.5 22 9.09123
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.7 22 8.88564
-      vertex -0.999999 22 10.0981
-      vertex -2.00557 22 9.02169
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -0.999999 22 10.0981
-      vertex -1.7 22 8.88564
-      vertex -0.492608 22 9.72943
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.42939 22 8.68903
-      vertex -0.492608 22 9.72943
-      vertex -1.7 22 8.88564
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -0.492608 22 9.72943
-      vertex -1.42939 22 8.68903
-      vertex -0.0729485 22 9.26336
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.20557 22 8.44046
-      vertex -0.0729485 22 9.26336
-      vertex -1.42939 22 8.68903
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -0.0729485 22 9.26336
-      vertex -1.20557 22 8.44046
-      vertex 0.240636 22 8.72021
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.03833 22 8.15078
-      vertex 0.240636 22 8.72021
-      vertex -1.20557 22 8.44046
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.03833 22 8.15078
-      vertex 0.434443 22 8.12373
-      vertex 0.240636 22 8.72021
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.934963 22 7.83266
-      vertex 0.434443 22 8.12373
-      vertex -1.03833 22 8.15078
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.9 22 7.5
-      vertex 0.434443 22 8.12373
-      vertex -0.934963 22 7.83266
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.9 22 7.5
-      vertex 0.5 22 7.5
-      vertex 0.434443 22 8.12373
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.934963 22 7.16734
-      vertex 0.5 22 7.5
-      vertex -0.9 22 7.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.934963 22 7.16734
-      vertex 0.434443 22 6.87626
-      vertex 0.5 22 7.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.03833 22 6.84922
-      vertex 0.434443 22 6.87626
-      vertex -0.934963 22 7.16734
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 0.240636 22 6.27979
-      vertex -1.03833 22 6.84922
-      vertex -1.20557 22 6.55954
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.0729485 22 5.73664
-      vertex -1.20557 22 6.55954
-      vertex -1.42939 22 6.31097
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.03833 22 6.84922
-      vertex 0.240636 22 6.27979
-      vertex 0.434443 22 6.87626
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.492608 22 5.27057
-      vertex -1.42939 22 6.31097
-      vertex -1.7 22 6.11436
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.999999 22 4.90192
-      vertex -1.7 22 6.11436
-      vertex -2.00557 22 5.97831
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.57295 22 4.64683
-      vertex -2.00557 22 5.97831
-      vertex -2.33275 22 5.90876
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.20557 22 6.55954
-      vertex -0.0729485 22 5.73664
-      vertex 0.240636 22 6.27979
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.5 22 4.51643
-      vertex -2.33275 22 5.90876
-      vertex -2.5 22 5.9
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.5 22 5.9
-      vertex -5.5 22 4.51643
-      vertex -2.5 22 5.9
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -5.99443 22 5.97831
-      vertex -6.42705 22 4.64683
-      vertex -5.66724 22 5.90876
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.5 22 4.51643
-      vertex -2.5 22 5.9
-      vertex -5.5 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.81359 22 4.51643
-      vertex -5.66724 22 5.90876
-      vertex -6.42705 22 4.64683
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -2.33275 22 5.90876
-      vertex -2.5 22 4.51643
-      vertex -2.18641 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.5 22 4.51643
-      vertex -5.66724 22 5.90876
-      vertex -5.81359 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.42939 22 6.31097
-      vertex -0.492608 22 5.27057
-      vertex -0.0729485 22 5.73664
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.66724 22 5.90876
-      vertex -5.5 22 4.51643
-      vertex -5.5 22 5.9
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.7 22 6.11436
-      vertex -0.999999 22 4.90192
-      vertex -0.492608 22 5.27057
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.00557 22 5.97831
-      vertex -1.57295 22 4.64683
-      vertex -0.999999 22 4.90192
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.33275 22 5.90876
-      vertex -2.18641 22 4.51643
-      vertex -1.57295 22 4.64683
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -5.5 22 9.1
-      vertex -5.66724 22 9.09123
-      vertex -5.5 22 9.09123
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.492608 15 9.72943
-      vertex -1 15 10.0981
-      vertex -0.999999 15 10.0981
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.0729485 15 9.26336
-      vertex -1 15 10.0981
-      vertex -0.492608 15 9.72943
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.240636 15 8.72021
-      vertex -1 15 10.0981
-      vertex -0.0729485 15 9.26336
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.434443 15 8.12373
-      vertex -1 15 10.0981
-      vertex 0.240636 15 8.72021
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.5 15 7.5
-      vertex -1 15 10.0981
-      vertex 0.434443 15 8.12373
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.434443 15 6.87626
-      vertex -1 15 10.0981
-      vertex 0.5 15 7.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.240636 15 6.27979
-      vertex -1 15 10.0981
-      vertex 0.434443 15 6.87626
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.0729485 15 5.73664
-      vertex -1 15 10.0981
-      vertex 0.240636 15 6.27979
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.492608 15 5.27057
-      vertex -1 15 10.0981
-      vertex -0.0729485 15 5.73664
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -1 15 4.90192
-      vertex -0.492608 15 5.27057
-      vertex -0.999999 15 4.90192
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.492608 15 5.27057
-      vertex -1 15 4.90192
-      vertex -1 15 10.0981
-    endloop
-  endfacet
-  facet normal -0.994522 0 0.104529
-    outer loop
-      vertex 0.434443 15 6.87626
-      vertex 0.5 22 7.5
-      vertex 0.434443 22 6.87626
-    endloop
-  endfacet
-  facet normal -0.994522 0 0.104529
-    outer loop
-      vertex 0.5 22 7.5
-      vertex 0.434443 15 6.87626
-      vertex 0.5 15 7.5
-    endloop
-  endfacet
-  facet normal -0.207911 0 0.978148
-    outer loop
-      vertex -2.18641 22 4.51643
-      vertex -1.57295 16 4.64683
-      vertex -1.57295 22 4.64683
-    endloop
-  endfacet
-  facet normal -0.207911 0 0.978148
-    outer loop
-      vertex -1.57295 16 4.64683
-      vertex -2.18641 22 4.51643
-      vertex -2.18641 16 4.51643
-    endloop
-  endfacet
-  facet normal -0.743144 0 -0.669131
-    outer loop
-      vertex -0.0729485 15 9.26336
-      vertex -0.492608 22 9.72943
-      vertex -0.0729485 22 9.26336
-    endloop
-  endfacet
-  facet normal -0.743144 -0 -0.669131
-    outer loop
-      vertex -0.492608 22 9.72943
-      vertex -0.0729485 15 9.26336
-      vertex -0.492608 15 9.72943
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.5 16 10.4836
-      vertex -2.18641 22 10.4836
-      vertex -2.18641 16 10.4836
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.18641 22 10.4836
-      vertex -2.5 16 10.4836
-      vertex -2.5 22 10.4836
-    endloop
-  endfacet
-  facet normal -0.866026 0 0.499999
-    outer loop
-      vertex -0.0729485 15 5.73664
-      vertex 0.240636 22 6.27979
-      vertex -0.0729485 22 5.73664
-    endloop
-  endfacet
-  facet normal -0.866026 0 0.499999
-    outer loop
-      vertex 0.240636 22 6.27979
-      vertex -0.0729485 15 5.73664
-      vertex 0.240636 15 6.27979
-    endloop
-  endfacet
-  facet normal -0.951056 0 0.309017
-    outer loop
-      vertex 0.240636 15 6.27979
-      vertex 0.434443 22 6.87626
-      vertex 0.240636 22 6.27979
-    endloop
-  endfacet
-  facet normal -0.951056 0 0.309017
-    outer loop
-      vertex 0.434443 22 6.87626
-      vertex 0.240636 15 6.27979
-      vertex 0.434443 15 6.87626
-    endloop
-  endfacet
-  facet normal -0.587786 0 0.809016
-    outer loop
-      vertex -0.999999 22 4.90192
-      vertex -0.492608 15 5.27057
-      vertex -0.492608 22 5.27057
-    endloop
-  endfacet
-  facet normal -0.587786 0 0.809016
-    outer loop
-      vertex -0.492608 15 5.27057
-      vertex -0.999999 22 4.90192
-      vertex -0.999999 15 4.90192
-    endloop
-  endfacet
-  facet normal -0.743144 0 0.669131
-    outer loop
-      vertex -0.492608 15 5.27057
-      vertex -0.0729485 22 5.73664
-      vertex -0.492608 22 5.27057
-    endloop
-  endfacet
-  facet normal -0.743144 0 0.669131
-    outer loop
-      vertex -0.0729485 22 5.73664
-      vertex -0.492608 15 5.27057
-      vertex -0.0729485 15 5.73664
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -2.5 22 4.51643
-      vertex -2.18641 16 4.51643
-      vertex -2.18641 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.18641 16 4.51643
-      vertex -2.5 22 4.51643
-      vertex -2.5 16 4.51643
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104529
-    outer loop
-      vertex -8.43444 16 8.12373
-      vertex -8.5 22 7.5
-      vertex -8.43444 22 8.12373
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104529
-    outer loop
-      vertex -8.5 22 7.5
-      vertex -8.43444 16 8.12373
-      vertex -8.5 16 7.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.81359 16 10.4836
-      vertex -5.5 22 10.4836
-      vertex -5.5 16 10.4836
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -5.5 22 10.4836
-      vertex -5.81359 16 10.4836
-      vertex -5.81359 22 10.4836
-    endloop
-  endfacet
-  facet normal 0.406737 0 -0.913545
-    outer loop
-      vertex -7 16 10.0981
-      vertex -6.42705 22 10.3532
-      vertex -6.42705 16 10.3532
-    endloop
-  endfacet
-  facet normal 0.406737 0 -0.913545
-    outer loop
-      vertex -6.42705 22 10.3532
-      vertex -7 16 10.0981
-      vertex -7 22 10.0981
-    endloop
-  endfacet
-  facet normal 0.866026 0 -0.5
-    outer loop
-      vertex -7.92705 16 9.26336
-      vertex -8.24064 22 8.72021
-      vertex -7.92705 22 9.26336
-    endloop
-  endfacet
-  facet normal 0.866026 0 -0.5
-    outer loop
-      vertex -8.24064 22 8.72021
-      vertex -7.92705 16 9.26336
-      vertex -8.24064 16 8.72021
-    endloop
-  endfacet
-  facet normal 0.951056 0 -0.309017
-    outer loop
-      vertex -8.24064 16 8.72021
-      vertex -8.43444 22 8.12373
-      vertex -8.24064 22 8.72021
-    endloop
-  endfacet
-  facet normal 0.951056 0 -0.309017
-    outer loop
-      vertex -8.43444 22 8.12373
-      vertex -8.24064 16 8.72021
-      vertex -8.43444 16 8.12373
-    endloop
-  endfacet
-  facet normal 0.207911 0 -0.978148
-    outer loop
-      vertex -6.42705 16 10.3532
-      vertex -5.81359 22 10.4836
-      vertex -5.81359 16 10.4836
-    endloop
-  endfacet
-  facet normal 0.207911 0 -0.978148
-    outer loop
-      vertex -5.81359 22 10.4836
-      vertex -6.42705 16 10.3532
-      vertex -6.42705 22 10.3532
-    endloop
-  endfacet
-  facet normal 0.994522 -0 0.104529
-    outer loop
-      vertex -8.5 16 7.5
-      vertex -8.43444 22 6.87626
-      vertex -8.5 22 7.5
-    endloop
-  endfacet
-  facet normal 0.994522 0 0.104529
-    outer loop
-      vertex -8.43444 22 6.87626
-      vertex -8.5 16 7.5
-      vertex -8.43444 16 6.87626
-    endloop
-  endfacet
-  facet normal 0.587785 0 -0.809017
-    outer loop
-      vertex -7.50739 16 9.72943
-      vertex -7 22 10.0981
-      vertex -7 16 10.0981
-    endloop
-  endfacet
-  facet normal 0.587785 0 -0.809017
-    outer loop
-      vertex -7 22 10.0981
-      vertex -7.50739 16 9.72943
-      vertex -7.50739 22 9.72943
-    endloop
-  endfacet
-  facet normal 0.743144 0 -0.669131
-    outer loop
-      vertex -7.50739 16 9.72943
-      vertex -7.92705 22 9.26336
-      vertex -7.50739 22 9.72943
-    endloop
-  endfacet
-  facet normal 0.743144 0 -0.669131
-    outer loop
-      vertex -7.92705 22 9.26336
-      vertex -7.50739 16 9.72943
-      vertex -7.92705 16 9.26336
-    endloop
-  endfacet
-  facet normal 0.866026 -0 0.5
-    outer loop
-      vertex -8.24064 16 6.27979
-      vertex -7.92705 22 5.73664
-      vertex -8.24064 22 6.27979
-    endloop
-  endfacet
-  facet normal 0.866026 0 0.5
-    outer loop
-      vertex -7.92705 22 5.73664
-      vertex -8.24064 16 6.27979
-      vertex -7.92705 16 5.73664
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.81359 22 4.51643
-      vertex -5.5 16 4.51643
-      vertex -5.5 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -5.5 16 4.51643
-      vertex -5.81359 22 4.51643
-      vertex -5.81359 16 4.51643
-    endloop
-  endfacet
-  facet normal 0.951056 -0 0.309017
-    outer loop
-      vertex -8.43444 16 6.87626
-      vertex -8.24064 22 6.27979
-      vertex -8.43444 22 6.87626
-    endloop
-  endfacet
-  facet normal 0.951056 0 0.309017
-    outer loop
-      vertex -8.24064 22 6.27979
-      vertex -8.43444 16 6.87626
-      vertex -8.24064 16 6.27979
-    endloop
-  endfacet
-  facet normal 0.743144 -0 0.669131
-    outer loop
-      vertex -7.92705 16 5.73664
-      vertex -7.50739 22 5.27057
-      vertex -7.92705 22 5.73664
-    endloop
-  endfacet
-  facet normal 0.743144 0 0.669131
-    outer loop
-      vertex -7.50739 22 5.27057
-      vertex -7.92705 16 5.73664
-      vertex -7.50739 16 5.27057
-    endloop
-  endfacet
-  facet normal 0.587786 0 0.809016
-    outer loop
-      vertex -7.50739 22 5.27057
-      vertex -7 16 4.90192
-      vertex -7 22 4.90192
-    endloop
-  endfacet
-  facet normal 0.587786 0 0.809016
-    outer loop
-      vertex -7 16 4.90192
-      vertex -7.50739 22 5.27057
-      vertex -7.50739 16 5.27057
-    endloop
-  endfacet
-  facet normal 0.406737 0 0.913545
-    outer loop
-      vertex -7 22 4.90192
-      vertex -6.42705 16 4.64683
-      vertex -6.42705 22 4.64683
-    endloop
-  endfacet
-  facet normal 0.406737 0 0.913545
-    outer loop
-      vertex -6.42705 16 4.64683
-      vertex -7 22 4.90192
-      vertex -7 16 4.90192
-    endloop
-  endfacet
-  facet normal 0.207911 0 0.978148
-    outer loop
-      vertex -6.42705 22 4.64683
-      vertex -5.81359 16 4.51643
-      vertex -5.81359 22 4.51643
-    endloop
-  endfacet
-  facet normal 0.207911 0 0.978148
-    outer loop
-      vertex -5.81359 16 4.51643
-      vertex -6.42705 22 4.64683
-      vertex -6.42705 16 4.64683
-    endloop
-  endfacet
-  facet normal 0.207909 0 -0.978148
-    outer loop
-      vertex 35.0056 22 9.02169
-      vertex 35.3328 26 9.09123
-      vertex 35.3328 22 9.09123
-    endloop
-  endfacet
-  facet normal 0.207909 0 -0.978148
-    outer loop
-      vertex 35.3328 26 9.09123
-      vertex 35.0056 22 9.02169
-      vertex 35.0056 26 9.02169
-    endloop
-  endfacet
-  facet normal 0.743148 0 -0.669127
-    outer loop
-      vertex 34.4294 22 8.68903
-      vertex 34.2056 26 8.44046
-      vertex 34.4294 26 8.68903
-    endloop
-  endfacet
-  facet normal 0.743148 0 -0.669127
-    outer loop
-      vertex 34.2056 26 8.44046
-      vertex 34.4294 22 8.68903
-      vertex 34.2056 22 8.44046
-    endloop
-  endfacet
-  facet normal 0.587782 0 -0.809019
-    outer loop
-      vertex 34.4294 22 8.68903
-      vertex 34.7 26 8.88564
-      vertex 34.7 22 8.88564
-    endloop
-  endfacet
-  facet normal 0.587782 0 -0.809019
-    outer loop
-      vertex 34.7 26 8.88564
-      vertex 34.4294 22 8.68903
-      vertex 34.4294 26 8.68903
-    endloop
-  endfacet
-  facet normal 0.951057 0 -0.309016
-    outer loop
-      vertex 34.0383 22 8.15078
-      vertex 33.935 26 7.83266
-      vertex 34.0383 26 8.15078
-    endloop
-  endfacet
-  facet normal 0.951057 0 -0.309016
-    outer loop
-      vertex 33.935 26 7.83266
-      vertex 34.0383 22 8.15078
-      vertex 33.935 22 7.83266
-    endloop
-  endfacet
-  facet normal 0.866023 0 -0.500004
-    outer loop
-      vertex 34.2056 22 8.44046
-      vertex 34.0383 26 8.15078
-      vertex 34.2056 26 8.44046
-    endloop
-  endfacet
-  facet normal 0.866023 0 -0.500004
-    outer loop
-      vertex 34.0383 26 8.15078
-      vertex 34.2056 22 8.44046
-      vertex 34.0383 22 8.15078
-    endloop
-  endfacet
-  facet normal 0.406738 0 -0.913545
-    outer loop
-      vertex 34.7 22 8.88564
-      vertex 35.0056 26 9.02169
-      vertex 35.0056 22 9.02169
-    endloop
-  endfacet
-  facet normal 0.406738 0 -0.913545
-    outer loop
-      vertex 35.0056 26 9.02169
-      vertex 34.7 22 8.88564
-      vertex 34.7 26 8.88564
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.3328 22 9.09123
-      vertex 35.5 26 9.09123
-      vertex 35.5 22 9.09123
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 35.5 26 9.09123
-      vertex 35.3328 22 9.09123
-      vertex 35.3328 26 9.09123
-    endloop
-  endfacet
-  facet normal 0.994523 0 -0.104522
-    outer loop
-      vertex 33.935 22 7.83266
-      vertex 33.9 26 7.5
-      vertex 33.935 26 7.83266
-    endloop
-  endfacet
-  facet normal 0.994523 0 -0.104522
-    outer loop
-      vertex 33.9 26 7.5
-      vertex 33.935 22 7.83266
-      vertex 33.9 22 7.5
-    endloop
-  endfacet
-  facet normal 0.994523 -0 0.104522
-    outer loop
-      vertex 33.9 22 7.5
-      vertex 33.935 26 7.16734
-      vertex 33.9 26 7.5
-    endloop
-  endfacet
-  facet normal 0.994523 0 0.104522
-    outer loop
-      vertex 33.935 26 7.16734
-      vertex 33.9 22 7.5
-      vertex 33.935 22 7.16734
-    endloop
-  endfacet
-  facet normal 0.406738 0 0.913545
-    outer loop
-      vertex 34.7 26 6.11436
-      vertex 35.0056 22 5.97831
-      vertex 35.0056 26 5.97831
-    endloop
-  endfacet
-  facet normal 0.406738 0 0.913545
-    outer loop
-      vertex 35.0056 22 5.97831
-      vertex 34.7 26 6.11436
-      vertex 34.7 22 6.11436
-    endloop
-  endfacet
-  facet normal 0.743148 -0 0.669127
-    outer loop
-      vertex 34.2056 22 6.55954
-      vertex 34.4294 26 6.31097
-      vertex 34.2056 26 6.55954
-    endloop
-  endfacet
-  facet normal 0.743148 0 0.669127
-    outer loop
-      vertex 34.4294 26 6.31097
-      vertex 34.2056 22 6.55954
-      vertex 34.4294 22 6.31097
-    endloop
-  endfacet
-  facet normal 0.866023 -0 0.500004
-    outer loop
-      vertex 34.0383 22 6.84922
-      vertex 34.2056 26 6.55954
-      vertex 34.0383 26 6.84922
-    endloop
-  endfacet
-  facet normal 0.866023 0 0.500004
-    outer loop
-      vertex 34.2056 26 6.55954
-      vertex 34.0383 22 6.84922
-      vertex 34.2056 22 6.55954
-    endloop
-  endfacet
-  facet normal 0.951057 -0 0.309016
-    outer loop
-      vertex 33.935 22 7.16734
-      vertex 34.0383 26 6.84922
-      vertex 33.935 26 7.16734
-    endloop
-  endfacet
-  facet normal 0.951057 0 0.309016
-    outer loop
-      vertex 34.0383 26 6.84922
-      vertex 33.935 22 7.16734
-      vertex 34.0383 22 6.84922
-    endloop
-  endfacet
-  facet normal 0.587782 0 0.809019
-    outer loop
-      vertex 34.4294 26 6.31097
-      vertex 34.7 22 6.11436
-      vertex 34.7 26 6.11436
-    endloop
-  endfacet
-  facet normal 0.587782 0 0.809019
-    outer loop
-      vertex 34.7 22 6.11436
-      vertex 34.4294 26 6.31097
-      vertex 34.4294 22 6.31097
-    endloop
-  endfacet
-  facet normal 0.207909 0 0.978148
-    outer loop
-      vertex 35.0056 26 5.97831
-      vertex 35.3328 22 5.90876
-      vertex 35.3328 26 5.90876
-    endloop
-  endfacet
-  facet normal 0.207909 0 0.978148
-    outer loop
-      vertex 35.3328 22 5.90876
-      vertex 35.0056 26 5.97831
-      vertex 35.0056 22 5.97831
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 35.3328 26 5.90876
-      vertex 35.5 22 5.90876
-      vertex 35.5 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 35.5 22 5.90876
-      vertex 35.3328 26 5.90876
-      vertex 35.3328 22 5.90876
-    endloop
-  endfacet
-  facet normal -0.994523 0 -0.104522
-    outer loop
-      vertex 40.1 22 7.5
-      vertex 40.065 26 7.83266
-      vertex 40.1 26 7.5
-    endloop
-  endfacet
-  facet normal -0.994523 -0 -0.104522
-    outer loop
-      vertex 40.065 26 7.83266
-      vertex 40.1 22 7.5
-      vertex 40.065 22 7.83266
-    endloop
-  endfacet
-  facet normal -0.951054 0 -0.309026
-    outer loop
-      vertex 40.065 22 7.83266
-      vertex 39.9617 26 8.15078
-      vertex 40.065 26 7.83266
-    endloop
-  endfacet
-  facet normal -0.951054 -0 -0.309026
-    outer loop
-      vertex 39.9617 26 8.15078
-      vertex 40.065 22 7.83266
-      vertex 39.9617 22 8.15078
-    endloop
-  endfacet
-  facet normal -0.587782 0 -0.809019
-    outer loop
-      vertex 39.3 22 8.88564
-      vertex 39.5706 26 8.68903
-      vertex 39.5706 22 8.68903
-    endloop
-  endfacet
-  facet normal -0.587782 0 -0.809019
-    outer loop
-      vertex 39.5706 26 8.68903
-      vertex 39.3 22 8.88564
-      vertex 39.3 26 8.88564
-    endloop
-  endfacet
-  facet normal -0.866028 0 -0.499995
-    outer loop
-      vertex 39.9617 22 8.15078
-      vertex 39.7944 26 8.44046
-      vertex 39.9617 26 8.15078
-    endloop
-  endfacet
-  facet normal -0.866028 -0 -0.499995
-    outer loop
-      vertex 39.7944 26 8.44046
-      vertex 39.9617 22 8.15078
-      vertex 39.7944 22 8.44046
-    endloop
-  endfacet
-  facet normal -0.207909 0 -0.978148
-    outer loop
-      vertex 38.6672 22 9.09123
-      vertex 38.9944 26 9.02169
-      vertex 38.9944 22 9.02169
-    endloop
-  endfacet
-  facet normal -0.207909 0 -0.978148
-    outer loop
-      vertex 38.9944 26 9.02169
-      vertex 38.6672 22 9.09123
-      vertex 38.6672 26 9.09123
-    endloop
-  endfacet
-  facet normal -0.406738 0 -0.913545
-    outer loop
-      vertex 38.9944 22 9.02169
-      vertex 39.3 26 8.88564
-      vertex 39.3 22 8.88564
-    endloop
-  endfacet
-  facet normal -0.406738 0 -0.913545
-    outer loop
-      vertex 39.3 26 8.88564
-      vertex 38.9944 22 9.02169
-      vertex 38.9944 26 9.02169
-    endloop
-  endfacet
-  facet normal -0.994523 0 0.104522
-    outer loop
-      vertex 40.065 22 7.16734
-      vertex 40.1 26 7.5
-      vertex 40.065 26 7.16734
-    endloop
-  endfacet
-  facet normal -0.994523 0 0.104522
-    outer loop
-      vertex 40.1 26 7.5
-      vertex 40.065 22 7.16734
-      vertex 40.1 22 7.5
-    endloop
-  endfacet
-  facet normal -0.207909 0 0.978148
-    outer loop
-      vertex 38.6672 26 5.90876
-      vertex 38.9944 22 5.97831
-      vertex 38.9944 26 5.97831
-    endloop
-  endfacet
-  facet normal -0.207909 0 0.978148
-    outer loop
-      vertex 38.9944 22 5.97831
-      vertex 38.6672 26 5.90876
-      vertex 38.6672 22 5.90876
-    endloop
-  endfacet
-  facet normal -0.587782 0 0.809019
-    outer loop
-      vertex 39.3 26 6.11436
-      vertex 39.5706 22 6.31097
-      vertex 39.5706 26 6.31097
-    endloop
-  endfacet
-  facet normal -0.587782 0 0.809019
-    outer loop
-      vertex 39.5706 22 6.31097
-      vertex 39.3 26 6.11436
-      vertex 39.3 22 6.11436
-    endloop
-  endfacet
-  facet normal -0.743148 0 -0.669127
-    outer loop
-      vertex 39.7944 22 8.44046
-      vertex 39.5706 26 8.68903
-      vertex 39.7944 26 8.44046
-    endloop
-  endfacet
-  facet normal -0.743148 -0 -0.669127
-    outer loop
-      vertex 39.5706 26 8.68903
-      vertex 39.7944 22 8.44046
-      vertex 39.5706 22 8.68903
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 38.5 22 9.09123
-      vertex 38.6672 26 9.09123
-      vertex 38.6672 22 9.09123
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 38.6672 26 9.09123
-      vertex 38.5 22 9.09123
-      vertex 38.5 26 9.09123
-    endloop
-  endfacet
-  facet normal -0.743148 0 0.669127
-    outer loop
-      vertex 39.5706 22 6.31097
-      vertex 39.7944 26 6.55954
-      vertex 39.5706 26 6.31097
-    endloop
-  endfacet
-  facet normal -0.743148 0 0.669127
-    outer loop
-      vertex 39.7944 26 6.55954
-      vertex 39.5706 22 6.31097
-      vertex 39.7944 22 6.55954
-    endloop
-  endfacet
-  facet normal -0.406738 0 0.913545
-    outer loop
-      vertex 38.9944 26 5.97831
-      vertex 39.3 22 6.11436
-      vertex 39.3 26 6.11436
-    endloop
-  endfacet
-  facet normal -0.406738 0 0.913545
-    outer loop
-      vertex 39.3 22 6.11436
-      vertex 38.9944 26 5.97831
-      vertex 38.9944 22 5.97831
-    endloop
-  endfacet
-  facet normal -0.866028 0 0.499995
-    outer loop
-      vertex 39.7944 22 6.55954
-      vertex 39.9617 26 6.84922
-      vertex 39.7944 26 6.55954
-    endloop
-  endfacet
-  facet normal -0.866028 0 0.499995
-    outer loop
-      vertex 39.9617 26 6.84922
-      vertex 39.7944 22 6.55954
-      vertex 39.9617 22 6.84922
-    endloop
-  endfacet
-  facet normal -0.951054 0 0.309026
-    outer loop
-      vertex 39.9617 22 6.84922
-      vertex 40.065 26 7.16734
-      vertex 39.9617 26 6.84922
-    endloop
-  endfacet
-  facet normal -0.951054 0 0.309026
-    outer loop
-      vertex 40.065 26 7.16734
-      vertex 39.9617 22 6.84922
-      vertex 40.065 22 7.16734
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 38.5 26 5.90876
-      vertex 38.6672 22 5.90876
-      vertex 38.6672 26 5.90876
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.6672 22 5.90876
-      vertex 38.5 26 5.90876
-      vertex 38.5 22 5.90876
-    endloop
-  endfacet
-  facet normal 0.207912 0 -0.978148
-    outer loop
-      vertex 34.5729 16 10.3532
-      vertex 35.1864 22 10.4836
-      vertex 35.1864 16 10.4836
-    endloop
-  endfacet
-  facet normal 0.207912 0 -0.978148
-    outer loop
-      vertex 35.1864 22 10.4836
-      vertex 34.5729 16 10.3532
-      vertex 34.5729 22 10.3532
-    endloop
-  endfacet
-  facet normal 0.743145 0 -0.66913
-    outer loop
-      vertex 33.4926 16 9.72943
-      vertex 33.0729 22 9.26336
-      vertex 33.4926 22 9.72943
-    endloop
-  endfacet
-  facet normal 0.743145 0 -0.66913
-    outer loop
-      vertex 33.0729 22 9.26336
-      vertex 33.4926 16 9.72943
-      vertex 33.0729 16 9.26336
-    endloop
-  endfacet
-  facet normal 0.587785 0 -0.809017
-    outer loop
-      vertex 33.4926 16 9.72943
-      vertex 34 22 10.0981
-      vertex 34 16 10.0981
-    endloop
-  endfacet
-  facet normal 0.587785 0 -0.809017
-    outer loop
-      vertex 34 22 10.0981
-      vertex 33.4926 16 9.72943
-      vertex 33.4926 22 9.72943
-    endloop
-  endfacet
-  facet normal 0.951057 0 -0.309016
-    outer loop
-      vertex 32.7594 16 8.72021
-      vertex 32.5656 22 8.12373
-      vertex 32.7594 22 8.72021
-    endloop
-  endfacet
-  facet normal 0.951057 0 -0.309016
-    outer loop
-      vertex 32.5656 22 8.12373
-      vertex 32.7594 16 8.72021
-      vertex 32.5656 16 8.12373
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.3328 22 9.09123
-      vertex 35.1864 22 10.4836
-      vertex 34.5729 22 10.3532
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 38.5 22 9.1
-      vertex 35.5 22 10.5
-      vertex 35.5 22 10.4836
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.1864 22 10.4836
-      vertex 35.3328 22 9.09123
-      vertex 35.5 22 10.4836
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.0056 22 9.02169
-      vertex 34.5729 22 10.3532
-      vertex 34 22 10.0981
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 34.7 22 8.88564
-      vertex 34 22 10.0981
-      vertex 33.4926 22 9.72943
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 34.4294 22 8.68903
-      vertex 33.4926 22 9.72943
-      vertex 33.0729 22 9.26336
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.5 22 10.4836
-      vertex 35.5 22 9.1
-      vertex 38.5 22 9.1
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.5 22 10.5
-      vertex 38.5 22 9.1
-      vertex 40.5 22 10.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 38.6672 22 9.09123
-      vertex 38.5 22 9.1
-      vertex 38.5 22 9.09123
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 38.5 22 9.1
-      vertex 38.6672 22 9.09123
-      vertex 40.5 22 10.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 38.9944 22 9.02169
-      vertex 40.5 22 10.5
-      vertex 38.6672 22 9.09123
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 39.3 22 8.88564
-      vertex 40.5 22 10.5
-      vertex 38.9944 22 9.02169
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 39.5706 22 8.68903
-      vertex 40.5 22 10.5
-      vertex 39.3 22 8.88564
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 39.7944 22 8.44046
-      vertex 40.5 22 10.5
-      vertex 39.5706 22 8.68903
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 39.9617 22 8.15078
-      vertex 40.5 22 10.5
-      vertex 39.7944 22 8.44046
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 40.065 22 7.83266
-      vertex 40.5 22 10.5
-      vertex 39.9617 22 8.15078
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 40.1 22 7.5
-      vertex 40.5 22 10.5
-      vertex 40.065 22 7.83266
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 40.5 22 4.5
-      vertex 40.1 22 7.5
-      vertex 40.065 22 7.16734
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 35.0056 22 5.97831
-      vertex 34.5729 22 4.64683
-      vertex 35.3328 22 5.90876
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.5 22 5.9
-      vertex 35.5 22 4.51643
-      vertex 38.5 22 5.9
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.1864 22 4.51643
-      vertex 35.3328 22 5.90876
-      vertex 34.5729 22 4.64683
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.5 22 4.5
-      vertex 38.5 22 5.9
-      vertex 35.5 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.5 22 4.51643
-      vertex 35.3328 22 5.90876
-      vertex 35.1864 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.3328 22 5.90876
-      vertex 35.5 22 4.51643
-      vertex 35.5 22 5.9
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 40.5 22 4.5
-      vertex 38.5 22 5.9
-      vertex 35.5 22 4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 38.5 22 5.9
-      vertex 40.5 22 4.5
-      vertex 38.6672 22 5.90876
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 40.1 22 7.5
-      vertex 40.5 22 4.5
-      vertex 40.5 22 10.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 39.9617 22 6.84922
-      vertex 40.5 22 4.5
-      vertex 40.065 22 7.16734
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 39.7944 22 6.55954
-      vertex 40.5 22 4.5
-      vertex 39.9617 22 6.84922
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 39.5706 22 6.31097
-      vertex 40.5 22 4.5
-      vertex 39.7944 22 6.55954
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 39.3 22 6.11436
-      vertex 40.5 22 4.5
-      vertex 39.5706 22 6.31097
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 38.9944 22 5.97831
-      vertex 40.5 22 4.5
-      vertex 39.3 22 6.11436
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 38.6672 22 5.90876
-      vertex 40.5 22 4.5
-      vertex 38.9944 22 5.97831
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 38.5 22 5.90876
-      vertex 38.5 22 5.9
-      vertex 38.6672 22 5.90876
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 35.5 22 10.4836
-      vertex 35.3328 22 9.09123
-      vertex 35.5 22 9.1
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 34.5729 22 10.3532
-      vertex 35.0056 22 9.02169
-      vertex 35.3328 22 9.09123
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 34 22 10.0981
-      vertex 34.7 22 8.88564
-      vertex 35.0056 22 9.02169
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 34.2056 22 8.44046
-      vertex 33.0729 22 9.26336
-      vertex 32.7594 22 8.72021
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 33.4926 22 9.72943
-      vertex 34.4294 22 8.68903
-      vertex 34.7 22 8.88564
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 33.0729 22 9.26336
-      vertex 34.2056 22 8.44046
-      vertex 34.4294 22 8.68903
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.7594 22 8.72021
-      vertex 34.0383 22 8.15078
-      vertex 34.2056 22 8.44046
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.5656 22 8.12373
-      vertex 34.0383 22 8.15078
-      vertex 32.7594 22 8.72021
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.5656 22 8.12373
-      vertex 33.935 22 7.83266
-      vertex 34.0383 22 8.15078
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.5 22 7.5
-      vertex 33.935 22 7.83266
-      vertex 32.5656 22 8.12373
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.5 22 7.5
-      vertex 33.9 22 7.5
-      vertex 33.935 22 7.83266
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.5 22 7.5
-      vertex 33.935 22 7.16734
-      vertex 33.9 22 7.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.5656 22 6.87626
-      vertex 33.935 22 7.16734
-      vertex 32.5 22 7.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.5656 22 6.87626
-      vertex 34.0383 22 6.84922
-      vertex 33.935 22 7.16734
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 32.7594 22 6.27979
-      vertex 34.0383 22 6.84922
-      vertex 32.5656 22 6.87626
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 34.0383 22 6.84922
-      vertex 32.7594 22 6.27979
-      vertex 34.2056 22 6.55954
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 33.0729 22 5.73664
-      vertex 34.2056 22 6.55954
-      vertex 32.7594 22 6.27979
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 34.2056 22 6.55954
-      vertex 33.0729 22 5.73664
-      vertex 34.4294 22 6.31097
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 33.4926 22 5.27057
-      vertex 34.4294 22 6.31097
-      vertex 33.0729 22 5.73664
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 34.4294 22 6.31097
-      vertex 33.4926 22 5.27057
-      vertex 34.7 22 6.11436
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 35.3328 22 5.90876
-      vertex 35.5 22 5.9
-      vertex 35.5 22 5.90876
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 34.5729 22 4.64683
-      vertex 35.0056 22 5.97831
-      vertex 34 22 4.90192
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 34.7 22 6.11436
-      vertex 34 22 4.90192
-      vertex 35.0056 22 5.97831
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 34 22 4.90192
-      vertex 34.7 22 6.11436
-      vertex 33.4926 22 5.27057
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 35.5 22 9.1
-      vertex 35.3328 22 9.09123
-      vertex 35.5 22 9.09123
-    endloop
-  endfacet
-  facet normal 0.866024 0 -0.500002
-    outer loop
-      vertex 33.0729 16 9.26336
-      vertex 32.7594 22 8.72021
-      vertex 33.0729 22 9.26336
-    endloop
-  endfacet
-  facet normal 0.866024 0 -0.500002
-    outer loop
-      vertex 32.7594 22 8.72021
-      vertex 33.0729 16 9.26336
-      vertex 32.7594 16 8.72021
-    endloop
-  endfacet
-  facet normal 0.406737 0 -0.913545
-    outer loop
-      vertex 34 16 10.0981
-      vertex 34.5729 22 10.3532
-      vertex 34.5729 16 10.3532
-    endloop
-  endfacet
-  facet normal 0.406737 0 -0.913545
-    outer loop
-      vertex 34.5729 22 10.3532
-      vertex 34 16 10.0981
-      vertex 34 22 10.0981
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.1864 16 10.4836
-      vertex 35.5 22 10.4836
-      vertex 35.5 16 10.4836
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 35.5 22 10.4836
-      vertex 35.1864 16 10.4836
-      vertex 35.1864 22 10.4836
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104526
-    outer loop
-      vertex 32.5656 16 8.12373
-      vertex 32.5 22 7.5
-      vertex 32.5656 22 8.12373
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104526
-    outer loop
-      vertex 32.5 22 7.5
-      vertex 32.5656 16 8.12373
-      vertex 32.5 16 7.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0 0.104526
-    outer loop
-      vertex 32.5 16 7.5
-      vertex 32.5656 22 6.87626
-      vertex 32.5 22 7.5
-    endloop
-  endfacet
-  facet normal 0.994522 0 0.104526
-    outer loop
-      vertex 32.5656 22 6.87626
-      vertex 32.5 16 7.5
-      vertex 32.5656 16 6.87626
-    endloop
-  endfacet
-  facet normal 0.406737 0 0.913545
-    outer loop
-      vertex 34 22 4.90192
-      vertex 34.5729 16 4.64683
-      vertex 34.5729 22 4.64683
-    endloop
-  endfacet
-  facet normal 0.406737 0 0.913545
-    outer loop
-      vertex 34.5729 16 4.64683
-      vertex 34 22 4.90192
-      vertex 34 16 4.90192
-    endloop
-  endfacet
-  facet normal 0.743145 -0 0.66913
-    outer loop
-      vertex 33.0729 16 5.73664
-      vertex 33.4926 22 5.27057
-      vertex 33.0729 22 5.73664
-    endloop
-  endfacet
-  facet normal 0.743145 0 0.66913
-    outer loop
-      vertex 33.4926 22 5.27057
-      vertex 33.0729 16 5.73664
-      vertex 33.4926 16 5.27057
-    endloop
-  endfacet
-  facet normal 0.866024 -0 0.500002
-    outer loop
-      vertex 32.7594 16 6.27979
-      vertex 33.0729 22 5.73664
-      vertex 32.7594 22 6.27979
-    endloop
-  endfacet
-  facet normal 0.866024 0 0.500002
-    outer loop
-      vertex 33.0729 22 5.73664
-      vertex 32.7594 16 6.27979
-      vertex 33.0729 16 5.73664
-    endloop
-  endfacet
-  facet normal 0.587785 0 0.809017
-    outer loop
-      vertex 33.4926 22 5.27057
-      vertex 34 16 4.90192
-      vertex 34 22 4.90192
-    endloop
-  endfacet
-  facet normal 0.587785 0 0.809017
-    outer loop
-      vertex 34 16 4.90192
-      vertex 33.4926 22 5.27057
-      vertex 33.4926 16 5.27057
-    endloop
-  endfacet
-  facet normal 0.951057 -0 0.309016
-    outer loop
-      vertex 32.5656 16 6.87626
-      vertex 32.7594 22 6.27979
-      vertex 32.5656 22 6.87626
-    endloop
-  endfacet
-  facet normal 0.951057 0 0.309016
-    outer loop
-      vertex 32.7594 22 6.27979
-      vertex 32.5656 16 6.87626
-      vertex 32.7594 16 6.27979
-    endloop
-  endfacet
-  facet normal 0.207912 0 0.978148
-    outer loop
-      vertex 34.5729 22 4.64683
-      vertex 35.1864 16 4.51643
-      vertex 35.1864 22 4.51643
-    endloop
-  endfacet
-  facet normal 0.207912 0 0.978148
-    outer loop
-      vertex 35.1864 16 4.51643
-      vertex 34.5729 22 4.64683
-      vertex 34.5729 16 4.64683
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 35.1864 22 4.51643
-      vertex 35.5 16 4.51643
-      vertex 35.5 22 4.51643
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 35.5 16 4.51643
-      vertex 35.1864 22 4.51643
-      vertex 35.1864 16 4.51643
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -5.5 16 4.51643
-      vertex -5.5 22 4.5
-      vertex -5.5 22 4.51643
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -5.5 22 4.5
-      vertex -5.5 16 4.51643
-      vertex -5.5 16 4.5
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -5.5 16 10.5
-      vertex -5.5 22 10.4836
-      vertex -5.5 22 10.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -5.5 22 10.4836
-      vertex -5.5 16 10.5
-      vertex -5.5 16 10.4836
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -5.5 22 5.90876
-      vertex -5.5 26 5.9
-      vertex -5.5 26 5.90876
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -5.5 26 5.9
-      vertex -5.5 22 5.90876
-      vertex -5.5 22 5.9
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -5.5 22 9.1
-      vertex -5.5 26 9.09123
-      vertex -5.5 26 9.1
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -5.5 26 9.09123
-      vertex -5.5 22 9.1
-      vertex -5.5 22 9.09123
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.5 22 9.1
-      vertex -2.5 26 9.1
-      vertex -2.5 22 9.1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.5 26 9.1
-      vertex -5.5 22 9.1
-      vertex -5.5 26 9.1
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -2.5 16 10.4836
-      vertex -2.5 22 10.5
-      vertex -2.5 22 10.4836
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex -2.5 22 10.5
-      vertex -2.5 16 10.4836
-      vertex -2.5 16 10.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -2.5 16 4.5
-      vertex -2.5 22 4.51643
-      vertex -2.5 22 4.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex -2.5 22 4.51643
-      vertex -2.5 16 4.5
-      vertex -2.5 16 4.51643
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -2.5 22 9.09123
-      vertex -2.5 26 9.1
-      vertex -2.5 26 9.09123
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex -2.5 26 9.1
-      vertex -2.5 22 9.09123
-      vertex -2.5 22 9.1
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -2.5 22 5.9
-      vertex -2.5 26 5.90876
-      vertex -2.5 26 5.9
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex -2.5 26 5.90876
-      vertex -2.5 22 5.9
-      vertex -2.5 22 5.90876
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.5 26 5.9
-      vertex -2.5 22 5.9
-      vertex -2.5 26 5.9
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.5 22 5.9
-      vertex -5.5 26 5.9
-      vertex -5.5 22 5.9
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 35.5 16 4.51643
-      vertex 35.5 22 4.5
-      vertex 35.5 22 4.51643
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 35.5 22 4.5
-      vertex 35.5 16 4.51643
-      vertex 35.5 16 4.5
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 35.5 16 10.5
-      vertex 35.5 22 10.4836
-      vertex 35.5 22 10.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 35.5 22 10.4836
-      vertex 35.5 16 10.5
-      vertex 35.5 16 10.4836
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 35.5 22 9.1
-      vertex 35.5 26 9.09123
-      vertex 35.5 26 9.1
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 35.5 26 9.09123
-      vertex 35.5 22 9.1
-      vertex 35.5 22 9.09123
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 35.5 22 5.90876
-      vertex 35.5 26 5.9
-      vertex 35.5 26 5.90876
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 35.5 26 5.9
-      vertex 35.5 22 5.90876
-      vertex 35.5 22 5.9
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.5 22 9.1
-      vertex 38.5 26 9.1
-      vertex 38.5 22 9.1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 38.5 26 9.1
-      vertex 35.5 22 9.1
-      vertex 35.5 26 9.1
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 38.5 22 9.09123
-      vertex 38.5 26 9.1
-      vertex 38.5 26 9.09123
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 38.5 26 9.1
-      vertex 38.5 22 9.09123
-      vertex 38.5 22 9.1
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 38.5 22 5.9
-      vertex 38.5 26 5.90876
-      vertex 38.5 26 5.9
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 38.5 26 5.90876
-      vertex 38.5 22 5.9
-      vertex 38.5 22 5.90876
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 35.5 26 5.9
-      vertex 38.5 22 5.9
-      vertex 38.5 26 5.9
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 38.5 22 5.9
-      vertex 35.5 26 5.9
-      vertex 35.5 22 5.9
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.5 16 10.5
-      vertex -2.5 22 10.5
-      vertex -2.5 16 10.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.5 22 10.5
-      vertex -5.5 16 10.5
-      vertex -5.5 22 10.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.5 22 4.5
-      vertex -2.5 16 4.5
-      vertex -2.5 22 4.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.5 16 4.5
-      vertex -5.5 22 4.5
-      vertex -5.5 16 4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.5 16 10.5
-      vertex 40.5 22 10.5
-      vertex 40.5 16 10.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 40.5 22 10.5
-      vertex 35.5 16 10.5
-      vertex 35.5 22 10.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 35.5 22 4.5
-      vertex 40.5 16 4.5
-      vertex 40.5 22 4.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 40.5 16 4.5
-      vertex 35.5 22 4.5
-      vertex 35.5 16 4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 23.2 18 2
-      vertex 23.0427 19.497 14
-      vertex 23.0427 19.497 2
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 23.0427 19.497 14
-      vertex 23.2 18 2
-      vertex 23.2 18 14
-    endloop
-  endfacet
-  facet normal 0.207911 -0.978148 0
-    outer loop
-      vertex 13.7751 24.8476 2
-      vertex 15.2474 25.1606 14
-      vertex 13.7751 24.8476 14
-    endloop
-  endfacet
-  facet normal 0.207911 -0.978148 0
-    outer loop
-      vertex 15.2474 25.1606 14
-      vertex 13.7751 24.8476 2
-      vertex 15.2474 25.1606 2
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 -1.39601e-006
-    outer loop
-      vertex 18.2249 11.1524 14
-      vertex 16.7526 10.8394 13.8394
-      vertex 17.508 11 14
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex 18.2249 11.1524 2
-      vertex 16.7526 10.8394 13.8394
-      vertex 18.2249 11.1524 14
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex 16.7526 10.8394 13.8394
-      vertex 18.2249 11.1524 2
-      vertex 16.7526 10.8394 2
-    endloop
-  endfacet
-  facet normal -0.587785 -0.809018 0
-    outer loop
-      vertex 19.6 24.2354 2
-      vertex 20.8177 23.3506 14
-      vertex 19.6 24.2354 14
-    endloop
-  endfacet
-  facet normal -0.587785 -0.809018 -0
-    outer loop
-      vertex 20.8177 23.3506 14
-      vertex 19.6 24.2354 2
-      vertex 20.8177 23.3506 2
-    endloop
-  endfacet
-  facet normal 0.866025 -0.5 0
-    outer loop
-      vertex 9.42247 20.9285 14
-      vertex 10.1751 22.2321 2
-      vertex 10.1751 22.2321 14
-    endloop
-  endfacet
-  facet normal 0.866025 -0.5 0
-    outer loop
-      vertex 10.1751 22.2321 2
-      vertex 9.42247 20.9285 14
-      vertex 9.42247 20.9285 2
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 8.95734 19.497 14
-      vertex 9.42247 20.9285 2
-      vertex 9.42247 20.9285 14
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 9.42247 20.9285 2
-      vertex 8.95734 19.497 14
-      vertex 8.95734 19.497 2
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 11.1823 23.3506 2
-      vertex 12.4 24.2354 14
-      vertex 11.1823 23.3506 14
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 12.4 24.2354 14
-      vertex 11.1823 23.3506 2
-      vertex 12.4 24.2354 2
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex 22.5775 15.0715 2
-      vertex 23.0427 16.503 14
-      vertex 23.0427 16.503 2
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex 23.0427 16.503 14
-      vertex 22.5775 15.0715 2
-      vertex 22.5775 15.0715 14
-    endloop
-  endfacet
   facet normal -0.866025 -0.5 0
     outer loop
       vertex 22.5775 20.9285 2
@@ -6857,76 +1656,6 @@ solid OpenSCAD_Model
       vertex 21.8249 22.2321 14
       vertex 22.5775 20.9285 2
       vertex 22.5775 20.9285 14
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309018 0
-    outer loop
-      vertex 23.0427 19.497 2
-      vertex 22.5775 20.9285 14
-      vertex 22.5775 20.9285 2
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309018 0
-    outer loop
-      vertex 22.5775 20.9285 14
-      vertex 23.0427 19.497 2
-      vertex 23.0427 19.497 14
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 21.8249 22.2321 2
-      vertex 20.8177 23.3506 14
-      vertex 20.8177 23.3506 2
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 20.8177 23.3506 14
-      vertex 21.8249 22.2321 2
-      vertex 21.8249 22.2321 14
-    endloop
-  endfacet
-  facet normal -0.207911 -0.978148 0
-    outer loop
-      vertex 16.7526 25.1606 2
-      vertex 18.2249 24.8476 14
-      vertex 16.7526 25.1606 14
-    endloop
-  endfacet
-  facet normal -0.207911 -0.978148 -0
-    outer loop
-      vertex 18.2249 24.8476 14
-      vertex 16.7526 25.1606 2
-      vertex 18.2249 24.8476 2
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 15.2474 25.1606 2
-      vertex 16.7526 25.1606 14
-      vertex 15.2474 25.1606 14
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 16.7526 25.1606 14
-      vertex 15.2474 25.1606 2
-      vertex 16.7526 25.1606 2
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 0
-    outer loop
-      vertex 18.2249 24.8476 2
-      vertex 19.6 24.2354 14
-      vertex 18.2249 24.8476 14
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 -0
-    outer loop
-      vertex 19.6 24.2354 14
-      vertex 18.2249 24.8476 2
-      vertex 19.6 24.2354 2
     endloop
   endfacet
   facet normal 0 0 1
@@ -7741,6 +2470,174 @@ solid OpenSCAD_Model
       vertex 8.8 18 2
     endloop
   endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex 21.8249 22.2321 2
+      vertex 20.8177 23.3506 14
+      vertex 20.8177 23.3506 2
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex 20.8177 23.3506 14
+      vertex 21.8249 22.2321 2
+      vertex 21.8249 22.2321 14
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.2474 25.1606 2
+      vertex 16.7526 25.1606 14
+      vertex 15.2474 25.1606 14
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 16.7526 25.1606 14
+      vertex 15.2474 25.1606 2
+      vertex 16.7526 25.1606 2
+    endloop
+  endfacet
+  facet normal -0.207911 -0.978148 0
+    outer loop
+      vertex 16.7526 25.1606 2
+      vertex 18.2249 24.8476 14
+      vertex 16.7526 25.1606 14
+    endloop
+  endfacet
+  facet normal -0.207911 -0.978148 -0
+    outer loop
+      vertex 18.2249 24.8476 14
+      vertex 16.7526 25.1606 2
+      vertex 18.2249 24.8476 2
+    endloop
+  endfacet
+  facet normal 0.587785 -0.809017 0
+    outer loop
+      vertex 11.1823 23.3506 2
+      vertex 12.4 24.2354 14
+      vertex 11.1823 23.3506 14
+    endloop
+  endfacet
+  facet normal 0.587785 -0.809017 0
+    outer loop
+      vertex 12.4 24.2354 14
+      vertex 11.1823 23.3506 2
+      vertex 12.4 24.2354 2
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309017 0
+    outer loop
+      vertex 8.95734 19.497 14
+      vertex 9.42247 20.9285 2
+      vertex 9.42247 20.9285 14
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309017 0
+    outer loop
+      vertex 9.42247 20.9285 2
+      vertex 8.95734 19.497 14
+      vertex 8.95734 19.497 2
+    endloop
+  endfacet
+  facet normal -0.994522 0.104528 0
+    outer loop
+      vertex 23.0427 16.503 2
+      vertex 23.2 18 14
+      vertex 23.2 18 2
+    endloop
+  endfacet
+  facet normal -0.994522 0.104528 0
+    outer loop
+      vertex 23.2 18 14
+      vertex 23.0427 16.503 2
+      vertex 23.0427 16.503 14
+    endloop
+  endfacet
+  facet normal -0.406737 0.913545 0
+    outer loop
+      vertex 19.6 11.7646 2
+      vertex 18.2249 11.1524 14
+      vertex 19.6 11.7646 14
+    endloop
+  endfacet
+  facet normal -0.406737 0.913545 0
+    outer loop
+      vertex 18.2249 11.1524 14
+      vertex 19.6 11.7646 2
+      vertex 18.2249 11.1524 2
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309018 0
+    outer loop
+      vertex 23.0427 19.497 2
+      vertex 22.5775 20.9285 14
+      vertex 22.5775 20.9285 2
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309018 0
+    outer loop
+      vertex 22.5775 20.9285 14
+      vertex 23.0427 19.497 2
+      vertex 23.0427 19.497 14
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809018 0
+    outer loop
+      vertex 19.6 24.2354 2
+      vertex 20.8177 23.3506 14
+      vertex 19.6 24.2354 14
+    endloop
+  endfacet
+  facet normal -0.587785 -0.809018 -0
+    outer loop
+      vertex 20.8177 23.3506 14
+      vertex 19.6 24.2354 2
+      vertex 20.8177 23.3506 2
+    endloop
+  endfacet
+  facet normal 0.207911 -0.978148 0
+    outer loop
+      vertex 13.7751 24.8476 2
+      vertex 15.2474 25.1606 14
+      vertex 13.7751 24.8476 14
+    endloop
+  endfacet
+  facet normal 0.207911 -0.978148 0
+    outer loop
+      vertex 15.2474 25.1606 14
+      vertex 13.7751 24.8476 2
+      vertex 15.2474 25.1606 2
+    endloop
+  endfacet
+  facet normal -0.406737 -0.913545 0
+    outer loop
+      vertex 18.2249 24.8476 2
+      vertex 19.6 24.2354 14
+      vertex 18.2249 24.8476 14
+    endloop
+  endfacet
+  facet normal -0.406737 -0.913545 -0
+    outer loop
+      vertex 19.6 24.2354 14
+      vertex 18.2249 24.8476 2
+      vertex 19.6 24.2354 2
+    endloop
+  endfacet
+  facet normal 0.994522 0.104528 0
+    outer loop
+      vertex 8.95734 16.503 14
+      vertex 8.8 18 2
+      vertex 8.8 18 14
+    endloop
+  endfacet
+  facet normal 0.994522 0.104528 0
+    outer loop
+      vertex 8.8 18 2
+      vertex 8.95734 16.503 14
+      vertex 8.95734 16.503 2
+    endloop
+  endfacet
   facet normal 0.743145 -0.66913 0
     outer loop
       vertex 10.1751 22.2321 14
@@ -7769,32 +2666,32 @@ solid OpenSCAD_Model
       vertex 13.7751 24.8476 2
     endloop
   endfacet
-  facet normal -0.994522 0.104528 0
+  facet normal 0.866025 -0.5 0
     outer loop
-      vertex 23.0427 16.503 2
-      vertex 23.2 18 14
+      vertex 9.42247 20.9285 14
+      vertex 10.1751 22.2321 2
+      vertex 10.1751 22.2321 14
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 10.1751 22.2321 2
+      vertex 9.42247 20.9285 14
+      vertex 9.42247 20.9285 2
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104528 0
+    outer loop
       vertex 23.2 18 2
+      vertex 23.0427 19.497 14
+      vertex 23.0427 19.497 2
     endloop
   endfacet
-  facet normal -0.994522 0.104528 0
+  facet normal -0.994522 -0.104528 0
     outer loop
+      vertex 23.0427 19.497 14
+      vertex 23.2 18 2
       vertex 23.2 18 14
-      vertex 23.0427 16.503 2
-      vertex 23.0427 16.503 14
-    endloop
-  endfacet
-  facet normal 0.994522 0.104528 0
-    outer loop
-      vertex 8.95734 16.503 14
-      vertex 8.8 18 2
-      vertex 8.8 18 14
-    endloop
-  endfacet
-  facet normal 0.994522 0.104528 0
-    outer loop
-      vertex 8.8 18 2
-      vertex 8.95734 16.503 14
-      vertex 8.95734 16.503 2
     endloop
   endfacet
   facet normal -0.743145 0.66913 0
@@ -7809,6 +2706,55 @@ solid OpenSCAD_Model
       vertex 21.8249 13.7679 14
       vertex 20.8177 12.6494 2
       vertex 20.8177 12.6494 14
+    endloop
+  endfacet
+  facet normal -0.207911 0.978148 -1.39601e-06
+    outer loop
+      vertex 18.2249 11.1524 14
+      vertex 16.7526 10.8394 13.8394
+      vertex 17.508 11 14
+    endloop
+  endfacet
+  facet normal -0.207911 0.978148 0
+    outer loop
+      vertex 18.2249 11.1524 2
+      vertex 16.7526 10.8394 13.8394
+      vertex 18.2249 11.1524 14
+    endloop
+  endfacet
+  facet normal -0.207911 0.978148 0
+    outer loop
+      vertex 16.7526 10.8394 13.8394
+      vertex 18.2249 11.1524 2
+      vertex 16.7526 10.8394 2
+    endloop
+  endfacet
+  facet normal 0.951057 0.309017 0
+    outer loop
+      vertex 9.42247 15.0715 14
+      vertex 8.95734 16.503 2
+      vertex 8.95734 16.503 14
+    endloop
+  endfacet
+  facet normal 0.951057 0.309017 0
+    outer loop
+      vertex 8.95734 16.503 2
+      vertex 9.42247 15.0715 14
+      vertex 9.42247 15.0715 2
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex 20.8177 12.6494 2
+      vertex 19.6 11.7646 14
+      vertex 20.8177 12.6494 14
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex 19.6 11.7646 14
+      vertex 20.8177 12.6494 2
+      vertex 19.6 11.7646 2
     endloop
   endfacet
   facet normal -0.866025 0.5 0
@@ -7825,60 +2771,18 @@ solid OpenSCAD_Model
       vertex 21.8249 13.7679 14
     endloop
   endfacet
-  facet normal -0.406737 0.913545 0
+  facet normal -0.951056 0.309018 0
     outer loop
-      vertex 19.6 11.7646 2
-      vertex 18.2249 11.1524 14
-      vertex 19.6 11.7646 14
+      vertex 22.5775 15.0715 2
+      vertex 23.0427 16.503 14
+      vertex 23.0427 16.503 2
     endloop
   endfacet
-  facet normal -0.406737 0.913545 0
+  facet normal -0.951056 0.309018 0
     outer loop
-      vertex 18.2249 11.1524 14
-      vertex 19.6 11.7646 2
-      vertex 18.2249 11.1524 2
-    endloop
-  endfacet
-  facet normal 0.866025 0.5 0
-    outer loop
-      vertex 9.67064 14.6417 14
-      vertex 9.42247 15.0715 2
-      vertex 9.42247 15.0715 14
-    endloop
-  endfacet
-  facet normal 0.866025 0.5 0
-    outer loop
-      vertex 9.42247 15.0715 2
-      vertex 9.67064 14.6417 14
-      vertex 9.67064 14.6417 2
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 9.42247 15.0715 14
-      vertex 8.95734 16.503 2
-      vertex 8.95734 16.503 14
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 8.95734 16.503 2
-      vertex 9.42247 15.0715 14
-      vertex 9.42247 15.0715 2
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex 20.8177 12.6494 2
-      vertex 19.6 11.7646 14
-      vertex 20.8177 12.6494 14
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex 19.6 11.7646 14
-      vertex 20.8177 12.6494 2
-      vertex 19.6 11.7646 2
+      vertex 23.0427 16.503 14
+      vertex 22.5775 15.0715 2
+      vertex 22.5775 15.0715 14
     endloop
   endfacet
   facet normal 0 1 -0
@@ -7895,18 +2799,60 @@ solid OpenSCAD_Model
       vertex 16.145 10.8394 2
     endloop
   endfacet
-  facet normal -0.994522 -0.104528 0
+  facet normal 0.866025 0.5 0
     outer loop
-      vertex 19.2 5 2
-      vertex 19.0427 6.49696 12.503
-      vertex 19.0427 6.49696 2
+      vertex 9.67064 14.6417 14
+      vertex 9.42247 15.0715 2
+      vertex 9.42247 15.0715 14
     endloop
   endfacet
-  facet normal -0.994522 -0.104528 0
+  facet normal 0.866025 0.5 0
     outer loop
-      vertex 19.0427 6.49696 12.503
-      vertex 19.2 5 2
+      vertex 9.42247 15.0715 2
+      vertex 9.67064 14.6417 14
+      vertex 9.67064 14.6417 2
+    endloop
+  endfacet
+  facet normal -0.866023 -0.500004 -0
+    outer loop
+      vertex 17.9012 9.1 12.1
+      vertex 17.8249 9.23205 2
+      vertex 17.9012 9.1 2
+    endloop
+  endfacet
+  facet normal -0.866023 -0.500004 0
+    outer loop
+      vertex 17.8249 9.23205 2
+      vertex 17.9012 9.1 12.1
+      vertex 17.8249 9.23205 12.2321
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 -0
+    outer loop
+      vertex 17.8249 9.23205 12.2321
+      vertex 16.8177 10.3506 2
+      vertex 17.8249 9.23205 2
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex 16.8177 10.3506 2
+      vertex 17.8249 9.23205 12.2321
+      vertex 16.8177 10.3506 13.3506
+    endloop
+  endfacet
+  facet normal -0.994522 0.104528 0
+    outer loop
+      vertex 19.0427 3.50304 2
       vertex 19.2 5 14
+      vertex 19.2 5 2
+    endloop
+  endfacet
+  facet normal -0.994522 0.104528 0
+    outer loop
+      vertex 19.0427 3.50304 14
+      vertex 19.2 5 14
+      vertex 19.0427 3.50304 2
     endloop
   endfacet
   facet normal -0.587785 -0.809017 0
@@ -7923,21 +2869,21 @@ solid OpenSCAD_Model
       vertex 16.8177 10.3506 2
     endloop
   endfacet
-  facet normal 0.866025 -0.5 0
+  facet normal 0.994522 0.104528 0
     outer loop
-      vertex 5.42247 7.9285 2
-      vertex 6.0411 9 12
-      vertex 5.42247 7.9285 13.0715
+      vertex 4.95734 3.50304 14
+      vertex 4.8 5 2
+      vertex 4.8 5 14
     endloop
   endfacet
-  facet normal 0.866025 -0.5 0
+  facet normal 0.994522 0.104528 0
     outer loop
-      vertex 6.0411 9 12
-      vertex 5.42247 7.9285 2
-      vertex 6.0411 9 2
+      vertex 4.8 5 2
+      vertex 4.95734 3.50304 14
+      vertex 4.95734 3.50304 2
     endloop
   endfacet
-  facet normal 0.951056 -0.309017 -5.98687e-007
+  facet normal 0.951056 -0.309017 -5.98687e-07
     outer loop
       vertex 4.95734 6.49696 14
       vertex 5.42247 7.9285 13.0715
@@ -7958,144 +2904,32 @@ solid OpenSCAD_Model
       vertex 5.42247 7.9285 2
     endloop
   endfacet
-  facet normal -0.866025 0.5 0
+  facet normal 0.866025 -0.5 0
     outer loop
-      vertex 17.8249 0.767945 2
-      vertex 18.5775 2.0715 14
-      vertex 18.5775 2.0715 2
+      vertex 5.42247 7.9285 2
+      vertex 6.0411 9 12
+      vertex 5.42247 7.9285 13.0715
     endloop
   endfacet
-  facet normal -0.866025 0.5 0
+  facet normal 0.866025 -0.5 0
     outer loop
-      vertex 18.5775 2.0715 14
-      vertex 17.8249 0.767945 2
-      vertex 17.8249 0.767945 14
+      vertex 6.0411 9 12
+      vertex 5.42247 7.9285 2
+      vertex 6.0411 9 2
     endloop
   endfacet
-  facet normal -0.866023 -0.500004 -0
+  facet normal -0.994522 -0.104528 0
     outer loop
-      vertex 17.9012 9.1 12.1
-      vertex 17.8249 9.23205 2
-      vertex 17.9012 9.1 2
-    endloop
-  endfacet
-  facet normal -0.866023 -0.500004 0
-    outer loop
-      vertex 17.8249 9.23205 2
-      vertex 17.9012 9.1 12.1
-      vertex 17.8249 9.23205 12.2321
-    endloop
-  endfacet
-  facet normal -0.951055 -0.30902 0
-    outer loop
-      vertex 19.0427 6.49696 2
-      vertex 18.8792 7 12
-      vertex 18.8792 7 2
-    endloop
-  endfacet
-  facet normal -0.951055 -0.30902 0
-    outer loop
-      vertex 18.8792 7 12
-      vertex 19.0427 6.49696 2
-      vertex 19.0427 6.49696 12.503
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 -0
-    outer loop
-      vertex 17.8249 9.23205 12.2321
-      vertex 16.8177 10.3506 2
-      vertex 17.8249 9.23205 2
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 16.8177 10.3506 2
-      vertex 17.8249 9.23205 12.2321
-      vertex 16.8177 10.3506 13.3506
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104528 0
-    outer loop
-      vertex 4.8 5 14
-      vertex 4.95734 6.49696 2
-      vertex 4.95734 6.49696 14
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104528 0
-    outer loop
-      vertex 4.95734 6.49696 2
-      vertex 4.8 5 14
-      vertex 4.8 5 2
-    endloop
-  endfacet
-  facet normal -0.743145 0.669131 0
-    outer loop
-      vertex 16.8177 -0.350642 2
-      vertex 17.8249 0.767945 14
-      vertex 17.8249 0.767945 2
-    endloop
-  endfacet
-  facet normal -0.743145 0.669131 0
-    outer loop
-      vertex 17.8249 0.767945 14
-      vertex 16.8177 -0.350642 2
-      vertex 16.8177 -0.350642 14
-    endloop
-  endfacet
-  facet normal 0.994522 0.104528 0
-    outer loop
-      vertex 4.95734 3.50304 14
-      vertex 4.8 5 2
-      vertex 4.8 5 14
-    endloop
-  endfacet
-  facet normal 0.994522 0.104528 0
-    outer loop
-      vertex 4.8 5 2
-      vertex 4.95734 3.50304 14
-      vertex 4.95734 3.50304 2
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex 18.5775 2.0715 2
-      vertex 19.0427 3.50304 14
-      vertex 19.0427 3.50304 2
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex 19.0427 3.50304 14
-      vertex 18.5775 2.0715 2
-      vertex 18.5775 2.0715 14
-    endloop
-  endfacet
-  facet normal -0.994522 0.104528 0
-    outer loop
-      vertex 19.0427 3.50304 2
-      vertex 19.2 5 14
       vertex 19.2 5 2
+      vertex 19.0427 6.49696 12.503
+      vertex 19.0427 6.49696 2
     endloop
   endfacet
-  facet normal -0.994522 0.104528 0
+  facet normal -0.994522 -0.104528 0
     outer loop
-      vertex 19.0427 3.50304 14
+      vertex 19.0427 6.49696 12.503
+      vertex 19.2 5 2
       vertex 19.2 5 14
-      vertex 19.0427 3.50304 2
-    endloop
-  endfacet
-  facet normal 0.743144 0.669131 0
-    outer loop
-      vertex 7.18226 -0.350642 14
-      vertex 6.17508 0.767945 2
-      vertex 6.17508 0.767945 14
-    endloop
-  endfacet
-  facet normal 0.743144 0.669131 0
-    outer loop
-      vertex 6.17508 0.767945 2
-      vertex 7.18226 -0.350642 14
-      vertex 7.18226 -0.350642 2
     endloop
   endfacet
   facet normal -0.587785 0.809017 0
@@ -8112,32 +2946,60 @@ solid OpenSCAD_Model
       vertex 15.924 -1 2
     endloop
   endfacet
-  facet normal 0.587785 0.809017 -0
+  facet normal -0.951056 0.309018 0
     outer loop
-      vertex 8.07602 -1 2
-      vertex 7.18226 -0.350642 14
-      vertex 8.07602 -1 14
+      vertex 18.5775 2.0715 2
+      vertex 19.0427 3.50304 14
+      vertex 19.0427 3.50304 2
     endloop
   endfacet
-  facet normal 0.587785 0.809017 0
+  facet normal -0.951056 0.309018 0
     outer loop
-      vertex 7.18226 -0.350642 14
-      vertex 8.07602 -1 2
-      vertex 7.18226 -0.350642 2
+      vertex 19.0427 3.50304 14
+      vertex 18.5775 2.0715 2
+      vertex 18.5775 2.0715 14
     endloop
   endfacet
-  facet normal 0.866025 0.5 0
+  facet normal -0.951055 -0.30902 0
     outer loop
-      vertex 6.17508 0.767945 14
-      vertex 5.42247 2.0715 2
-      vertex 5.42247 2.0715 14
+      vertex 19.0427 6.49696 2
+      vertex 18.8792 7 12
+      vertex 18.8792 7 2
     endloop
   endfacet
-  facet normal 0.866025 0.5 0
+  facet normal -0.951055 -0.30902 0
     outer loop
-      vertex 5.42247 2.0715 2
-      vertex 6.17508 0.767945 14
-      vertex 6.17508 0.767945 2
+      vertex 18.8792 7 12
+      vertex 19.0427 6.49696 2
+      vertex 19.0427 6.49696 12.503
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104528 0
+    outer loop
+      vertex 4.8 5 14
+      vertex 4.95734 6.49696 2
+      vertex 4.95734 6.49696 14
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104528 0
+    outer loop
+      vertex 4.95734 6.49696 2
+      vertex 4.8 5 14
+      vertex 4.8 5 2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 17.8249 0.767945 2
+      vertex 18.5775 2.0715 14
+      vertex 18.5775 2.0715 2
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex 18.5775 2.0715 14
+      vertex 17.8249 0.767945 2
+      vertex 17.8249 0.767945 14
     endloop
   endfacet
   facet normal 0.951056 0.309017 0
@@ -8154,18 +3016,5058 @@ solid OpenSCAD_Model
       vertex 5.42247 2.0715 2
     endloop
   endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 6.17508 0.767945 14
+      vertex 5.42247 2.0715 2
+      vertex 5.42247 2.0715 14
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 5.42247 2.0715 2
+      vertex 6.17508 0.767945 14
+      vertex 6.17508 0.767945 2
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 -0
+    outer loop
+      vertex 8.07602 -1 2
+      vertex 7.18226 -0.350642 14
+      vertex 8.07602 -1 14
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 0
+    outer loop
+      vertex 7.18226 -0.350642 14
+      vertex 8.07602 -1 2
+      vertex 7.18226 -0.350642 2
+    endloop
+  endfacet
+  facet normal 0.743144 0.669131 0
+    outer loop
+      vertex 7.18226 -0.350642 14
+      vertex 6.17508 0.767945 2
+      vertex 6.17508 0.767945 14
+    endloop
+  endfacet
+  facet normal 0.743144 0.669131 0
+    outer loop
+      vertex 6.17508 0.767945 2
+      vertex 7.18226 -0.350642 14
+      vertex 7.18226 -0.350642 2
+    endloop
+  endfacet
+  facet normal -0.743145 0.669131 0
+    outer loop
+      vertex 16.8177 -0.350642 2
+      vertex 17.8249 0.767945 14
+      vertex 17.8249 0.767945 2
+    endloop
+  endfacet
+  facet normal -0.743145 0.669131 0
+    outer loop
+      vertex 17.8249 0.767945 14
+      vertex 16.8177 -0.350642 2
+      vertex 16.8177 -0.350642 14
+    endloop
+  endfacet
+  facet normal 0.994522 0.10453 0
+    outer loop
+      vertex 19.5 18 11
+      vertex 19.4235 18.7277 2
+      vertex 19.4235 18.7277 11
+    endloop
+  endfacet
+  facet normal 0.994522 0.10453 0
+    outer loop
+      vertex 19.4235 18.7277 2
+      vertex 19.5 18 11
+      vertex 19.5 18 2
+    endloop
+  endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 6.0411 9 2
-      vertex -1 9 12
-      vertex 6.0411 9 12
+      vertex 16.3658 21.4808 2
+      vertex 15.6341 21.4808 11
+      vertex 16.3658 21.4808 11
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -1 9 12
-      vertex 6.0411 9 2
-      vertex -1 9 2
+      vertex 15.6341 21.4808 11
+      vertex 16.3658 21.4808 2
+      vertex 15.6341 21.4808 2
+    endloop
+  endfacet
+  facet normal 0.587787 0.809016 -0
+    outer loop
+      vertex 18.342 20.601 2
+      vertex 17.75 21.0311 11
+      vertex 18.342 20.601 11
+    endloop
+  endfacet
+  facet normal 0.587787 0.809016 0
+    outer loop
+      vertex 17.75 21.0311 11
+      vertex 18.342 20.601 2
+      vertex 17.75 21.0311 2
+    endloop
+  endfacet
+  facet normal -0.743145 0.66913 0
+    outer loop
+      vertex 13.1684 20.0572 2
+      vertex 13.658 20.601 11
+      vertex 13.658 20.601 2
+    endloop
+  endfacet
+  facet normal -0.743145 0.66913 0
+    outer loop
+      vertex 13.658 20.601 11
+      vertex 13.1684 20.0572 2
+      vertex 13.1684 20.0572 11
+    endloop
+  endfacet
+  facet normal -0.406735 0.913546 0
+    outer loop
+      vertex 14.9184 21.3287 2
+      vertex 14.25 21.0311 11
+      vertex 14.9184 21.3287 11
+    endloop
+  endfacet
+  facet normal -0.406735 0.913546 0
+    outer loop
+      vertex 14.25 21.0311 11
+      vertex 14.9184 21.3287 2
+      vertex 14.25 21.0311 2
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 18.8316 15.9428 11
+      vertex 19.1974 16.5764 2
+      vertex 19.1974 16.5764 11
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex 19.1974 16.5764 2
+      vertex 18.8316 15.9428 11
+      vertex 18.8316 15.9428 2
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309017 0
+    outer loop
+      vertex 12.8026 16.5764 2
+      vertex 12.5765 17.2723 11
+      vertex 12.5765 17.2723 2
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309017 0
+    outer loop
+      vertex 12.5765 17.2723 11
+      vertex 12.8026 16.5764 2
+      vertex 12.8026 16.5764 11
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 19.1974 19.4236 11
+      vertex 18.8316 20.0572 2
+      vertex 18.8316 20.0572 11
+    endloop
+  endfacet
+  facet normal 0.866025 0.5 0
+    outer loop
+      vertex 18.8316 20.0572 2
+      vertex 19.1974 19.4236 11
+      vertex 19.1974 19.4236 2
+    endloop
+  endfacet
+  facet normal 0.951057 0.309017 0
+    outer loop
+      vertex 19.4235 18.7277 11
+      vertex 19.1974 19.4236 2
+      vertex 19.1974 19.4236 11
+    endloop
+  endfacet
+  facet normal 0.951057 0.309017 0
+    outer loop
+      vertex 19.1974 19.4236 2
+      vertex 19.4235 18.7277 11
+      vertex 19.4235 18.7277 2
+    endloop
+  endfacet
+  facet normal 0.743146 0.66913 0
+    outer loop
+      vertex 18.8316 20.0572 11
+      vertex 18.342 20.601 2
+      vertex 18.342 20.601 11
+    endloop
+  endfacet
+  facet normal 0.743146 0.66913 0
+    outer loop
+      vertex 18.342 20.601 2
+      vertex 18.8316 20.0572 11
+      vertex 18.8316 20.0572 2
+    endloop
+  endfacet
+  facet normal 0.207913 0.978147 -0
+    outer loop
+      vertex 17.0816 21.3287 2
+      vertex 16.3658 21.4808 11
+      vertex 17.0816 21.3287 11
+    endloop
+  endfacet
+  facet normal 0.207913 0.978147 0
+    outer loop
+      vertex 16.3658 21.4808 11
+      vertex 17.0816 21.3287 2
+      vertex 16.3658 21.4808 2
+    endloop
+  endfacet
+  facet normal 0.406734 0.913546 -0
+    outer loop
+      vertex 17.75 21.0311 2
+      vertex 17.0816 21.3287 11
+      vertex 17.75 21.0311 11
+    endloop
+  endfacet
+  facet normal 0.406734 0.913546 0
+    outer loop
+      vertex 17.0816 21.3287 11
+      vertex 17.75 21.0311 2
+      vertex 17.0816 21.3287 2
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex 12.5765 18.7277 2
+      vertex 12.8026 19.4236 11
+      vertex 12.8026 19.4236 2
+    endloop
+  endfacet
+  facet normal -0.951056 0.309018 0
+    outer loop
+      vertex 12.8026 19.4236 11
+      vertex 12.5765 18.7277 2
+      vertex 12.5765 18.7277 11
+    endloop
+  endfacet
+  facet normal -0.866026 0.499999 0
+    outer loop
+      vertex 12.8026 19.4236 2
+      vertex 13.1684 20.0572 11
+      vertex 13.1684 20.0572 2
+    endloop
+  endfacet
+  facet normal -0.866026 0.499999 0
+    outer loop
+      vertex 13.1684 20.0572 11
+      vertex 12.8026 19.4236 2
+      vertex 12.8026 19.4236 11
+    endloop
+  endfacet
+  facet normal -0.994522 0.104528 0
+    outer loop
+      vertex 12.5 18 2
+      vertex 12.5765 18.7277 11
+      vertex 12.5765 18.7277 2
+    endloop
+  endfacet
+  facet normal -0.994522 0.104528 0
+    outer loop
+      vertex 12.5765 18.7277 11
+      vertex 12.5 18 2
+      vertex 12.5 18 11
+    endloop
+  endfacet
+  facet normal -0.587787 0.809016 0
+    outer loop
+      vertex 14.25 21.0311 2
+      vertex 13.658 20.601 11
+      vertex 14.25 21.0311 11
+    endloop
+  endfacet
+  facet normal -0.587787 0.809016 0
+    outer loop
+      vertex 13.658 20.601 11
+      vertex 14.25 21.0311 2
+      vertex 13.658 20.601 2
+    endloop
+  endfacet
+  facet normal -0.207913 0.978147 0
+    outer loop
+      vertex 15.6341 21.4808 2
+      vertex 14.9184 21.3287 11
+      vertex 15.6341 21.4808 11
+    endloop
+  endfacet
+  facet normal -0.207913 0.978147 0
+    outer loop
+      vertex 14.9184 21.3287 11
+      vertex 15.6341 21.4808 2
+      vertex 14.9184 21.3287 2
+    endloop
+  endfacet
+  facet normal 0.207912 -0.978147 0
+    outer loop
+      vertex 16.3658 14.5192 2
+      vertex 17.0816 14.6713 11
+      vertex 16.3658 14.5192 11
+    endloop
+  endfacet
+  facet normal 0.207912 -0.978147 0
+    outer loop
+      vertex 17.0816 14.6713 11
+      vertex 16.3658 14.5192 2
+      vertex 17.0816 14.6713 2
+    endloop
+  endfacet
+  facet normal 0.587786 -0.809017 0
+    outer loop
+      vertex 17.75 14.9689 2
+      vertex 18.342 15.399 11
+      vertex 17.75 14.9689 11
+    endloop
+  endfacet
+  facet normal 0.587786 -0.809017 0
+    outer loop
+      vertex 18.342 15.399 11
+      vertex 17.75 14.9689 2
+      vertex 18.342 15.399 2
+    endloop
+  endfacet
+  facet normal -0.406736 -0.913546 0
+    outer loop
+      vertex 14.25 14.9689 2
+      vertex 14.9184 14.6713 11
+      vertex 14.25 14.9689 11
+    endloop
+  endfacet
+  facet normal -0.406736 -0.913546 -0
+    outer loop
+      vertex 14.9184 14.6713 11
+      vertex 14.25 14.9689 2
+      vertex 14.9184 14.6713 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.6341 14.5192 2
+      vertex 16.3658 14.5192 11
+      vertex 15.6341 14.5192 11
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 16.3658 14.5192 11
+      vertex 15.6341 14.5192 2
+      vertex 16.3658 14.5192 2
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex 13.658 15.399 2
+      vertex 13.1684 15.9428 11
+      vertex 13.1684 15.9428 2
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex 13.1684 15.9428 11
+      vertex 13.658 15.399 2
+      vertex 13.658 15.399 11
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 0
+    outer loop
+      vertex 13.1684 15.9428 2
+      vertex 12.8026 16.5764 11
+      vertex 12.8026 16.5764 2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 0
+    outer loop
+      vertex 12.8026 16.5764 11
+      vertex 13.1684 15.9428 2
+      vertex 13.1684 15.9428 11
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104528 0
+    outer loop
+      vertex 12.5765 17.2723 2
+      vertex 12.5 18 11
+      vertex 12.5 18 2
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104528 0
+    outer loop
+      vertex 12.5 18 11
+      vertex 12.5765 17.2723 2
+      vertex 12.5765 17.2723 11
+    endloop
+  endfacet
+  facet normal 0.406735 -0.913546 0
+    outer loop
+      vertex 17.0816 14.6713 2
+      vertex 17.75 14.9689 11
+      vertex 17.0816 14.6713 11
+    endloop
+  endfacet
+  facet normal 0.406735 -0.913546 0
+    outer loop
+      vertex 17.75 14.9689 11
+      vertex 17.0816 14.6713 2
+      vertex 17.75 14.9689 2
+    endloop
+  endfacet
+  facet normal 0.743146 -0.66913 0
+    outer loop
+      vertex 18.342 15.399 11
+      vertex 18.8316 15.9428 2
+      vertex 18.8316 15.9428 11
+    endloop
+  endfacet
+  facet normal 0.743146 -0.66913 0
+    outer loop
+      vertex 18.8316 15.9428 2
+      vertex 18.342 15.399 11
+      vertex 18.342 15.399 2
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309016 0
+    outer loop
+      vertex 19.1974 16.5764 11
+      vertex 19.4235 17.2723 2
+      vertex 19.4235 17.2723 11
+    endloop
+  endfacet
+  facet normal 0.951057 -0.309016 0
+    outer loop
+      vertex 19.4235 17.2723 2
+      vertex 19.1974 16.5764 11
+      vertex 19.1974 16.5764 2
+    endloop
+  endfacet
+  facet normal 0.994522 -0.10453 0
+    outer loop
+      vertex 19.4235 17.2723 11
+      vertex 19.5 18 2
+      vertex 19.5 18 11
+    endloop
+  endfacet
+  facet normal 0.994522 -0.10453 0
+    outer loop
+      vertex 19.5 18 2
+      vertex 19.4235 17.2723 11
+      vertex 19.4235 17.2723 2
+    endloop
+  endfacet
+  facet normal -0.207912 -0.978147 0
+    outer loop
+      vertex 14.9184 14.6713 2
+      vertex 15.6341 14.5192 11
+      vertex 14.9184 14.6713 11
+    endloop
+  endfacet
+  facet normal -0.207912 -0.978147 -0
+    outer loop
+      vertex 15.6341 14.5192 11
+      vertex 14.9184 14.6713 2
+      vertex 15.6341 14.5192 2
+    endloop
+  endfacet
+  facet normal -0.587786 -0.809017 0
+    outer loop
+      vertex 13.658 15.399 2
+      vertex 14.25 14.9689 11
+      vertex 13.658 15.399 11
+    endloop
+  endfacet
+  facet normal -0.587786 -0.809017 -0
+    outer loop
+      vertex 14.25 14.9689 11
+      vertex 13.658 15.399 2
+      vertex 14.25 14.9689 2
+    endloop
+  endfacet
+  facet normal 0.944002 0.0992173 0.314667
+    outer loop
+      vertex 19.5 18 11
+      vertex 18.4454 18.5198 14
+      vertex 18.5 18 14
+    endloop
+  endfacet
+  facet normal 0.944002 0.0992202 0.314667
+    outer loop
+      vertex 19.4235 18.7277 11
+      vertex 18.4454 18.5198 14
+      vertex 19.5 18 11
+    endloop
+  endfacet
+  facet normal -0.386075 -0.867139 0.314668
+    outer loop
+      vertex 14.75 15.8349 14
+      vertex 14.25 14.9689 11
+      vertex 15.2275 15.6224 14
+    endloop
+  endfacet
+  facet normal 0.386074 0.867139 0.314668
+    outer loop
+      vertex 17.75 21.0311 11
+      vertex 16.7725 20.3776 14
+      vertex 17.25 20.1651 14
+    endloop
+  endfacet
+  facet normal 0.557927 -0.76792 0.314667
+    outer loop
+      vertex 18.342 15.399 11
+      vertex 17.25 15.8349 14
+      vertex 17.75 14.9689 11
+    endloop
+  endfacet
+  facet normal 0.822032 -0.474602 0.314668
+    outer loop
+      vertex 18.2839 16.9832 14
+      vertex 18.0225 16.5305 14
+      vertex 18.8316 15.9428 11
+    endloop
+  endfacet
+  facet normal -0.705395 0.63514 0.314667
+    outer loop
+      vertex 13.658 20.601 11
+      vertex 13.1684 20.0572 11
+      vertex 13.9775 19.4695 14
+    endloop
+  endfacet
+  facet normal 0.705395 0.635139 0.314667
+    outer loop
+      vertex 18.342 20.601 11
+      vertex 18.0225 19.4695 14
+      vertex 18.8316 20.0572 11
+    endloop
+  endfacet
+  facet normal 0 0.949202 0.314667
+    outer loop
+      vertex 16.3658 21.4808 11
+      vertex 15.7387 20.4863 14
+      vertex 16.2613 20.4863 14
+    endloop
+  endfacet
+  facet normal 0 0.949202 0.314667
+    outer loop
+      vertex 15.7387 20.4863 14
+      vertex 16.3658 21.4808 11
+      vertex 15.6341 21.4808 11
+    endloop
+  endfacet
+  facet normal 0.197352 0.928459 0.314668
+    outer loop
+      vertex 17.0816 21.3287 11
+      vertex 16.3658 21.4808 11
+      vertex 16.7725 20.3776 14
+    endloop
+  endfacet
+  facet normal -0.705395 -0.63514 0.314668
+    outer loop
+      vertex 13.9775 16.5305 14
+      vertex 13.1684 15.9428 11
+      vertex 13.658 15.399 11
+    endloop
+  endfacet
+  facet normal -0.197351 -0.92846 0.314667
+    outer loop
+      vertex 15.2275 15.6224 14
+      vertex 14.9184 14.6713 11
+      vertex 15.6341 14.5192 11
+    endloop
+  endfacet
+  facet normal 0.705395 -0.635139 0.314668
+    outer loop
+      vertex 18.8316 15.9428 11
+      vertex 18.0225 16.5305 14
+      vertex 18.342 15.399 11
+    endloop
+  endfacet
+  facet normal 0.944002 -0.0992202 0.314667
+    outer loop
+      vertex 19.5 18 11
+      vertex 18.4454 17.4802 14
+      vertex 19.4235 17.2723 11
+    endloop
+  endfacet
+  facet normal 0.902745 -0.293319 0.314667
+    outer loop
+      vertex 19.4235 17.2723 11
+      vertex 18.4454 17.4802 14
+      vertex 19.1974 16.5764 11
+    endloop
+  endfacet
+  facet normal 0.902745 0.29332 0.314667
+    outer loop
+      vertex 19.1974 19.4236 11
+      vertex 18.4454 18.5198 14
+      vertex 19.4235 18.7277 11
+    endloop
+  endfacet
+  facet normal -0.944002 -0.0992173 0.314667
+    outer loop
+      vertex 13.5 18 14
+      vertex 12.5 18 11
+      vertex 13.5546 17.4802 14
+    endloop
+  endfacet
+  facet normal -0.386076 0.867139 0.314668
+    outer loop
+      vertex 15.2275 20.3776 14
+      vertex 14.25 21.0311 11
+      vertex 14.75 20.1651 14
+    endloop
+  endfacet
+  facet normal 0.557929 0.767919 0.314668
+    outer loop
+      vertex 17.75 21.0311 11
+      vertex 17.25 20.1651 14
+      vertex 18.342 20.601 11
+    endloop
+  endfacet
+  facet normal 0.822032 0.474602 0.314667
+    outer loop
+      vertex 18.8316 20.0572 11
+      vertex 18.0225 19.4695 14
+      vertex 18.2839 19.0168 14
+    endloop
+  endfacet
+  facet normal 0.386073 0.86714 0.314668
+    outer loop
+      vertex 17.0816 21.3287 11
+      vertex 16.7725 20.3776 14
+      vertex 17.75 21.0311 11
+    endloop
+  endfacet
+  facet normal -0.902745 -0.29332 0.314667
+    outer loop
+      vertex 13.5546 17.4802 14
+      vertex 12.5765 17.2723 11
+      vertex 12.8026 16.5764 11
+    endloop
+  endfacet
+  facet normal -0.557927 -0.76792 0.314667
+    outer loop
+      vertex 14.75 15.8349 14
+      vertex 13.658 15.399 11
+      vertex 14.25 14.9689 11
+    endloop
+  endfacet
+  facet normal -0.822033 -0.474601 0.314668
+    outer loop
+      vertex 13.7161 16.9832 14
+      vertex 13.1684 15.9428 11
+      vertex 13.9775 16.5305 14
+    endloop
+  endfacet
+  facet normal -0.386075 -0.867139 0.314667
+    outer loop
+      vertex 15.2275 15.6224 14
+      vertex 14.25 14.9689 11
+      vertex 14.9184 14.6713 11
+    endloop
+  endfacet
+  facet normal 0.197351 -0.928459 0.314667
+    outer loop
+      vertex 16.7725 15.6224 14
+      vertex 16.2613 15.5137 14
+      vertex 16.3658 14.5192 11
+    endloop
+  endfacet
+  facet normal 0.386074 -0.86714 0.314667
+    outer loop
+      vertex 17.25 15.8349 14
+      vertex 16.7725 15.6224 14
+      vertex 17.75 14.9689 11
+    endloop
+  endfacet
+  facet normal 0.822033 -0.474601 0.314667
+    outer loop
+      vertex 19.1974 16.5764 11
+      vertex 18.2839 16.9832 14
+      vertex 18.8316 15.9428 11
+    endloop
+  endfacet
+  facet normal 0.944002 -0.0992173 0.314667
+    outer loop
+      vertex 18.5 18 14
+      vertex 18.4454 17.4802 14
+      vertex 19.5 18 11
+    endloop
+  endfacet
+  facet normal -0.944002 -0.0992177 0.314667
+    outer loop
+      vertex 13.5546 17.4802 14
+      vertex 12.5 18 11
+      vertex 12.5765 17.2723 11
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.4454 18.5198 14
+      vertex 18.4454 17.4802 14
+      vertex 18.5 18 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2839 19.0168 14
+      vertex 18.4454 17.4802 14
+      vertex 18.4454 18.5198 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2839 19.0168 14
+      vertex 18.2839 16.9832 14
+      vertex 18.4454 17.4802 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0225 19.4695 14
+      vertex 18.2839 16.9832 14
+      vertex 18.2839 19.0168 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0225 19.4695 14
+      vertex 18.0225 16.5305 14
+      vertex 18.2839 16.9832 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6728 19.8579 14
+      vertex 18.0225 16.5305 14
+      vertex 18.0225 19.4695 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.6728 19.8579 14
+      vertex 17.6728 16.1421 14
+      vertex 18.0225 16.5305 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.25 20.1651 14
+      vertex 17.6728 16.1421 14
+      vertex 17.6728 19.8579 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.25 20.1651 14
+      vertex 17.25 15.8349 14
+      vertex 17.6728 16.1421 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7725 20.3776 14
+      vertex 17.25 15.8349 14
+      vertex 17.25 20.1651 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7725 20.3776 14
+      vertex 16.7725 15.6224 14
+      vertex 17.25 15.8349 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.2613 20.4863 14
+      vertex 16.7725 15.6224 14
+      vertex 16.7725 20.3776 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.2613 20.4863 14
+      vertex 16.2613 15.5137 14
+      vertex 16.7725 15.6224 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.7387 20.4863 14
+      vertex 16.2613 15.5137 14
+      vertex 16.2613 20.4863 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.7387 20.4863 14
+      vertex 15.7387 15.5137 14
+      vertex 16.2613 15.5137 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 15.2275 20.3776 14
+      vertex 15.7387 15.5137 14
+      vertex 15.7387 20.4863 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.2275 20.3776 14
+      vertex 15.2275 15.6224 14
+      vertex 15.7387 15.5137 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.75 20.1651 14
+      vertex 15.2275 15.6224 14
+      vertex 15.2275 20.3776 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.75 20.1651 14
+      vertex 14.75 15.8349 14
+      vertex 15.2275 15.6224 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.3272 19.8579 14
+      vertex 14.75 15.8349 14
+      vertex 14.75 20.1651 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.3272 19.8579 14
+      vertex 14.3272 16.1421 14
+      vertex 14.75 15.8349 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.9775 19.4695 14
+      vertex 14.3272 16.1421 14
+      vertex 14.3272 19.8579 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.9775 19.4695 14
+      vertex 13.9775 16.5305 14
+      vertex 14.3272 16.1421 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.7161 19.0168 14
+      vertex 13.9775 16.5305 14
+      vertex 13.9775 19.4695 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7161 19.0168 14
+      vertex 13.7161 16.9832 14
+      vertex 13.9775 16.5305 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 13.5546 18.5198 14
+      vertex 13.7161 16.9832 14
+      vertex 13.7161 19.0168 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.5546 18.5198 14
+      vertex 13.5546 17.4802 14
+      vertex 13.7161 16.9832 14
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 13.5546 17.4802 14
+      vertex 13.5546 18.5198 14
+      vertex 13.5 18 14
+    endloop
+  endfacet
+  facet normal -0.944002 0.0992177 0.314667
+    outer loop
+      vertex 12.5765 18.7277 11
+      vertex 12.5 18 11
+      vertex 13.5546 18.5198 14
+    endloop
+  endfacet
+  facet normal -0.902745 0.29332 0.314667
+    outer loop
+      vertex 13.7161 19.0168 14
+      vertex 12.8026 19.4236 11
+      vertex 13.5546 18.5198 14
+    endloop
+  endfacet
+  facet normal -0.557928 0.767919 0.314668
+    outer loop
+      vertex 14.25 21.0311 11
+      vertex 13.658 20.601 11
+      vertex 14.75 20.1651 14
+    endloop
+  endfacet
+  facet normal -0.197354 0.928459 0.314667
+    outer loop
+      vertex 15.6341 21.4808 11
+      vertex 15.2275 20.3776 14
+      vertex 15.7387 20.4863 14
+    endloop
+  endfacet
+  facet normal 0.705393 0.635142 0.314668
+    outer loop
+      vertex 18.342 20.601 11
+      vertex 17.6728 19.8579 14
+      vertex 18.0225 19.4695 14
+    endloop
+  endfacet
+  facet normal 0.557928 0.767919 0.314668
+    outer loop
+      vertex 18.342 20.601 11
+      vertex 17.25 20.1651 14
+      vertex 17.6728 19.8579 14
+    endloop
+  endfacet
+  facet normal 0.902744 0.293322 0.314667
+    outer loop
+      vertex 19.1974 19.4236 11
+      vertex 18.2839 19.0168 14
+      vertex 18.4454 18.5198 14
+    endloop
+  endfacet
+  facet normal 0.822033 0.474601 0.314667
+    outer loop
+      vertex 18.8316 20.0572 11
+      vertex 18.2839 19.0168 14
+      vertex 19.1974 19.4236 11
+    endloop
+  endfacet
+  facet normal -0.705394 -0.63514 0.314668
+    outer loop
+      vertex 13.9775 16.5305 14
+      vertex 13.658 15.399 11
+      vertex 14.3272 16.1421 14
+    endloop
+  endfacet
+  facet normal -0.557927 -0.76792 0.314668
+    outer loop
+      vertex 14.3272 16.1421 14
+      vertex 13.658 15.399 11
+      vertex 14.75 15.8349 14
+    endloop
+  endfacet
+  facet normal -0.902745 -0.29332 0.314667
+    outer loop
+      vertex 13.5546 17.4802 14
+      vertex 12.8026 16.5764 11
+      vertex 13.7161 16.9832 14
+    endloop
+  endfacet
+  facet normal -0.822033 -0.4746 0.314667
+    outer loop
+      vertex 13.7161 16.9832 14
+      vertex 12.8026 16.5764 11
+      vertex 13.1684 15.9428 11
+    endloop
+  endfacet
+  facet normal 0 -0.949202 0.314667
+    outer loop
+      vertex 15.6341 14.5192 11
+      vertex 16.2613 15.5137 14
+      vertex 15.7387 15.5137 14
+    endloop
+  endfacet
+  facet normal 0 -0.949202 0.314667
+    outer loop
+      vertex 16.2613 15.5137 14
+      vertex 15.6341 14.5192 11
+      vertex 16.3658 14.5192 11
+    endloop
+  endfacet
+  facet normal 0.557928 -0.767919 0.314668
+    outer loop
+      vertex 17.6728 16.1421 14
+      vertex 17.25 15.8349 14
+      vertex 18.342 15.399 11
+    endloop
+  endfacet
+  facet normal 0.705394 -0.63514 0.314668
+    outer loop
+      vertex 18.0225 16.5305 14
+      vertex 17.6728 16.1421 14
+      vertex 18.342 15.399 11
+    endloop
+  endfacet
+  facet normal 0.197351 -0.92846 0.314667
+    outer loop
+      vertex 16.7725 15.6224 14
+      vertex 16.3658 14.5192 11
+      vertex 17.0816 14.6713 11
+    endloop
+  endfacet
+  facet normal 0.386074 -0.86714 0.314667
+    outer loop
+      vertex 17.75 14.9689 11
+      vertex 16.7725 15.6224 14
+      vertex 17.0816 14.6713 11
+    endloop
+  endfacet
+  facet normal 0.902744 -0.293322 0.314667
+    outer loop
+      vertex 18.4454 17.4802 14
+      vertex 18.2839 16.9832 14
+      vertex 19.1974 16.5764 11
+    endloop
+  endfacet
+  facet normal -0.944002 0.0992173 0.314667
+    outer loop
+      vertex 13.5546 18.5198 14
+      vertex 12.5 18 11
+      vertex 13.5 18 14
+    endloop
+  endfacet
+  facet normal -0.822033 0.474601 0.314667
+    outer loop
+      vertex 13.1684 20.0572 11
+      vertex 12.8026 19.4236 11
+      vertex 13.7161 19.0168 14
+    endloop
+  endfacet
+  facet normal -0.902744 0.293321 0.314667
+    outer loop
+      vertex 12.8026 19.4236 11
+      vertex 12.5765 18.7277 11
+      vertex 13.5546 18.5198 14
+    endloop
+  endfacet
+  facet normal -0.557927 0.767921 0.314668
+    outer loop
+      vertex 14.75 20.1651 14
+      vertex 13.658 20.601 11
+      vertex 14.3272 19.8579 14
+    endloop
+  endfacet
+  facet normal -0.705393 0.635142 0.314668
+    outer loop
+      vertex 14.3272 19.8579 14
+      vertex 13.658 20.601 11
+      vertex 13.9775 19.4695 14
+    endloop
+  endfacet
+  facet normal -0.197352 0.928459 0.314668
+    outer loop
+      vertex 15.6341 21.4808 11
+      vertex 14.9184 21.3287 11
+      vertex 15.2275 20.3776 14
+    endloop
+  endfacet
+  facet normal -0.386074 0.86714 0.314668
+    outer loop
+      vertex 14.9184 21.3287 11
+      vertex 14.25 21.0311 11
+      vertex 15.2275 20.3776 14
+    endloop
+  endfacet
+  facet normal 0.197355 0.928459 0.314667
+    outer loop
+      vertex 16.3658 21.4808 11
+      vertex 16.2613 20.4863 14
+      vertex 16.7725 20.3776 14
+    endloop
+  endfacet
+  facet normal -0.197351 -0.92846 0.314667
+    outer loop
+      vertex 15.7387 15.5137 14
+      vertex 15.2275 15.6224 14
+      vertex 15.6341 14.5192 11
+    endloop
+  endfacet
+  facet normal -0.822033 0.474601 0.314667
+    outer loop
+      vertex 13.9775 19.4695 14
+      vertex 13.1684 20.0572 11
+      vertex 13.7161 19.0168 14
+    endloop
+  endfacet
+  facet normal 0.994522 0.104529 0
+    outer loop
+      vertex 15.5 5 11
+      vertex 15.4235 5.72769 2
+      vertex 15.4235 5.72769 11
+    endloop
+  endfacet
+  facet normal 0.994522 0.104529 0
+    outer loop
+      vertex 15.4235 5.72769 2
+      vertex 15.5 5 11
+      vertex 15.5 5 2
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 12.3658 8.48083 2
+      vertex 11.6341 8.48083 11
+      vertex 12.3658 8.48083 11
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.6341 8.48083 11
+      vertex 12.3658 8.48083 2
+      vertex 11.6341 8.48083 2
+    endloop
+  endfacet
+  facet normal 0.587786 0.809017 -0
+    outer loop
+      vertex 14.342 7.60101 2
+      vertex 13.75 8.03109 11
+      vertex 14.342 7.60101 11
+    endloop
+  endfacet
+  facet normal 0.587786 0.809017 0
+    outer loop
+      vertex 13.75 8.03109 11
+      vertex 14.342 7.60101 2
+      vertex 13.75 8.03109 2
+    endloop
+  endfacet
+  facet normal -0.743145 0.66913 0
+    outer loop
+      vertex 9.16844 7.05725 2
+      vertex 9.65804 7.60101 11
+      vertex 9.65804 7.60101 2
+    endloop
+  endfacet
+  facet normal -0.743145 0.66913 0
+    outer loop
+      vertex 9.65804 7.60101 11
+      vertex 9.16844 7.05725 2
+      vertex 9.16844 7.05725 11
+    endloop
+  endfacet
+  facet normal -0.406736 0.913546 0
+    outer loop
+      vertex 10.9184 8.3287 2
+      vertex 10.25 8.03109 11
+      vertex 10.9184 8.3287 11
+    endloop
+  endfacet
+  facet normal -0.406736 0.913546 0
+    outer loop
+      vertex 10.25 8.03109 11
+      vertex 10.9184 8.3287 2
+      vertex 10.25 8.03109 2
+    endloop
+  endfacet
+  facet normal 0.866026 0.499999 0
+    outer loop
+      vertex 15.1974 6.42358 11
+      vertex 14.8316 7.05725 2
+      vertex 14.8316 7.05725 11
+    endloop
+  endfacet
+  facet normal 0.866026 0.499999 0
+    outer loop
+      vertex 14.8316 7.05725 2
+      vertex 15.1974 6.42358 11
+      vertex 15.1974 6.42358 2
+    endloop
+  endfacet
+  facet normal 0.951056 0.309017 0
+    outer loop
+      vertex 15.4235 5.72769 11
+      vertex 15.1974 6.42358 2
+      vertex 15.1974 6.42358 11
+    endloop
+  endfacet
+  facet normal 0.951056 0.309017 0
+    outer loop
+      vertex 15.1974 6.42358 2
+      vertex 15.4235 5.72769 11
+      vertex 15.4235 5.72769 2
+    endloop
+  endfacet
+  facet normal 0.743145 0.66913 0
+    outer loop
+      vertex 14.8316 7.05725 11
+      vertex 14.342 7.60101 2
+      vertex 14.342 7.60101 11
+    endloop
+  endfacet
+  facet normal 0.743145 0.66913 0
+    outer loop
+      vertex 14.342 7.60101 2
+      vertex 14.8316 7.05725 11
+      vertex 14.8316 7.05725 2
+    endloop
+  endfacet
+  facet normal 0.207912 0.978147 -0
+    outer loop
+      vertex 13.0816 8.3287 2
+      vertex 12.3658 8.48083 11
+      vertex 13.0816 8.3287 11
+    endloop
+  endfacet
+  facet normal 0.207912 0.978147 0
+    outer loop
+      vertex 12.3658 8.48083 11
+      vertex 13.0816 8.3287 2
+      vertex 12.3658 8.48083 2
+    endloop
+  endfacet
+  facet normal 0.406736 0.913546 -0
+    outer loop
+      vertex 13.75 8.03109 2
+      vertex 13.0816 8.3287 11
+      vertex 13.75 8.03109 11
+    endloop
+  endfacet
+  facet normal 0.406736 0.913546 0
+    outer loop
+      vertex 13.0816 8.3287 11
+      vertex 13.75 8.03109 2
+      vertex 13.0816 8.3287 2
+    endloop
+  endfacet
+  facet normal -0.951056 0.309017 0
+    outer loop
+      vertex 8.57648 5.72769 2
+      vertex 8.80259 6.42358 11
+      vertex 8.80259 6.42358 2
+    endloop
+  endfacet
+  facet normal -0.951056 0.309017 0
+    outer loop
+      vertex 8.80259 6.42358 11
+      vertex 8.57648 5.72769 2
+      vertex 8.57648 5.72769 11
+    endloop
+  endfacet
+  facet normal -0.866026 0.499999 0
+    outer loop
+      vertex 8.80259 6.42358 2
+      vertex 9.16844 7.05725 11
+      vertex 9.16844 7.05725 2
+    endloop
+  endfacet
+  facet normal -0.866026 0.499999 0
+    outer loop
+      vertex 9.16844 7.05725 11
+      vertex 8.80259 6.42358 2
+      vertex 8.80259 6.42358 11
+    endloop
+  endfacet
+  facet normal -0.994522 0.104528 0
+    outer loop
+      vertex 8.5 5 2
+      vertex 8.57648 5.72769 11
+      vertex 8.57648 5.72769 2
+    endloop
+  endfacet
+  facet normal -0.994522 0.104528 0
+    outer loop
+      vertex 8.57648 5.72769 11
+      vertex 8.5 5 2
+      vertex 8.5 5 11
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex 10.25 8.03109 2
+      vertex 9.65804 7.60101 11
+      vertex 10.25 8.03109 11
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 0
+    outer loop
+      vertex 9.65804 7.60101 11
+      vertex 10.25 8.03109 2
+      vertex 9.65804 7.60101 2
+    endloop
+  endfacet
+  facet normal -0.207912 0.978147 0
+    outer loop
+      vertex 11.6341 8.48083 2
+      vertex 10.9184 8.3287 11
+      vertex 11.6341 8.48083 11
+    endloop
+  endfacet
+  facet normal -0.207912 0.978147 0
+    outer loop
+      vertex 10.9184 8.3287 11
+      vertex 11.6341 8.48083 2
+      vertex 10.9184 8.3287 2
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104529 0
+    outer loop
+      vertex 15.4235 4.27231 11
+      vertex 15.5 5 2
+      vertex 15.5 5 11
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104529 0
+    outer loop
+      vertex 15.5 5 2
+      vertex 15.4235 4.27231 11
+      vertex 15.4235 4.27231 2
+    endloop
+  endfacet
+  facet normal 0.207912 -0.978147 0
+    outer loop
+      vertex 12.3658 1.51917 2
+      vertex 13.0816 1.6713 11
+      vertex 12.3658 1.51917 11
+    endloop
+  endfacet
+  facet normal 0.207912 -0.978147 0
+    outer loop
+      vertex 13.0816 1.6713 11
+      vertex 12.3658 1.51917 2
+      vertex 13.0816 1.6713 2
+    endloop
+  endfacet
+  facet normal 0.587786 -0.809017 0
+    outer loop
+      vertex 13.75 1.96891 2
+      vertex 14.342 2.39899 11
+      vertex 13.75 1.96891 11
+    endloop
+  endfacet
+  facet normal 0.587786 -0.809017 0
+    outer loop
+      vertex 14.342 2.39899 11
+      vertex 13.75 1.96891 2
+      vertex 14.342 2.39899 2
+    endloop
+  endfacet
+  facet normal -0.406736 -0.913546 0
+    outer loop
+      vertex 10.25 1.96891 2
+      vertex 10.9184 1.6713 11
+      vertex 10.25 1.96891 11
+    endloop
+  endfacet
+  facet normal -0.406736 -0.913546 -0
+    outer loop
+      vertex 10.9184 1.6713 11
+      vertex 10.25 1.96891 2
+      vertex 10.9184 1.6713 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 11.6341 1.51917 2
+      vertex 12.3658 1.51917 11
+      vertex 11.6341 1.51917 11
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 12.3658 1.51917 11
+      vertex 11.6341 1.51917 2
+      vertex 12.3658 1.51917 2
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex 9.65804 2.39899 2
+      vertex 9.16844 2.94275 11
+      vertex 9.16844 2.94275 2
+    endloop
+  endfacet
+  facet normal -0.743145 -0.66913 0
+    outer loop
+      vertex 9.16844 2.94275 11
+      vertex 9.65804 2.39899 2
+      vertex 9.65804 2.39899 11
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309017 0
+    outer loop
+      vertex 8.80259 3.57642 2
+      vertex 8.57648 4.27231 11
+      vertex 8.57648 4.27231 2
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309017 0
+    outer loop
+      vertex 8.57648 4.27231 11
+      vertex 8.80259 3.57642 2
+      vertex 8.80259 3.57642 11
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104528 0
+    outer loop
+      vertex 8.57648 4.27231 2
+      vertex 8.5 5 11
+      vertex 8.5 5 2
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104528 0
+    outer loop
+      vertex 8.5 5 11
+      vertex 8.57648 4.27231 2
+      vertex 8.57648 4.27231 11
+    endloop
+  endfacet
+  facet normal 0.406736 -0.913546 0
+    outer loop
+      vertex 13.0816 1.6713 2
+      vertex 13.75 1.96891 11
+      vertex 13.0816 1.6713 11
+    endloop
+  endfacet
+  facet normal 0.406736 -0.913546 0
+    outer loop
+      vertex 13.75 1.96891 11
+      vertex 13.0816 1.6713 2
+      vertex 13.75 1.96891 2
+    endloop
+  endfacet
+  facet normal 0.743145 -0.66913 0
+    outer loop
+      vertex 14.342 2.39899 11
+      vertex 14.8316 2.94275 2
+      vertex 14.8316 2.94275 11
+    endloop
+  endfacet
+  facet normal 0.743145 -0.66913 0
+    outer loop
+      vertex 14.8316 2.94275 2
+      vertex 14.342 2.39899 11
+      vertex 14.342 2.39899 2
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309017 0
+    outer loop
+      vertex 15.1974 3.57642 11
+      vertex 15.4235 4.27231 2
+      vertex 15.4235 4.27231 11
+    endloop
+  endfacet
+  facet normal 0.951056 -0.309017 0
+    outer loop
+      vertex 15.4235 4.27231 2
+      vertex 15.1974 3.57642 11
+      vertex 15.1974 3.57642 2
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499999 0
+    outer loop
+      vertex 14.8316 2.94275 11
+      vertex 15.1974 3.57642 2
+      vertex 15.1974 3.57642 11
+    endloop
+  endfacet
+  facet normal 0.866026 -0.499999 0
+    outer loop
+      vertex 15.1974 3.57642 2
+      vertex 14.8316 2.94275 11
+      vertex 14.8316 2.94275 2
+    endloop
+  endfacet
+  facet normal -0.207912 -0.978147 0
+    outer loop
+      vertex 10.9184 1.6713 2
+      vertex 11.6341 1.51917 11
+      vertex 10.9184 1.6713 11
+    endloop
+  endfacet
+  facet normal -0.207912 -0.978147 -0
+    outer loop
+      vertex 11.6341 1.51917 11
+      vertex 10.9184 1.6713 2
+      vertex 11.6341 1.51917 2
+    endloop
+  endfacet
+  facet normal -0.587786 -0.809017 0
+    outer loop
+      vertex 9.65804 2.39899 2
+      vertex 10.25 1.96891 11
+      vertex 9.65804 2.39899 11
+    endloop
+  endfacet
+  facet normal -0.587786 -0.809017 -0
+    outer loop
+      vertex 10.25 1.96891 11
+      vertex 9.65804 2.39899 2
+      vertex 10.25 1.96891 2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 0
+    outer loop
+      vertex 9.16844 2.94275 2
+      vertex 8.80259 3.57642 11
+      vertex 8.80259 3.57642 2
+    endloop
+  endfacet
+  facet normal -0.866026 -0.499999 0
+    outer loop
+      vertex 8.80259 3.57642 11
+      vertex 9.16844 2.94275 2
+      vertex 9.16844 2.94275 11
+    endloop
+  endfacet
+  facet normal 0.944002 0.0992191 0.314667
+    outer loop
+      vertex 15.5 5 11
+      vertex 14.4454 5.51978 14
+      vertex 14.5 5 14
+    endloop
+  endfacet
+  facet normal 0.944002 0.0992191 0.314667
+    outer loop
+      vertex 15.4235 5.72769 11
+      vertex 14.4454 5.51978 14
+      vertex 15.5 5 11
+    endloop
+  endfacet
+  facet normal -0.944002 -0.0992177 0.314667
+    outer loop
+      vertex 9.55463 4.48022 14
+      vertex 8.5 5 11
+      vertex 8.57648 4.27231 11
+    endloop
+  endfacet
+  facet normal 0.902744 0.29332 0.314667
+    outer loop
+      vertex 15.1974 6.42358 11
+      vertex 14.2839 6.01684 14
+      vertex 14.4454 5.51978 14
+    endloop
+  endfacet
+  facet normal 0 0.949202 0.314667
+    outer loop
+      vertex 12.3658 8.48083 11
+      vertex 11.7387 7.4863 14
+      vertex 12.2613 7.4863 14
+    endloop
+  endfacet
+  facet normal 0 0.949202 0.314667
+    outer loop
+      vertex 11.7387 7.4863 14
+      vertex 12.3658 8.48083 11
+      vertex 11.6341 8.48083 11
+    endloop
+  endfacet
+  facet normal -0.902744 -0.29332 0.314667
+    outer loop
+      vertex 9.55463 4.48022 14
+      vertex 8.80259 3.57642 11
+      vertex 9.71614 3.98316 14
+    endloop
+  endfacet
+  facet normal 0.557927 0.76792 0.314667
+    outer loop
+      vertex 13.75 8.03109 11
+      vertex 13.25 7.16506 14
+      vertex 14.342 7.60101 11
+    endloop
+  endfacet
+  facet normal -0.557927 -0.76792 0.314667
+    outer loop
+      vertex 10.75 2.83494 14
+      vertex 9.65804 2.39899 11
+      vertex 10.25 1.96891 11
+    endloop
+  endfacet
+  facet normal 0 -0.949202 0.314667
+    outer loop
+      vertex 11.6341 1.51917 11
+      vertex 12.2613 2.51369 14
+      vertex 11.7387 2.51369 14
+    endloop
+  endfacet
+  facet normal 0 -0.949202 0.314667
+    outer loop
+      vertex 12.2613 2.51369 14
+      vertex 11.6341 1.51917 11
+      vertex 12.3658 1.51917 11
+    endloop
+  endfacet
+  facet normal 0.705394 -0.63514 0.314668
+    outer loop
+      vertex 14.0225 3.53054 14
+      vertex 13.6728 3.14214 14
+      vertex 14.342 2.39899 11
+    endloop
+  endfacet
+  facet normal 0.902744 -0.29332 0.314667
+    outer loop
+      vertex 14.4454 4.48022 14
+      vertex 14.2839 3.98316 14
+      vertex 15.1974 3.57642 11
+    endloop
+  endfacet
+  facet normal 0.902745 -0.29332 0.314667
+    outer loop
+      vertex 15.4235 4.27231 11
+      vertex 14.4454 4.48022 14
+      vertex 15.1974 3.57642 11
+    endloop
+  endfacet
+  facet normal 0.822033 0.4746 0.314667
+    outer loop
+      vertex 14.8316 7.05725 11
+      vertex 14.2839 6.01684 14
+      vertex 15.1974 6.42358 11
+    endloop
+  endfacet
+  facet normal 0.902745 0.29332 0.314667
+    outer loop
+      vertex 15.1974 6.42358 11
+      vertex 14.4454 5.51978 14
+      vertex 15.4235 5.72769 11
+    endloop
+  endfacet
+  facet normal -0.705395 0.63514 0.314668
+    outer loop
+      vertex 9.65804 7.60101 11
+      vertex 9.16844 7.05725 11
+      vertex 9.97746 6.46946 14
+    endloop
+  endfacet
+  facet normal -0.944002 0.0992173 0.314667
+    outer loop
+      vertex 9.55463 5.51978 14
+      vertex 8.5 5 11
+      vertex 9.5 5 14
+    endloop
+  endfacet
+  facet normal -0.197351 0.92846 0.314667
+    outer loop
+      vertex 11.6341 8.48083 11
+      vertex 10.9184 8.3287 11
+      vertex 11.2275 7.37764 14
+    endloop
+  endfacet
+  facet normal 0.705395 0.63514 0.314668
+    outer loop
+      vertex 14.342 7.60101 11
+      vertex 14.0225 6.46946 14
+      vertex 14.8316 7.05725 11
+    endloop
+  endfacet
+  facet normal 0.386075 0.867139 0.314667
+    outer loop
+      vertex 13.0816 8.3287 11
+      vertex 12.7725 7.37764 14
+      vertex 13.75 8.03109 11
+    endloop
+  endfacet
+  facet normal -0.822033 -0.4746 0.314667
+    outer loop
+      vertex 9.71614 3.98316 14
+      vertex 8.80259 3.57642 11
+      vertex 9.16844 2.94275 11
+    endloop
+  endfacet
+  facet normal -0.902745 -0.29332 0.314667
+    outer loop
+      vertex 9.55463 4.48022 14
+      vertex 8.57648 4.27231 11
+      vertex 8.80259 3.57642 11
+    endloop
+  endfacet
+  facet normal -0.705395 -0.63514 0.314668
+    outer loop
+      vertex 9.97746 3.53054 14
+      vertex 9.16844 2.94275 11
+      vertex 9.65804 2.39899 11
+    endloop
+  endfacet
+  facet normal -0.386075 -0.867139 0.314667
+    outer loop
+      vertex 11.2275 2.62236 14
+      vertex 10.25 1.96891 11
+      vertex 10.9184 1.6713 11
+    endloop
+  endfacet
+  facet normal 0.197351 -0.92846 0.314667
+    outer loop
+      vertex 12.7725 2.62236 14
+      vertex 12.3658 1.51917 11
+      vertex 13.0816 1.6713 11
+    endloop
+  endfacet
+  facet normal 0.386075 -0.867139 0.314668
+    outer loop
+      vertex 13.25 2.83494 14
+      vertex 12.7725 2.62236 14
+      vertex 13.75 1.96891 11
+    endloop
+  endfacet
+  facet normal 0.386075 -0.867139 0.314667
+    outer loop
+      vertex 13.75 1.96891 11
+      vertex 12.7725 2.62236 14
+      vertex 13.0816 1.6713 11
+    endloop
+  endfacet
+  facet normal 0.557927 -0.76792 0.314667
+    outer loop
+      vertex 14.342 2.39899 11
+      vertex 13.25 2.83494 14
+      vertex 13.75 1.96891 11
+    endloop
+  endfacet
+  facet normal 0.705395 -0.63514 0.314668
+    outer loop
+      vertex 14.8316 2.94275 11
+      vertex 14.0225 3.53054 14
+      vertex 14.342 2.39899 11
+    endloop
+  endfacet
+  facet normal 0.944002 -0.099219 0.314667
+    outer loop
+      vertex 15.5 5 11
+      vertex 14.4454 4.48022 14
+      vertex 15.4235 4.27231 11
+    endloop
+  endfacet
+  facet normal 0.944002 -0.0992189 0.314667
+    outer loop
+      vertex 14.5 5 14
+      vertex 14.4454 4.48022 14
+      vertex 15.5 5 11
+    endloop
+  endfacet
+  facet normal -0.944002 0.0992179 0.314667
+    outer loop
+      vertex 8.57648 5.72769 11
+      vertex 8.5 5 11
+      vertex 9.55463 5.51978 14
+    endloop
+  endfacet
+  facet normal -0.902744 0.29332 0.314667
+    outer loop
+      vertex 9.71614 6.01684 14
+      vertex 8.80259 6.42358 11
+      vertex 9.55463 5.51978 14
+    endloop
+  endfacet
+  facet normal -0.557927 0.767921 0.314668
+    outer loop
+      vertex 10.25 8.03109 11
+      vertex 9.65804 7.60101 11
+      vertex 10.75 7.16506 14
+    endloop
+  endfacet
+  facet normal -0.386075 0.867139 0.314667
+    outer loop
+      vertex 10.9184 8.3287 11
+      vertex 10.25 8.03109 11
+      vertex 11.2275 7.37764 14
+    endloop
+  endfacet
+  facet normal -0.386076 0.867139 0.314668
+    outer loop
+      vertex 11.2275 7.37764 14
+      vertex 10.25 8.03109 11
+      vertex 10.75 7.16506 14
+    endloop
+  endfacet
+  facet normal 0.822033 0.474601 0.314668
+    outer loop
+      vertex 14.8316 7.05725 11
+      vertex 14.0225 6.46946 14
+      vertex 14.2839 6.01684 14
+    endloop
+  endfacet
+  facet normal 0.705394 0.63514 0.314668
+    outer loop
+      vertex 14.342 7.60101 11
+      vertex 13.6728 6.85786 14
+      vertex 14.0225 6.46946 14
+    endloop
+  endfacet
+  facet normal 0.557927 0.76792 0.314668
+    outer loop
+      vertex 14.342 7.60101 11
+      vertex 13.25 7.16506 14
+      vertex 13.6728 6.85786 14
+    endloop
+  endfacet
+  facet normal 0.197351 0.92846 0.314667
+    outer loop
+      vertex 13.0816 8.3287 11
+      vertex 12.3658 8.48083 11
+      vertex 12.7725 7.37764 14
+    endloop
+  endfacet
+  facet normal 0.197351 0.92846 0.314667
+    outer loop
+      vertex 12.3658 8.48083 11
+      vertex 12.2613 7.4863 14
+      vertex 12.7725 7.37764 14
+    endloop
+  endfacet
+  facet normal -0.822033 -0.474601 0.314668
+    outer loop
+      vertex 9.71614 3.98316 14
+      vertex 9.16844 2.94275 11
+      vertex 9.97746 3.53054 14
+    endloop
+  endfacet
+  facet normal -0.705394 -0.63514 0.314668
+    outer loop
+      vertex 9.97746 3.53054 14
+      vertex 9.65804 2.39899 11
+      vertex 10.3272 3.14214 14
+    endloop
+  endfacet
+  facet normal -0.557927 -0.76792 0.314668
+    outer loop
+      vertex 10.3272 3.14214 14
+      vertex 9.65804 2.39899 11
+      vertex 10.75 2.83494 14
+    endloop
+  endfacet
+  facet normal -0.197351 -0.92846 0.314667
+    outer loop
+      vertex 11.2275 2.62236 14
+      vertex 10.9184 1.6713 11
+      vertex 11.6341 1.51917 11
+    endloop
+  endfacet
+  facet normal -0.197351 -0.92846 0.314667
+    outer loop
+      vertex 11.7387 2.51369 14
+      vertex 11.2275 2.62236 14
+      vertex 11.6341 1.51917 11
+    endloop
+  endfacet
+  facet normal 0.557927 -0.76792 0.314668
+    outer loop
+      vertex 13.6728 3.14214 14
+      vertex 13.25 2.83494 14
+      vertex 14.342 2.39899 11
+    endloop
+  endfacet
+  facet normal 0.197351 -0.92846 0.314667
+    outer loop
+      vertex 12.7725 2.62236 14
+      vertex 12.2613 2.51369 14
+      vertex 12.3658 1.51917 11
+    endloop
+  endfacet
+  facet normal 0.822033 -0.474601 0.314668
+    outer loop
+      vertex 14.2839 3.98316 14
+      vertex 14.0225 3.53054 14
+      vertex 14.8316 2.94275 11
+    endloop
+  endfacet
+  facet normal 0.822033 -0.4746 0.314667
+    outer loop
+      vertex 15.1974 3.57642 11
+      vertex 14.2839 3.98316 14
+      vertex 14.8316 2.94275 11
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.4454 5.51978 14
+      vertex 14.4454 4.48022 14
+      vertex 14.5 5 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.2839 6.01684 14
+      vertex 14.4454 4.48022 14
+      vertex 14.4454 5.51978 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.2839 6.01684 14
+      vertex 14.2839 3.98316 14
+      vertex 14.4454 4.48022 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.0225 6.46946 14
+      vertex 14.2839 3.98316 14
+      vertex 14.2839 6.01684 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.0225 6.46946 14
+      vertex 14.0225 3.53054 14
+      vertex 14.2839 3.98316 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6728 6.85786 14
+      vertex 14.0225 3.53054 14
+      vertex 14.0225 6.46946 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6728 6.85786 14
+      vertex 13.6728 3.14214 14
+      vertex 14.0225 3.53054 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.25 7.16506 14
+      vertex 13.6728 3.14214 14
+      vertex 13.6728 6.85786 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.25 7.16506 14
+      vertex 13.25 2.83494 14
+      vertex 13.6728 3.14214 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7725 7.37764 14
+      vertex 13.25 2.83494 14
+      vertex 13.25 7.16506 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7725 7.37764 14
+      vertex 12.7725 2.62236 14
+      vertex 13.25 2.83494 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2613 7.4863 14
+      vertex 12.7725 2.62236 14
+      vertex 12.7725 7.37764 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.2613 7.4863 14
+      vertex 12.2613 2.51369 14
+      vertex 12.7725 2.62236 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.7387 7.4863 14
+      vertex 12.2613 2.51369 14
+      vertex 12.2613 7.4863 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.7387 7.4863 14
+      vertex 11.7387 2.51369 14
+      vertex 12.2613 2.51369 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.2275 7.37764 14
+      vertex 11.7387 2.51369 14
+      vertex 11.7387 7.4863 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.2275 7.37764 14
+      vertex 11.2275 2.62236 14
+      vertex 11.7387 2.51369 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.75 7.16506 14
+      vertex 11.2275 2.62236 14
+      vertex 11.2275 7.37764 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.75 7.16506 14
+      vertex 10.75 2.83494 14
+      vertex 11.2275 2.62236 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.3272 6.85786 14
+      vertex 10.75 2.83494 14
+      vertex 10.75 7.16506 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.3272 6.85786 14
+      vertex 10.3272 3.14214 14
+      vertex 10.75 2.83494 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.97746 6.46946 14
+      vertex 10.3272 3.14214 14
+      vertex 10.3272 6.85786 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.97746 6.46946 14
+      vertex 9.97746 3.53054 14
+      vertex 10.3272 3.14214 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.71614 6.01684 14
+      vertex 9.97746 3.53054 14
+      vertex 9.97746 6.46946 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.71614 6.01684 14
+      vertex 9.71614 3.98316 14
+      vertex 9.97746 3.53054 14
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 9.55463 5.51978 14
+      vertex 9.71614 3.98316 14
+      vertex 9.71614 6.01684 14
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.55463 5.51978 14
+      vertex 9.55463 4.48022 14
+      vertex 9.71614 3.98316 14
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 9.55463 4.48022 14
+      vertex 9.55463 5.51978 14
+      vertex 9.5 5 14
+    endloop
+  endfacet
+  facet normal -0.944002 -0.0992172 0.314667
+    outer loop
+      vertex 9.5 5 14
+      vertex 8.5 5 11
+      vertex 9.55463 4.48022 14
+    endloop
+  endfacet
+  facet normal -0.822033 0.4746 0.314667
+    outer loop
+      vertex 9.16844 7.05725 11
+      vertex 8.80259 6.42358 11
+      vertex 9.71614 6.01684 14
+    endloop
+  endfacet
+  facet normal -0.902745 0.29332 0.314667
+    outer loop
+      vertex 8.80259 6.42358 11
+      vertex 8.57648 5.72769 11
+      vertex 9.55463 5.51978 14
+    endloop
+  endfacet
+  facet normal -0.557927 0.767921 0.314668
+    outer loop
+      vertex 10.75 7.16506 14
+      vertex 9.65804 7.60101 11
+      vertex 10.3272 6.85786 14
+    endloop
+  endfacet
+  facet normal -0.705394 0.63514 0.314668
+    outer loop
+      vertex 10.3272 6.85786 14
+      vertex 9.65804 7.60101 11
+      vertex 9.97746 6.46946 14
+    endloop
+  endfacet
+  facet normal -0.197351 0.92846 0.314667
+    outer loop
+      vertex 11.6341 8.48083 11
+      vertex 11.2275 7.37764 14
+      vertex 11.7387 7.4863 14
+    endloop
+  endfacet
+  facet normal 0.386075 0.867139 0.314668
+    outer loop
+      vertex 13.75 8.03109 11
+      vertex 12.7725 7.37764 14
+      vertex 13.25 7.16506 14
+    endloop
+  endfacet
+  facet normal -0.386075 -0.867139 0.314668
+    outer loop
+      vertex 10.75 2.83494 14
+      vertex 10.25 1.96891 11
+      vertex 11.2275 2.62236 14
+    endloop
+  endfacet
+  facet normal -0.822033 0.474601 0.314668
+    outer loop
+      vertex 9.97746 6.46946 14
+      vertex 9.16844 7.05725 11
+      vertex 9.71614 6.01684 14
+    endloop
+  endfacet
+  facet normal -0.994522 0 -0.104528
+    outer loop
+      vertex -0.9 22 7.5
+      vertex -0.934963 26 7.83266
+      vertex -0.9 26 7.5
+    endloop
+  endfacet
+  facet normal -0.994522 -0 -0.104528
+    outer loop
+      vertex -0.934963 26 7.83266
+      vertex -0.9 22 7.5
+      vertex -0.934963 22 7.83266
+    endloop
+  endfacet
+  facet normal -0.951056 0 -0.309018
+    outer loop
+      vertex -0.934963 22 7.83266
+      vertex -1.03833 26 8.15078
+      vertex -0.934963 26 7.83266
+    endloop
+  endfacet
+  facet normal -0.951056 -0 -0.309018
+    outer loop
+      vertex -1.03833 26 8.15078
+      vertex -0.934963 22 7.83266
+      vertex -1.03833 22 8.15078
+    endloop
+  endfacet
+  facet normal -0.587785 0 -0.809017
+    outer loop
+      vertex -1.7 22 8.88564
+      vertex -1.42939 26 8.68903
+      vertex -1.42939 22 8.68903
+    endloop
+  endfacet
+  facet normal -0.587785 0 -0.809017
+    outer loop
+      vertex -1.42939 26 8.68903
+      vertex -1.7 22 8.88564
+      vertex -1.7 26 8.88564
+    endloop
+  endfacet
+  facet normal -0.866027 0 -0.499998
+    outer loop
+      vertex -1.03833 22 8.15078
+      vertex -1.20557 26 8.44046
+      vertex -1.03833 26 8.15078
+    endloop
+  endfacet
+  facet normal -0.866027 -0 -0.499998
+    outer loop
+      vertex -1.20557 26 8.44046
+      vertex -1.03833 22 8.15078
+      vertex -1.20557 22 8.44046
+    endloop
+  endfacet
+  facet normal -0.207909 0 -0.978148
+    outer loop
+      vertex -2.33275 22 9.09123
+      vertex -2.00557 26 9.02169
+      vertex -2.00557 22 9.02169
+    endloop
+  endfacet
+  facet normal -0.207909 0 -0.978148
+    outer loop
+      vertex -2.00557 26 9.02169
+      vertex -2.33275 22 9.09123
+      vertex -2.33275 26 9.09123
+    endloop
+  endfacet
+  facet normal -0.406738 0 -0.913545
+    outer loop
+      vertex -2.00557 22 9.02169
+      vertex -1.7 26 8.88564
+      vertex -1.7 22 8.88564
+    endloop
+  endfacet
+  facet normal -0.406738 0 -0.913545
+    outer loop
+      vertex -1.7 26 8.88564
+      vertex -2.00557 22 9.02169
+      vertex -2.00557 26 9.02169
+    endloop
+  endfacet
+  facet normal -0.994522 0 0.104528
+    outer loop
+      vertex -0.934963 22 7.16734
+      vertex -0.9 26 7.5
+      vertex -0.934963 26 7.16734
+    endloop
+  endfacet
+  facet normal -0.994522 0 0.104528
+    outer loop
+      vertex -0.9 26 7.5
+      vertex -0.934963 22 7.16734
+      vertex -0.9 22 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.5 26 5.90876
+      vertex -2.33275 22 5.90876
+      vertex -2.33275 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.33275 22 5.90876
+      vertex -2.5 26 5.90876
+      vertex -2.5 22 5.90876
+    endloop
+  endfacet
+  facet normal -0.207909 0 0.978148
+    outer loop
+      vertex -2.33275 26 5.90876
+      vertex -2.00557 22 5.97831
+      vertex -2.00557 26 5.97831
+    endloop
+  endfacet
+  facet normal -0.207909 0 0.978148
+    outer loop
+      vertex -2.00557 22 5.97831
+      vertex -2.33275 26 5.90876
+      vertex -2.33275 22 5.90876
+    endloop
+  endfacet
+  facet normal -0.743144 0 0.669132
+    outer loop
+      vertex -1.42939 22 6.31097
+      vertex -1.20557 26 6.55954
+      vertex -1.42939 26 6.31097
+    endloop
+  endfacet
+  facet normal -0.743144 0 0.669132
+    outer loop
+      vertex -1.20557 26 6.55954
+      vertex -1.42939 22 6.31097
+      vertex -1.20557 22 6.55954
+    endloop
+  endfacet
+  facet normal -0.587785 0 0.809017
+    outer loop
+      vertex -1.7 26 6.11436
+      vertex -1.42939 22 6.31097
+      vertex -1.42939 26 6.31097
+    endloop
+  endfacet
+  facet normal -0.587785 0 0.809017
+    outer loop
+      vertex -1.42939 22 6.31097
+      vertex -1.7 26 6.11436
+      vertex -1.7 22 6.11436
+    endloop
+  endfacet
+  facet normal -0.743144 0 -0.669132
+    outer loop
+      vertex -1.20557 22 8.44046
+      vertex -1.42939 26 8.68903
+      vertex -1.20557 26 8.44046
+    endloop
+  endfacet
+  facet normal -0.743144 -0 -0.669132
+    outer loop
+      vertex -1.42939 26 8.68903
+      vertex -1.20557 22 8.44046
+      vertex -1.42939 22 8.68903
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.5 22 9.09123
+      vertex -2.33275 26 9.09123
+      vertex -2.33275 22 9.09123
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.33275 26 9.09123
+      vertex -2.5 22 9.09123
+      vertex -2.5 26 9.09123
+    endloop
+  endfacet
+  facet normal -0.866027 0 0.499998
+    outer loop
+      vertex -1.20557 22 6.55954
+      vertex -1.03833 26 6.84922
+      vertex -1.20557 26 6.55954
+    endloop
+  endfacet
+  facet normal -0.866027 0 0.499998
+    outer loop
+      vertex -1.03833 26 6.84922
+      vertex -1.20557 22 6.55954
+      vertex -1.03833 22 6.84922
+    endloop
+  endfacet
+  facet normal -0.406738 0 0.913545
+    outer loop
+      vertex -2.00557 26 5.97831
+      vertex -1.7 22 6.11436
+      vertex -1.7 26 6.11436
+    endloop
+  endfacet
+  facet normal -0.406738 0 0.913545
+    outer loop
+      vertex -1.7 22 6.11436
+      vertex -2.00557 26 5.97831
+      vertex -2.00557 22 5.97831
+    endloop
+  endfacet
+  facet normal -0.951056 0 0.309018
+    outer loop
+      vertex -1.03833 22 6.84922
+      vertex -0.934963 26 7.16734
+      vertex -1.03833 26 6.84922
+    endloop
+  endfacet
+  facet normal -0.951056 0 0.309018
+    outer loop
+      vertex -0.934963 26 7.16734
+      vertex -1.03833 22 6.84922
+      vertex -0.934963 22 7.16734
+    endloop
+  endfacet
+  facet normal 0.951056 0 -0.309018
+    outer loop
+      vertex -6.96167 22 8.15078
+      vertex -7.06504 26 7.83266
+      vertex -6.96167 26 8.15078
+    endloop
+  endfacet
+  facet normal 0.951056 0 -0.309018
+    outer loop
+      vertex -7.06504 26 7.83266
+      vertex -6.96167 22 8.15078
+      vertex -7.06504 22 7.83266
+    endloop
+  endfacet
+  facet normal 0.743144 0 -0.669132
+    outer loop
+      vertex -6.57061 22 8.68903
+      vertex -6.79443 26 8.44046
+      vertex -6.57061 26 8.68903
+    endloop
+  endfacet
+  facet normal 0.743144 0 -0.669132
+    outer loop
+      vertex -6.79443 26 8.44046
+      vertex -6.57061 22 8.68903
+      vertex -6.79443 22 8.44046
+    endloop
+  endfacet
+  facet normal 0.207909 0 -0.978148
+    outer loop
+      vertex -5.99443 22 9.02169
+      vertex -5.66724 26 9.09123
+      vertex -5.66724 22 9.09123
+    endloop
+  endfacet
+  facet normal 0.207909 0 -0.978148
+    outer loop
+      vertex -5.66724 26 9.09123
+      vertex -5.99443 22 9.02169
+      vertex -5.99443 26 9.02169
+    endloop
+  endfacet
+  facet normal 0.994522 -0 0.104528
+    outer loop
+      vertex -7.1 22 7.5
+      vertex -7.06504 26 7.16734
+      vertex -7.1 26 7.5
+    endloop
+  endfacet
+  facet normal 0.994522 0 0.104528
+    outer loop
+      vertex -7.06504 26 7.16734
+      vertex -7.1 22 7.5
+      vertex -7.06504 22 7.16734
+    endloop
+  endfacet
+  facet normal 0.866027 0 -0.499998
+    outer loop
+      vertex -6.79443 22 8.44046
+      vertex -6.96167 26 8.15078
+      vertex -6.79443 26 8.44046
+    endloop
+  endfacet
+  facet normal 0.866027 0 -0.499998
+    outer loop
+      vertex -6.96167 26 8.15078
+      vertex -6.79443 22 8.44046
+      vertex -6.96167 22 8.15078
+    endloop
+  endfacet
+  facet normal 0.743144 -0 0.669132
+    outer loop
+      vertex -6.79443 22 6.55954
+      vertex -6.57061 26 6.31097
+      vertex -6.79443 26 6.55954
+    endloop
+  endfacet
+  facet normal 0.743144 0 0.669132
+    outer loop
+      vertex -6.57061 26 6.31097
+      vertex -6.79443 22 6.55954
+      vertex -6.57061 22 6.31097
+    endloop
+  endfacet
+  facet normal 0.866027 -0 0.499998
+    outer loop
+      vertex -6.96167 22 6.84922
+      vertex -6.79443 26 6.55954
+      vertex -6.96167 26 6.84922
+    endloop
+  endfacet
+  facet normal 0.866027 0 0.499998
+    outer loop
+      vertex -6.79443 26 6.55954
+      vertex -6.96167 22 6.84922
+      vertex -6.79443 22 6.55954
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.66724 22 9.09123
+      vertex -5.5 26 9.09123
+      vertex -5.5 22 9.09123
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.5 26 9.09123
+      vertex -5.66724 22 9.09123
+      vertex -5.66724 26 9.09123
+    endloop
+  endfacet
+  facet normal 0.994522 0 -0.104528
+    outer loop
+      vertex -7.06504 22 7.83266
+      vertex -7.1 26 7.5
+      vertex -7.06504 26 7.83266
+    endloop
+  endfacet
+  facet normal 0.994522 0 -0.104528
+    outer loop
+      vertex -7.1 26 7.5
+      vertex -7.06504 22 7.83266
+      vertex -7.1 22 7.5
+    endloop
+  endfacet
+  facet normal 0.406738 0 -0.913545
+    outer loop
+      vertex -6.3 22 8.88564
+      vertex -5.99443 26 9.02169
+      vertex -5.99443 22 9.02169
+    endloop
+  endfacet
+  facet normal 0.406738 0 -0.913545
+    outer loop
+      vertex -5.99443 26 9.02169
+      vertex -6.3 22 8.88564
+      vertex -6.3 26 8.88564
+    endloop
+  endfacet
+  facet normal 0.587785 0 -0.809017
+    outer loop
+      vertex -6.57061 22 8.68903
+      vertex -6.3 26 8.88564
+      vertex -6.3 22 8.88564
+    endloop
+  endfacet
+  facet normal 0.587785 0 -0.809017
+    outer loop
+      vertex -6.3 26 8.88564
+      vertex -6.57061 22 8.68903
+      vertex -6.57061 26 8.68903
+    endloop
+  endfacet
+  facet normal 0.951056 -0 0.309018
+    outer loop
+      vertex -7.06504 22 7.16734
+      vertex -6.96167 26 6.84922
+      vertex -7.06504 26 7.16734
+    endloop
+  endfacet
+  facet normal 0.951056 0 0.309018
+    outer loop
+      vertex -6.96167 26 6.84922
+      vertex -7.06504 22 7.16734
+      vertex -6.96167 22 6.84922
+    endloop
+  endfacet
+  facet normal 0.406738 0 0.913545
+    outer loop
+      vertex -6.3 26 6.11436
+      vertex -5.99443 22 5.97831
+      vertex -5.99443 26 5.97831
+    endloop
+  endfacet
+  facet normal 0.406738 0 0.913545
+    outer loop
+      vertex -5.99443 22 5.97831
+      vertex -6.3 26 6.11436
+      vertex -6.3 22 6.11436
+    endloop
+  endfacet
+  facet normal 0.587785 0 0.809017
+    outer loop
+      vertex -6.57061 26 6.31097
+      vertex -6.3 22 6.11436
+      vertex -6.3 26 6.11436
+    endloop
+  endfacet
+  facet normal 0.587785 0 0.809017
+    outer loop
+      vertex -6.3 22 6.11436
+      vertex -6.57061 26 6.31097
+      vertex -6.57061 22 6.31097
+    endloop
+  endfacet
+  facet normal 0.207909 0 0.978148
+    outer loop
+      vertex -5.99443 26 5.97831
+      vertex -5.66724 22 5.90876
+      vertex -5.66724 26 5.90876
+    endloop
+  endfacet
+  facet normal 0.207909 0 0.978148
+    outer loop
+      vertex -5.66724 22 5.90876
+      vertex -5.99443 26 5.97831
+      vertex -5.99443 22 5.97831
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.66724 26 5.90876
+      vertex -5.5 22 5.90876
+      vertex -5.5 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 22 5.90876
+      vertex -5.66724 26 5.90876
+      vertex -5.66724 22 5.90876
+    endloop
+  endfacet
+  facet normal -0.994522 0 -0.104529
+    outer loop
+      vertex 0.5 15 7.5
+      vertex 0.434443 22 8.12373
+      vertex 0.5 22 7.5
+    endloop
+  endfacet
+  facet normal -0.994522 -0 -0.104529
+    outer loop
+      vertex 0.434443 22 8.12373
+      vertex 0.5 15 7.5
+      vertex 0.434443 15 8.12373
+    endloop
+  endfacet
+  facet normal -0.951056 0 -0.309017
+    outer loop
+      vertex 0.434443 15 8.12373
+      vertex 0.240636 22 8.72021
+      vertex 0.434443 22 8.12373
+    endloop
+  endfacet
+  facet normal -0.951056 -0 -0.309017
+    outer loop
+      vertex 0.240636 22 8.72021
+      vertex 0.434443 15 8.12373
+      vertex 0.240636 15 8.72021
+    endloop
+  endfacet
+  facet normal -0.447214 0 0.894427
+    outer loop
+      vertex -0.999999 22 4.90192
+      vertex -1 16 4.90192
+      vertex -0.999999 15 4.90192
+    endloop
+  endfacet
+  facet normal -0.406737 -7.95301e-09 0.913545
+    outer loop
+      vertex -1.57295 22 4.64683
+      vertex -1 16 4.90192
+      vertex -0.999999 22 4.90192
+    endloop
+  endfacet
+  facet normal -0.406737 0 0.913545
+    outer loop
+      vertex -1 16 4.90192
+      vertex -1.57295 22 4.64683
+      vertex -1.57295 16 4.64683
+    endloop
+  endfacet
+  facet normal -0.447214 0 0.894427
+    outer loop
+      vertex -0.999999 15 4.90192
+      vertex -1 16 4.90192
+      vertex -1 15 4.90192
+    endloop
+  endfacet
+  facet normal -0.587786 0 -0.809016
+    outer loop
+      vertex -0.999999 15 10.0981
+      vertex -0.492608 22 9.72943
+      vertex -0.492608 15 9.72943
+    endloop
+  endfacet
+  facet normal -0.587786 0 -0.809016
+    outer loop
+      vertex -0.492608 22 9.72943
+      vertex -0.999999 15 10.0981
+      vertex -0.999999 22 10.0981
+    endloop
+  endfacet
+  facet normal -0.866026 0 -0.499999
+    outer loop
+      vertex 0.240636 15 8.72021
+      vertex -0.0729485 22 9.26336
+      vertex 0.240636 22 8.72021
+    endloop
+  endfacet
+  facet normal -0.866026 -0 -0.499999
+    outer loop
+      vertex -0.0729485 22 9.26336
+      vertex 0.240636 15 8.72021
+      vertex -0.0729485 15 9.26336
+    endloop
+  endfacet
+  facet normal -0.207911 0 -0.978148
+    outer loop
+      vertex -2.18641 16 10.4836
+      vertex -1.57295 22 10.3532
+      vertex -1.57295 16 10.3532
+    endloop
+  endfacet
+  facet normal -0.207911 0 -0.978148
+    outer loop
+      vertex -1.57295 22 10.3532
+      vertex -2.18641 16 10.4836
+      vertex -2.18641 22 10.4836
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1 16 10.0981
+      vertex -0.999999 15 10.0981
+      vertex -1 15 10.0981
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.999999 15 10.0981
+      vertex -1 16 10.0981
+      vertex -0.999999 22 10.0981
+    endloop
+  endfacet
+  facet normal -0.406737 6.46492e-08 -0.913545
+    outer loop
+      vertex -1.57295 16 10.3532
+      vertex -0.999999 22 10.0981
+      vertex -1 16 10.0981
+    endloop
+  endfacet
+  facet normal -0.406737 0 -0.913545
+    outer loop
+      vertex -0.999999 22 10.0981
+      vertex -1.57295 16 10.3532
+      vertex -1.57295 22 10.3532
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.5 22 4.5
+      vertex -2.5 22 4.51643
+      vertex -5.5 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.5 22 4.51643
+      vertex -5.5 22 4.5
+      vertex -2.5 22 4.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5 22 5.90876
+      vertex -2.5 22 5.9
+      vertex -2.33275 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.66724 22 9.09123
+      vertex -5.5 22 10.4836
+      vertex -5.81359 22 10.4836
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.5 22 10.4836
+      vertex -5.5 22 9.1
+      vertex -2.5 22 10.4836
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.66724 22 9.09123
+      vertex -5.81359 22 10.4836
+      vertex -6.42705 22 10.3532
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5 22 9.1
+      vertex -2.5 22 10.4836
+      vertex -5.5 22 9.1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.99443 22 9.02169
+      vertex -6.42705 22 10.3532
+      vertex -7 22 10.0981
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.33275 22 9.09123
+      vertex -2.5 22 10.4836
+      vertex -2.5 22 9.1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -6.3 22 8.88564
+      vertex -7 22 10.0981
+      vertex -7.50739 22 9.72943
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5 22 10.4836
+      vertex -2.33275 22 9.09123
+      vertex -2.18641 22 10.4836
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -6.57061 22 8.68903
+      vertex -7.50739 22 9.72943
+      vertex -7.92705 22 9.26336
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.18641 22 10.4836
+      vertex -2.33275 22 9.09123
+      vertex -1.57295 22 10.3532
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.00557 22 9.02169
+      vertex -1.57295 22 10.3532
+      vertex -2.33275 22 9.09123
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -5.5 22 10.4836
+      vertex -5.66724 22 9.09123
+      vertex -5.5 22 9.1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -6.42705 22 10.3532
+      vertex -5.99443 22 9.02169
+      vertex -5.66724 22 9.09123
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7 22 10.0981
+      vertex -6.3 22 8.88564
+      vertex -5.99443 22 9.02169
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -6.79443 22 8.44046
+      vertex -7.92705 22 9.26336
+      vertex -8.24064 22 8.72021
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.50739 22 9.72943
+      vertex -6.57061 22 8.68903
+      vertex -6.3 22 8.88564
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.92705 22 9.26336
+      vertex -6.79443 22 8.44046
+      vertex -6.57061 22 8.68903
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.24064 22 8.72021
+      vertex -6.96167 22 8.15078
+      vertex -6.79443 22 8.44046
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.43444 22 8.12373
+      vertex -6.96167 22 8.15078
+      vertex -8.24064 22 8.72021
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.43444 22 8.12373
+      vertex -7.06504 22 7.83266
+      vertex -6.96167 22 8.15078
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.5 22 7.5
+      vertex -7.06504 22 7.83266
+      vertex -8.43444 22 8.12373
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.5 22 7.5
+      vertex -7.1 22 7.5
+      vertex -7.06504 22 7.83266
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.5 22 7.5
+      vertex -7.06504 22 7.16734
+      vertex -7.1 22 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.43444 22 6.87626
+      vertex -7.06504 22 7.16734
+      vertex -8.5 22 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.43444 22 6.87626
+      vertex -6.96167 22 6.84922
+      vertex -7.06504 22 7.16734
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -8.24064 22 6.27979
+      vertex -6.96167 22 6.84922
+      vertex -8.43444 22 6.87626
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -6.96167 22 6.84922
+      vertex -8.24064 22 6.27979
+      vertex -6.79443 22 6.55954
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.92705 22 5.73664
+      vertex -6.79443 22 6.55954
+      vertex -8.24064 22 6.27979
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -6.79443 22 6.55954
+      vertex -7.92705 22 5.73664
+      vertex -6.57061 22 6.31097
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7.50739 22 5.27057
+      vertex -6.57061 22 6.31097
+      vertex -7.92705 22 5.73664
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -6.57061 22 6.31097
+      vertex -7.50739 22 5.27057
+      vertex -6.3 22 6.11436
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.66724 22 5.90876
+      vertex -5.5 22 5.9
+      vertex -5.5 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -6.42705 22 4.64683
+      vertex -5.99443 22 5.97831
+      vertex -7 22 4.90192
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -6.3 22 6.11436
+      vertex -7 22 4.90192
+      vertex -5.99443 22 5.97831
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -7 22 4.90192
+      vertex -6.3 22 6.11436
+      vertex -7.50739 22 5.27057
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.5 22 10.4836
+      vertex -2.5 22 10.5
+      vertex -5.5 22 10.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.5 22 10.5
+      vertex -5.5 22 10.4836
+      vertex -2.5 22 10.4836
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -1.57295 22 10.3532
+      vertex -2.00557 22 9.02169
+      vertex -0.999999 22 10.0981
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.33275 22 9.09123
+      vertex -2.5 22 9.1
+      vertex -2.5 22 9.09123
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.7 22 8.88564
+      vertex -0.999999 22 10.0981
+      vertex -2.00557 22 9.02169
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.999999 22 10.0981
+      vertex -1.7 22 8.88564
+      vertex -0.492608 22 9.72943
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.42939 22 8.68903
+      vertex -0.492608 22 9.72943
+      vertex -1.7 22 8.88564
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.492608 22 9.72943
+      vertex -1.42939 22 8.68903
+      vertex -0.0729485 22 9.26336
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.20557 22 8.44046
+      vertex -0.0729485 22 9.26336
+      vertex -1.42939 22 8.68903
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.0729485 22 9.26336
+      vertex -1.20557 22 8.44046
+      vertex 0.240636 22 8.72021
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.03833 22 8.15078
+      vertex 0.240636 22 8.72021
+      vertex -1.20557 22 8.44046
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.03833 22 8.15078
+      vertex 0.434443 22 8.12373
+      vertex 0.240636 22 8.72021
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.934963 22 7.83266
+      vertex 0.434443 22 8.12373
+      vertex -1.03833 22 8.15078
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.9 22 7.5
+      vertex 0.434443 22 8.12373
+      vertex -0.934963 22 7.83266
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.9 22 7.5
+      vertex 0.5 22 7.5
+      vertex 0.434443 22 8.12373
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.934963 22 7.16734
+      vertex 0.5 22 7.5
+      vertex -0.9 22 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.934963 22 7.16734
+      vertex 0.434443 22 6.87626
+      vertex 0.5 22 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.03833 22 6.84922
+      vertex 0.434443 22 6.87626
+      vertex -0.934963 22 7.16734
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.240636 22 6.27979
+      vertex -1.03833 22 6.84922
+      vertex -1.20557 22 6.55954
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.0729485 22 5.73664
+      vertex -1.20557 22 6.55954
+      vertex -1.42939 22 6.31097
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.03833 22 6.84922
+      vertex 0.240636 22 6.27979
+      vertex 0.434443 22 6.87626
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.492608 22 5.27057
+      vertex -1.42939 22 6.31097
+      vertex -1.7 22 6.11436
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -0.999999 22 4.90192
+      vertex -1.7 22 6.11436
+      vertex -2.00557 22 5.97831
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.57295 22 4.64683
+      vertex -2.00557 22 5.97831
+      vertex -2.33275 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.20557 22 6.55954
+      vertex -0.0729485 22 5.73664
+      vertex 0.240636 22 6.27979
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5 22 4.51643
+      vertex -2.33275 22 5.90876
+      vertex -2.5 22 5.9
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.5 22 5.9
+      vertex -5.5 22 4.51643
+      vertex -2.5 22 5.9
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -5.99443 22 5.97831
+      vertex -6.42705 22 4.64683
+      vertex -5.66724 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.5 22 4.51643
+      vertex -2.5 22 5.9
+      vertex -5.5 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.81359 22 4.51643
+      vertex -5.66724 22 5.90876
+      vertex -6.42705 22 4.64683
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -2.33275 22 5.90876
+      vertex -2.5 22 4.51643
+      vertex -2.18641 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.5 22 4.51643
+      vertex -5.66724 22 5.90876
+      vertex -5.81359 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.42939 22 6.31097
+      vertex -0.492608 22 5.27057
+      vertex -0.0729485 22 5.73664
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.66724 22 5.90876
+      vertex -5.5 22 4.51643
+      vertex -5.5 22 5.9
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.7 22 6.11436
+      vertex -0.999999 22 4.90192
+      vertex -0.492608 22 5.27057
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.00557 22 5.97831
+      vertex -1.57295 22 4.64683
+      vertex -0.999999 22 4.90192
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.33275 22 5.90876
+      vertex -2.18641 22 4.51643
+      vertex -1.57295 22 4.64683
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -5.5 22 9.1
+      vertex -5.66724 22 9.09123
+      vertex -5.5 22 9.09123
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.492608 15 9.72943
+      vertex -1 15 10.0981
+      vertex -0.999999 15 10.0981
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.0729485 15 9.26336
+      vertex -1 15 10.0981
+      vertex -0.492608 15 9.72943
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.240636 15 8.72021
+      vertex -1 15 10.0981
+      vertex -0.0729485 15 9.26336
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.434443 15 8.12373
+      vertex -1 15 10.0981
+      vertex 0.240636 15 8.72021
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.5 15 7.5
+      vertex -1 15 10.0981
+      vertex 0.434443 15 8.12373
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.434443 15 6.87626
+      vertex -1 15 10.0981
+      vertex 0.5 15 7.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.240636 15 6.27979
+      vertex -1 15 10.0981
+      vertex 0.434443 15 6.87626
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.0729485 15 5.73664
+      vertex -1 15 10.0981
+      vertex 0.240636 15 6.27979
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.492608 15 5.27057
+      vertex -1 15 10.0981
+      vertex -0.0729485 15 5.73664
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1 15 4.90192
+      vertex -0.492608 15 5.27057
+      vertex -0.999999 15 4.90192
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.492608 15 5.27057
+      vertex -1 15 4.90192
+      vertex -1 15 10.0981
+    endloop
+  endfacet
+  facet normal -0.994522 0 0.104529
+    outer loop
+      vertex 0.434443 15 6.87626
+      vertex 0.5 22 7.5
+      vertex 0.434443 22 6.87626
+    endloop
+  endfacet
+  facet normal -0.994522 0 0.104529
+    outer loop
+      vertex 0.5 22 7.5
+      vertex 0.434443 15 6.87626
+      vertex 0.5 15 7.5
+    endloop
+  endfacet
+  facet normal -0.207911 0 0.978148
+    outer loop
+      vertex -2.18641 22 4.51643
+      vertex -1.57295 16 4.64683
+      vertex -1.57295 22 4.64683
+    endloop
+  endfacet
+  facet normal -0.207911 0 0.978148
+    outer loop
+      vertex -1.57295 16 4.64683
+      vertex -2.18641 22 4.51643
+      vertex -2.18641 16 4.51643
+    endloop
+  endfacet
+  facet normal -0.743144 0 -0.669131
+    outer loop
+      vertex -0.0729485 15 9.26336
+      vertex -0.492608 22 9.72943
+      vertex -0.0729485 22 9.26336
+    endloop
+  endfacet
+  facet normal -0.743144 -0 -0.669131
+    outer loop
+      vertex -0.492608 22 9.72943
+      vertex -0.0729485 15 9.26336
+      vertex -0.492608 15 9.72943
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.5 16 10.4836
+      vertex -2.18641 22 10.4836
+      vertex -2.18641 16 10.4836
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.18641 22 10.4836
+      vertex -2.5 16 10.4836
+      vertex -2.5 22 10.4836
+    endloop
+  endfacet
+  facet normal -0.587786 0 0.809016
+    outer loop
+      vertex -0.999999 22 4.90192
+      vertex -0.492608 15 5.27057
+      vertex -0.492608 22 5.27057
+    endloop
+  endfacet
+  facet normal -0.587786 0 0.809016
+    outer loop
+      vertex -0.492608 15 5.27057
+      vertex -0.999999 22 4.90192
+      vertex -0.999999 15 4.90192
+    endloop
+  endfacet
+  facet normal -0.866026 0 0.499999
+    outer loop
+      vertex -0.0729485 15 5.73664
+      vertex 0.240636 22 6.27979
+      vertex -0.0729485 22 5.73664
+    endloop
+  endfacet
+  facet normal -0.866026 0 0.499999
+    outer loop
+      vertex 0.240636 22 6.27979
+      vertex -0.0729485 15 5.73664
+      vertex 0.240636 15 6.27979
+    endloop
+  endfacet
+  facet normal -0.951056 0 0.309017
+    outer loop
+      vertex 0.240636 15 6.27979
+      vertex 0.434443 22 6.87626
+      vertex 0.240636 22 6.27979
+    endloop
+  endfacet
+  facet normal -0.951056 0 0.309017
+    outer loop
+      vertex 0.434443 22 6.87626
+      vertex 0.240636 15 6.27979
+      vertex 0.434443 15 6.87626
+    endloop
+  endfacet
+  facet normal -0.743144 0 0.669131
+    outer loop
+      vertex -0.492608 15 5.27057
+      vertex -0.0729485 22 5.73664
+      vertex -0.492608 22 5.27057
+    endloop
+  endfacet
+  facet normal -0.743144 0 0.669131
+    outer loop
+      vertex -0.0729485 22 5.73664
+      vertex -0.492608 15 5.27057
+      vertex -0.0729485 15 5.73664
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.5 22 4.51643
+      vertex -2.18641 16 4.51643
+      vertex -2.18641 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18641 16 4.51643
+      vertex -2.5 22 4.51643
+      vertex -2.5 16 4.51643
+    endloop
+  endfacet
+  facet normal 0.994522 0 -0.104529
+    outer loop
+      vertex -8.43444 16 8.12373
+      vertex -8.5 22 7.5
+      vertex -8.43444 22 8.12373
+    endloop
+  endfacet
+  facet normal 0.994522 0 -0.104529
+    outer loop
+      vertex -8.5 22 7.5
+      vertex -8.43444 16 8.12373
+      vertex -8.5 16 7.5
+    endloop
+  endfacet
+  facet normal 0.406737 0 -0.913545
+    outer loop
+      vertex -7 16 10.0981
+      vertex -6.42705 22 10.3532
+      vertex -6.42705 16 10.3532
+    endloop
+  endfacet
+  facet normal 0.406737 0 -0.913545
+    outer loop
+      vertex -6.42705 22 10.3532
+      vertex -7 16 10.0981
+      vertex -7 22 10.0981
+    endloop
+  endfacet
+  facet normal 0.951056 0 -0.309017
+    outer loop
+      vertex -8.24064 16 8.72021
+      vertex -8.43444 22 8.12373
+      vertex -8.24064 22 8.72021
+    endloop
+  endfacet
+  facet normal 0.951056 0 -0.309017
+    outer loop
+      vertex -8.43444 22 8.12373
+      vertex -8.24064 16 8.72021
+      vertex -8.43444 16 8.12373
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.81359 16 10.4836
+      vertex -5.5 22 10.4836
+      vertex -5.5 16 10.4836
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.5 22 10.4836
+      vertex -5.81359 16 10.4836
+      vertex -5.81359 22 10.4836
+    endloop
+  endfacet
+  facet normal 0.866026 0 -0.5
+    outer loop
+      vertex -7.92705 16 9.26336
+      vertex -8.24064 22 8.72021
+      vertex -7.92705 22 9.26336
+    endloop
+  endfacet
+  facet normal 0.866026 0 -0.5
+    outer loop
+      vertex -8.24064 22 8.72021
+      vertex -7.92705 16 9.26336
+      vertex -8.24064 16 8.72021
+    endloop
+  endfacet
+  facet normal 0.743144 0 -0.669131
+    outer loop
+      vertex -7.50739 16 9.72943
+      vertex -7.92705 22 9.26336
+      vertex -7.50739 22 9.72943
+    endloop
+  endfacet
+  facet normal 0.743144 0 -0.669131
+    outer loop
+      vertex -7.92705 22 9.26336
+      vertex -7.50739 16 9.72943
+      vertex -7.92705 16 9.26336
+    endloop
+  endfacet
+  facet normal 0.743144 -0 0.669131
+    outer loop
+      vertex -7.92705 16 5.73664
+      vertex -7.50739 22 5.27057
+      vertex -7.92705 22 5.73664
+    endloop
+  endfacet
+  facet normal 0.743144 0 0.669131
+    outer loop
+      vertex -7.50739 22 5.27057
+      vertex -7.92705 16 5.73664
+      vertex -7.50739 16 5.27057
+    endloop
+  endfacet
+  facet normal 0.994522 -0 0.104529
+    outer loop
+      vertex -8.5 16 7.5
+      vertex -8.43444 22 6.87626
+      vertex -8.5 22 7.5
+    endloop
+  endfacet
+  facet normal 0.994522 0 0.104529
+    outer loop
+      vertex -8.43444 22 6.87626
+      vertex -8.5 16 7.5
+      vertex -8.43444 16 6.87626
+    endloop
+  endfacet
+  facet normal 0.207911 0 -0.978148
+    outer loop
+      vertex -6.42705 16 10.3532
+      vertex -5.81359 22 10.4836
+      vertex -5.81359 16 10.4836
+    endloop
+  endfacet
+  facet normal 0.207911 0 -0.978148
+    outer loop
+      vertex -5.81359 22 10.4836
+      vertex -6.42705 16 10.3532
+      vertex -6.42705 22 10.3532
+    endloop
+  endfacet
+  facet normal 0.587785 0 -0.809017
+    outer loop
+      vertex -7.50739 16 9.72943
+      vertex -7 22 10.0981
+      vertex -7 16 10.0981
+    endloop
+  endfacet
+  facet normal 0.587785 0 -0.809017
+    outer loop
+      vertex -7 22 10.0981
+      vertex -7.50739 16 9.72943
+      vertex -7.50739 22 9.72943
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.81359 22 4.51643
+      vertex -5.5 16 4.51643
+      vertex -5.5 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 16 4.51643
+      vertex -5.81359 22 4.51643
+      vertex -5.81359 16 4.51643
+    endloop
+  endfacet
+  facet normal 0.951056 -0 0.309017
+    outer loop
+      vertex -8.43444 16 6.87626
+      vertex -8.24064 22 6.27979
+      vertex -8.43444 22 6.87626
+    endloop
+  endfacet
+  facet normal 0.951056 0 0.309017
+    outer loop
+      vertex -8.24064 22 6.27979
+      vertex -8.43444 16 6.87626
+      vertex -8.24064 16 6.27979
+    endloop
+  endfacet
+  facet normal 0.866026 -0 0.5
+    outer loop
+      vertex -8.24064 16 6.27979
+      vertex -7.92705 22 5.73664
+      vertex -8.24064 22 6.27979
+    endloop
+  endfacet
+  facet normal 0.866026 0 0.5
+    outer loop
+      vertex -7.92705 22 5.73664
+      vertex -8.24064 16 6.27979
+      vertex -7.92705 16 5.73664
+    endloop
+  endfacet
+  facet normal 0.587786 0 0.809016
+    outer loop
+      vertex -7.50739 22 5.27057
+      vertex -7 16 4.90192
+      vertex -7 22 4.90192
+    endloop
+  endfacet
+  facet normal 0.587786 0 0.809016
+    outer loop
+      vertex -7 16 4.90192
+      vertex -7.50739 22 5.27057
+      vertex -7.50739 16 5.27057
+    endloop
+  endfacet
+  facet normal 0.406737 0 0.913545
+    outer loop
+      vertex -7 22 4.90192
+      vertex -6.42705 16 4.64683
+      vertex -6.42705 22 4.64683
+    endloop
+  endfacet
+  facet normal 0.406737 0 0.913545
+    outer loop
+      vertex -6.42705 16 4.64683
+      vertex -7 22 4.90192
+      vertex -7 16 4.90192
+    endloop
+  endfacet
+  facet normal 0.207911 0 0.978148
+    outer loop
+      vertex -6.42705 22 4.64683
+      vertex -5.81359 16 4.51643
+      vertex -5.81359 22 4.51643
+    endloop
+  endfacet
+  facet normal 0.207911 0 0.978148
+    outer loop
+      vertex -5.81359 16 4.51643
+      vertex -6.42705 22 4.64683
+      vertex -6.42705 16 4.64683
+    endloop
+  endfacet
+  facet normal 0.951057 0 -0.309016
+    outer loop
+      vertex 34.0383 22 8.15078
+      vertex 33.935 26 7.83266
+      vertex 34.0383 26 8.15078
+    endloop
+  endfacet
+  facet normal 0.951057 0 -0.309016
+    outer loop
+      vertex 33.935 26 7.83266
+      vertex 34.0383 22 8.15078
+      vertex 33.935 22 7.83266
+    endloop
+  endfacet
+  facet normal 0.743148 0 -0.669127
+    outer loop
+      vertex 34.4294 22 8.68903
+      vertex 34.2056 26 8.44046
+      vertex 34.4294 26 8.68903
+    endloop
+  endfacet
+  facet normal 0.743148 0 -0.669127
+    outer loop
+      vertex 34.2056 26 8.44046
+      vertex 34.4294 22 8.68903
+      vertex 34.2056 22 8.44046
+    endloop
+  endfacet
+  facet normal 0.207909 0 -0.978148
+    outer loop
+      vertex 35.0056 22 9.02169
+      vertex 35.3328 26 9.09123
+      vertex 35.3328 22 9.09123
+    endloop
+  endfacet
+  facet normal 0.207909 0 -0.978148
+    outer loop
+      vertex 35.3328 26 9.09123
+      vertex 35.0056 22 9.02169
+      vertex 35.0056 26 9.02169
+    endloop
+  endfacet
+  facet normal 0.994523 -0 0.104522
+    outer loop
+      vertex 33.9 22 7.5
+      vertex 33.935 26 7.16734
+      vertex 33.9 26 7.5
+    endloop
+  endfacet
+  facet normal 0.994523 0 0.104522
+    outer loop
+      vertex 33.935 26 7.16734
+      vertex 33.9 22 7.5
+      vertex 33.935 22 7.16734
+    endloop
+  endfacet
+  facet normal 0.866023 0 -0.500004
+    outer loop
+      vertex 34.2056 22 8.44046
+      vertex 34.0383 26 8.15078
+      vertex 34.2056 26 8.44046
+    endloop
+  endfacet
+  facet normal 0.866023 0 -0.500004
+    outer loop
+      vertex 34.0383 26 8.15078
+      vertex 34.2056 22 8.44046
+      vertex 34.0383 22 8.15078
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.3328 26 5.90876
+      vertex 35.5 22 5.90876
+      vertex 35.5 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.5 22 5.90876
+      vertex 35.3328 26 5.90876
+      vertex 35.3328 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.3328 22 9.09123
+      vertex 35.5 26 9.09123
+      vertex 35.5 22 9.09123
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.5 26 9.09123
+      vertex 35.3328 22 9.09123
+      vertex 35.3328 26 9.09123
+    endloop
+  endfacet
+  facet normal 0.994523 0 -0.104522
+    outer loop
+      vertex 33.935 22 7.83266
+      vertex 33.9 26 7.5
+      vertex 33.935 26 7.83266
+    endloop
+  endfacet
+  facet normal 0.994523 0 -0.104522
+    outer loop
+      vertex 33.9 26 7.5
+      vertex 33.935 22 7.83266
+      vertex 33.9 22 7.5
+    endloop
+  endfacet
+  facet normal 0.406738 0 -0.913545
+    outer loop
+      vertex 34.7 22 8.88564
+      vertex 35.0056 26 9.02169
+      vertex 35.0056 22 9.02169
+    endloop
+  endfacet
+  facet normal 0.406738 0 -0.913545
+    outer loop
+      vertex 35.0056 26 9.02169
+      vertex 34.7 22 8.88564
+      vertex 34.7 26 8.88564
+    endloop
+  endfacet
+  facet normal 0.587782 0 -0.809019
+    outer loop
+      vertex 34.4294 22 8.68903
+      vertex 34.7 26 8.88564
+      vertex 34.7 22 8.88564
+    endloop
+  endfacet
+  facet normal 0.587782 0 -0.809019
+    outer loop
+      vertex 34.7 26 8.88564
+      vertex 34.4294 22 8.68903
+      vertex 34.4294 26 8.68903
+    endloop
+  endfacet
+  facet normal 0.587782 0 0.809019
+    outer loop
+      vertex 34.4294 26 6.31097
+      vertex 34.7 22 6.11436
+      vertex 34.7 26 6.11436
+    endloop
+  endfacet
+  facet normal 0.587782 0 0.809019
+    outer loop
+      vertex 34.7 22 6.11436
+      vertex 34.4294 26 6.31097
+      vertex 34.4294 22 6.31097
+    endloop
+  endfacet
+  facet normal 0.951057 -0 0.309016
+    outer loop
+      vertex 33.935 22 7.16734
+      vertex 34.0383 26 6.84922
+      vertex 33.935 26 7.16734
+    endloop
+  endfacet
+  facet normal 0.951057 0 0.309016
+    outer loop
+      vertex 34.0383 26 6.84922
+      vertex 33.935 22 7.16734
+      vertex 34.0383 22 6.84922
+    endloop
+  endfacet
+  facet normal 0.743148 -0 0.669127
+    outer loop
+      vertex 34.2056 22 6.55954
+      vertex 34.4294 26 6.31097
+      vertex 34.2056 26 6.55954
+    endloop
+  endfacet
+  facet normal 0.743148 0 0.669127
+    outer loop
+      vertex 34.4294 26 6.31097
+      vertex 34.2056 22 6.55954
+      vertex 34.4294 22 6.31097
+    endloop
+  endfacet
+  facet normal 0.866023 -0 0.500004
+    outer loop
+      vertex 34.0383 22 6.84922
+      vertex 34.2056 26 6.55954
+      vertex 34.0383 26 6.84922
+    endloop
+  endfacet
+  facet normal 0.866023 0 0.500004
+    outer loop
+      vertex 34.2056 26 6.55954
+      vertex 34.0383 22 6.84922
+      vertex 34.2056 22 6.55954
+    endloop
+  endfacet
+  facet normal 0.406738 0 0.913545
+    outer loop
+      vertex 34.7 26 6.11436
+      vertex 35.0056 22 5.97831
+      vertex 35.0056 26 5.97831
+    endloop
+  endfacet
+  facet normal 0.406738 0 0.913545
+    outer loop
+      vertex 35.0056 22 5.97831
+      vertex 34.7 26 6.11436
+      vertex 34.7 22 6.11436
+    endloop
+  endfacet
+  facet normal 0.207909 0 0.978148
+    outer loop
+      vertex 35.0056 26 5.97831
+      vertex 35.3328 22 5.90876
+      vertex 35.3328 26 5.90876
+    endloop
+  endfacet
+  facet normal 0.207909 0 0.978148
+    outer loop
+      vertex 35.3328 22 5.90876
+      vertex 35.0056 26 5.97831
+      vertex 35.0056 22 5.97831
+    endloop
+  endfacet
+  facet normal -0.994523 0 -0.104522
+    outer loop
+      vertex 40.1 22 7.5
+      vertex 40.065 26 7.83266
+      vertex 40.1 26 7.5
+    endloop
+  endfacet
+  facet normal -0.994523 -0 -0.104522
+    outer loop
+      vertex 40.065 26 7.83266
+      vertex 40.1 22 7.5
+      vertex 40.065 22 7.83266
+    endloop
+  endfacet
+  facet normal -0.951054 0 -0.309026
+    outer loop
+      vertex 40.065 22 7.83266
+      vertex 39.9617 26 8.15078
+      vertex 40.065 26 7.83266
+    endloop
+  endfacet
+  facet normal -0.951054 -0 -0.309026
+    outer loop
+      vertex 39.9617 26 8.15078
+      vertex 40.065 22 7.83266
+      vertex 39.9617 22 8.15078
+    endloop
+  endfacet
+  facet normal -0.587782 0 -0.809019
+    outer loop
+      vertex 39.3 22 8.88564
+      vertex 39.5706 26 8.68903
+      vertex 39.5706 22 8.68903
+    endloop
+  endfacet
+  facet normal -0.587782 0 -0.809019
+    outer loop
+      vertex 39.5706 26 8.68903
+      vertex 39.3 22 8.88564
+      vertex 39.3 26 8.88564
+    endloop
+  endfacet
+  facet normal -0.866028 0 -0.499995
+    outer loop
+      vertex 39.9617 22 8.15078
+      vertex 39.7944 26 8.44046
+      vertex 39.9617 26 8.15078
+    endloop
+  endfacet
+  facet normal -0.866028 -0 -0.499995
+    outer loop
+      vertex 39.7944 26 8.44046
+      vertex 39.9617 22 8.15078
+      vertex 39.7944 22 8.44046
+    endloop
+  endfacet
+  facet normal -0.207909 0 -0.978148
+    outer loop
+      vertex 38.6672 22 9.09123
+      vertex 38.9944 26 9.02169
+      vertex 38.9944 22 9.02169
+    endloop
+  endfacet
+  facet normal -0.207909 0 -0.978148
+    outer loop
+      vertex 38.9944 26 9.02169
+      vertex 38.6672 22 9.09123
+      vertex 38.6672 26 9.09123
+    endloop
+  endfacet
+  facet normal -0.406738 0 -0.913545
+    outer loop
+      vertex 38.9944 22 9.02169
+      vertex 39.3 26 8.88564
+      vertex 39.3 22 8.88564
+    endloop
+  endfacet
+  facet normal -0.406738 0 -0.913545
+    outer loop
+      vertex 39.3 26 8.88564
+      vertex 38.9944 22 9.02169
+      vertex 38.9944 26 9.02169
+    endloop
+  endfacet
+  facet normal -0.994523 0 0.104522
+    outer loop
+      vertex 40.065 22 7.16734
+      vertex 40.1 26 7.5
+      vertex 40.065 26 7.16734
+    endloop
+  endfacet
+  facet normal -0.994523 0 0.104522
+    outer loop
+      vertex 40.1 26 7.5
+      vertex 40.065 22 7.16734
+      vertex 40.1 22 7.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 38.5 26 5.90876
+      vertex 38.6672 22 5.90876
+      vertex 38.6672 26 5.90876
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.6672 22 5.90876
+      vertex 38.5 26 5.90876
+      vertex 38.5 22 5.90876
+    endloop
+  endfacet
+  facet normal -0.207909 0 0.978148
+    outer loop
+      vertex 38.6672 26 5.90876
+      vertex 38.9944 22 5.97831
+      vertex 38.9944 26 5.97831
+    endloop
+  endfacet
+  facet normal -0.207909 0 0.978148
+    outer loop
+      vertex 38.9944 22 5.97831
+      vertex 38.6672 26 5.90876
+      vertex 38.6672 22 5.90876
+    endloop
+  endfacet
+  facet normal -0.743148 0 -0.669127
+    outer loop
+      vertex 39.7944 22 8.44046
+      vertex 39.5706 26 8.68903
+      vertex 39.7944 26 8.44046
+    endloop
+  endfacet
+  facet normal -0.743148 -0 -0.669127
+    outer loop
+      vertex 39.5706 26 8.68903
+      vertex 39.7944 22 8.44046
+      vertex 39.5706 22 8.68903
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 38.5 22 9.09123
+      vertex 38.6672 26 9.09123
+      vertex 38.6672 22 9.09123
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 38.6672 26 9.09123
+      vertex 38.5 22 9.09123
+      vertex 38.5 26 9.09123
+    endloop
+  endfacet
+  facet normal -0.743148 0 0.669127
+    outer loop
+      vertex 39.5706 22 6.31097
+      vertex 39.7944 26 6.55954
+      vertex 39.5706 26 6.31097
+    endloop
+  endfacet
+  facet normal -0.743148 0 0.669127
+    outer loop
+      vertex 39.7944 26 6.55954
+      vertex 39.5706 22 6.31097
+      vertex 39.7944 22 6.55954
+    endloop
+  endfacet
+  facet normal -0.866028 0 0.499995
+    outer loop
+      vertex 39.7944 22 6.55954
+      vertex 39.9617 26 6.84922
+      vertex 39.7944 26 6.55954
+    endloop
+  endfacet
+  facet normal -0.866028 0 0.499995
+    outer loop
+      vertex 39.9617 26 6.84922
+      vertex 39.7944 22 6.55954
+      vertex 39.9617 22 6.84922
+    endloop
+  endfacet
+  facet normal -0.406738 0 0.913545
+    outer loop
+      vertex 38.9944 26 5.97831
+      vertex 39.3 22 6.11436
+      vertex 39.3 26 6.11436
+    endloop
+  endfacet
+  facet normal -0.406738 0 0.913545
+    outer loop
+      vertex 39.3 22 6.11436
+      vertex 38.9944 26 5.97831
+      vertex 38.9944 22 5.97831
+    endloop
+  endfacet
+  facet normal -0.951054 0 0.309026
+    outer loop
+      vertex 39.9617 22 6.84922
+      vertex 40.065 26 7.16734
+      vertex 39.9617 26 6.84922
+    endloop
+  endfacet
+  facet normal -0.951054 0 0.309026
+    outer loop
+      vertex 40.065 26 7.16734
+      vertex 39.9617 22 6.84922
+      vertex 40.065 22 7.16734
+    endloop
+  endfacet
+  facet normal -0.587782 0 0.809019
+    outer loop
+      vertex 39.3 26 6.11436
+      vertex 39.5706 22 6.31097
+      vertex 39.5706 26 6.31097
+    endloop
+  endfacet
+  facet normal -0.587782 0 0.809019
+    outer loop
+      vertex 39.5706 22 6.31097
+      vertex 39.3 26 6.11436
+      vertex 39.3 22 6.11436
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.3328 22 9.09123
+      vertex 35.1864 22 10.4836
+      vertex 34.5729 22 10.3532
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 38.5 22 9.1
+      vertex 35.5 22 10.5
+      vertex 35.5 22 10.4836
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.1864 22 10.4836
+      vertex 35.3328 22 9.09123
+      vertex 35.5 22 10.4836
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.0056 22 9.02169
+      vertex 34.5729 22 10.3532
+      vertex 34 22 10.0981
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 34.7 22 8.88564
+      vertex 34 22 10.0981
+      vertex 33.4926 22 9.72943
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 34.4294 22 8.68903
+      vertex 33.4926 22 9.72943
+      vertex 33.0729 22 9.26336
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.5 22 10.4836
+      vertex 35.5 22 9.1
+      vertex 38.5 22 9.1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.5 22 10.5
+      vertex 38.5 22 9.1
+      vertex 40.5 22 10.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 38.6672 22 9.09123
+      vertex 38.5 22 9.1
+      vertex 38.5 22 9.09123
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 38.5 22 9.1
+      vertex 38.6672 22 9.09123
+      vertex 40.5 22 10.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 38.9944 22 9.02169
+      vertex 40.5 22 10.5
+      vertex 38.6672 22 9.09123
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 39.3 22 8.88564
+      vertex 40.5 22 10.5
+      vertex 38.9944 22 9.02169
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 39.5706 22 8.68903
+      vertex 40.5 22 10.5
+      vertex 39.3 22 8.88564
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 39.7944 22 8.44046
+      vertex 40.5 22 10.5
+      vertex 39.5706 22 8.68903
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 39.9617 22 8.15078
+      vertex 40.5 22 10.5
+      vertex 39.7944 22 8.44046
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40.065 22 7.83266
+      vertex 40.5 22 10.5
+      vertex 39.9617 22 8.15078
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40.1 22 7.5
+      vertex 40.5 22 10.5
+      vertex 40.065 22 7.83266
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40.5 22 4.5
+      vertex 40.1 22 7.5
+      vertex 40.065 22 7.16734
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 35.0056 22 5.97831
+      vertex 34.5729 22 4.64683
+      vertex 35.3328 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.5 22 5.9
+      vertex 35.5 22 4.51643
+      vertex 38.5 22 5.9
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.1864 22 4.51643
+      vertex 35.3328 22 5.90876
+      vertex 34.5729 22 4.64683
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.5 22 4.5
+      vertex 38.5 22 5.9
+      vertex 35.5 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.5 22 4.51643
+      vertex 35.3328 22 5.90876
+      vertex 35.1864 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.3328 22 5.90876
+      vertex 35.5 22 4.51643
+      vertex 35.5 22 5.9
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40.5 22 4.5
+      vertex 38.5 22 5.9
+      vertex 35.5 22 4.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 38.5 22 5.9
+      vertex 40.5 22 4.5
+      vertex 38.6672 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 40.1 22 7.5
+      vertex 40.5 22 4.5
+      vertex 40.5 22 10.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 39.9617 22 6.84922
+      vertex 40.5 22 4.5
+      vertex 40.065 22 7.16734
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 39.7944 22 6.55954
+      vertex 40.5 22 4.5
+      vertex 39.9617 22 6.84922
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 39.5706 22 6.31097
+      vertex 40.5 22 4.5
+      vertex 39.7944 22 6.55954
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 39.3 22 6.11436
+      vertex 40.5 22 4.5
+      vertex 39.5706 22 6.31097
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 38.9944 22 5.97831
+      vertex 40.5 22 4.5
+      vertex 39.3 22 6.11436
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 38.6672 22 5.90876
+      vertex 40.5 22 4.5
+      vertex 38.9944 22 5.97831
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 38.5 22 5.90876
+      vertex 38.5 22 5.9
+      vertex 38.6672 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 35.5 22 10.4836
+      vertex 35.3328 22 9.09123
+      vertex 35.5 22 9.1
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 34.5729 22 10.3532
+      vertex 35.0056 22 9.02169
+      vertex 35.3328 22 9.09123
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 34 22 10.0981
+      vertex 34.7 22 8.88564
+      vertex 35.0056 22 9.02169
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 34.2056 22 8.44046
+      vertex 33.0729 22 9.26336
+      vertex 32.7594 22 8.72021
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 33.4926 22 9.72943
+      vertex 34.4294 22 8.68903
+      vertex 34.7 22 8.88564
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 33.0729 22 9.26336
+      vertex 34.2056 22 8.44046
+      vertex 34.4294 22 8.68903
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.7594 22 8.72021
+      vertex 34.0383 22 8.15078
+      vertex 34.2056 22 8.44046
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.5656 22 8.12373
+      vertex 34.0383 22 8.15078
+      vertex 32.7594 22 8.72021
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.5656 22 8.12373
+      vertex 33.935 22 7.83266
+      vertex 34.0383 22 8.15078
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.5 22 7.5
+      vertex 33.935 22 7.83266
+      vertex 32.5656 22 8.12373
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.5 22 7.5
+      vertex 33.9 22 7.5
+      vertex 33.935 22 7.83266
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.5 22 7.5
+      vertex 33.935 22 7.16734
+      vertex 33.9 22 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.5656 22 6.87626
+      vertex 33.935 22 7.16734
+      vertex 32.5 22 7.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.5656 22 6.87626
+      vertex 34.0383 22 6.84922
+      vertex 33.935 22 7.16734
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 32.7594 22 6.27979
+      vertex 34.0383 22 6.84922
+      vertex 32.5656 22 6.87626
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 34.0383 22 6.84922
+      vertex 32.7594 22 6.27979
+      vertex 34.2056 22 6.55954
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 33.0729 22 5.73664
+      vertex 34.2056 22 6.55954
+      vertex 32.7594 22 6.27979
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 34.2056 22 6.55954
+      vertex 33.0729 22 5.73664
+      vertex 34.4294 22 6.31097
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 33.4926 22 5.27057
+      vertex 34.4294 22 6.31097
+      vertex 33.0729 22 5.73664
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 34.4294 22 6.31097
+      vertex 33.4926 22 5.27057
+      vertex 34.7 22 6.11436
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 35.3328 22 5.90876
+      vertex 35.5 22 5.9
+      vertex 35.5 22 5.90876
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 34.5729 22 4.64683
+      vertex 35.0056 22 5.97831
+      vertex 34 22 4.90192
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 34.7 22 6.11436
+      vertex 34 22 4.90192
+      vertex 35.0056 22 5.97831
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 34 22 4.90192
+      vertex 34.7 22 6.11436
+      vertex 33.4926 22 5.27057
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 35.5 22 9.1
+      vertex 35.3328 22 9.09123
+      vertex 35.5 22 9.09123
+    endloop
+  endfacet
+  facet normal 0.951057 0 -0.309016
+    outer loop
+      vertex 32.7594 16 8.72021
+      vertex 32.5656 22 8.12373
+      vertex 32.7594 22 8.72021
+    endloop
+  endfacet
+  facet normal 0.951057 0 -0.309016
+    outer loop
+      vertex 32.5656 22 8.12373
+      vertex 32.7594 16 8.72021
+      vertex 32.5656 16 8.12373
+    endloop
+  endfacet
+  facet normal 0.743145 0 -0.66913
+    outer loop
+      vertex 33.4926 16 9.72943
+      vertex 33.0729 22 9.26336
+      vertex 33.4926 22 9.72943
+    endloop
+  endfacet
+  facet normal 0.743145 0 -0.66913
+    outer loop
+      vertex 33.0729 22 9.26336
+      vertex 33.4926 16 9.72943
+      vertex 33.0729 16 9.26336
+    endloop
+  endfacet
+  facet normal 0.207912 0 -0.978148
+    outer loop
+      vertex 34.5729 16 10.3532
+      vertex 35.1864 22 10.4836
+      vertex 35.1864 16 10.4836
+    endloop
+  endfacet
+  facet normal 0.207912 0 -0.978148
+    outer loop
+      vertex 35.1864 22 10.4836
+      vertex 34.5729 16 10.3532
+      vertex 34.5729 22 10.3532
+    endloop
+  endfacet
+  facet normal 0.994522 -0 0.104526
+    outer loop
+      vertex 32.5 16 7.5
+      vertex 32.5656 22 6.87626
+      vertex 32.5 22 7.5
+    endloop
+  endfacet
+  facet normal 0.994522 0 0.104526
+    outer loop
+      vertex 32.5656 22 6.87626
+      vertex 32.5 16 7.5
+      vertex 32.5656 16 6.87626
+    endloop
+  endfacet
+  facet normal 0.866024 0 -0.500002
+    outer loop
+      vertex 33.0729 16 9.26336
+      vertex 32.7594 22 8.72021
+      vertex 33.0729 22 9.26336
+    endloop
+  endfacet
+  facet normal 0.866024 0 -0.500002
+    outer loop
+      vertex 32.7594 22 8.72021
+      vertex 33.0729 16 9.26336
+      vertex 32.7594 16 8.72021
+    endloop
+  endfacet
+  facet normal 0.743145 -0 0.66913
+    outer loop
+      vertex 33.0729 16 5.73664
+      vertex 33.4926 22 5.27057
+      vertex 33.0729 22 5.73664
+    endloop
+  endfacet
+  facet normal 0.743145 0 0.66913
+    outer loop
+      vertex 33.4926 22 5.27057
+      vertex 33.0729 16 5.73664
+      vertex 33.4926 16 5.27057
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.1864 16 10.4836
+      vertex 35.5 22 10.4836
+      vertex 35.5 16 10.4836
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 35.5 22 10.4836
+      vertex 35.1864 16 10.4836
+      vertex 35.1864 22 10.4836
+    endloop
+  endfacet
+  facet normal 0.994522 0 -0.104526
+    outer loop
+      vertex 32.5656 16 8.12373
+      vertex 32.5 22 7.5
+      vertex 32.5656 22 8.12373
+    endloop
+  endfacet
+  facet normal 0.994522 0 -0.104526
+    outer loop
+      vertex 32.5 22 7.5
+      vertex 32.5656 16 8.12373
+      vertex 32.5 16 7.5
+    endloop
+  endfacet
+  facet normal 0.406737 0 -0.913545
+    outer loop
+      vertex 34 16 10.0981
+      vertex 34.5729 22 10.3532
+      vertex 34.5729 16 10.3532
+    endloop
+  endfacet
+  facet normal 0.406737 0 -0.913545
+    outer loop
+      vertex 34.5729 22 10.3532
+      vertex 34 16 10.0981
+      vertex 34 22 10.0981
+    endloop
+  endfacet
+  facet normal 0.587785 0 -0.809017
+    outer loop
+      vertex 33.4926 16 9.72943
+      vertex 34 22 10.0981
+      vertex 34 16 10.0981
+    endloop
+  endfacet
+  facet normal 0.587785 0 -0.809017
+    outer loop
+      vertex 34 22 10.0981
+      vertex 33.4926 16 9.72943
+      vertex 33.4926 22 9.72943
+    endloop
+  endfacet
+  facet normal 0.951057 -0 0.309016
+    outer loop
+      vertex 32.5656 16 6.87626
+      vertex 32.7594 22 6.27979
+      vertex 32.5656 22 6.87626
+    endloop
+  endfacet
+  facet normal 0.951057 0 0.309016
+    outer loop
+      vertex 32.7594 22 6.27979
+      vertex 32.5656 16 6.87626
+      vertex 32.7594 16 6.27979
+    endloop
+  endfacet
+  facet normal 0.866024 -0 0.500002
+    outer loop
+      vertex 32.7594 16 6.27979
+      vertex 33.0729 22 5.73664
+      vertex 32.7594 22 6.27979
+    endloop
+  endfacet
+  facet normal 0.866024 0 0.500002
+    outer loop
+      vertex 33.0729 22 5.73664
+      vertex 32.7594 16 6.27979
+      vertex 33.0729 16 5.73664
+    endloop
+  endfacet
+  facet normal 0.587785 0 0.809017
+    outer loop
+      vertex 33.4926 22 5.27057
+      vertex 34 16 4.90192
+      vertex 34 22 4.90192
+    endloop
+  endfacet
+  facet normal 0.587785 0 0.809017
+    outer loop
+      vertex 34 16 4.90192
+      vertex 33.4926 22 5.27057
+      vertex 33.4926 16 5.27057
+    endloop
+  endfacet
+  facet normal 0.406737 0 0.913545
+    outer loop
+      vertex 34 22 4.90192
+      vertex 34.5729 16 4.64683
+      vertex 34.5729 22 4.64683
+    endloop
+  endfacet
+  facet normal 0.406737 0 0.913545
+    outer loop
+      vertex 34.5729 16 4.64683
+      vertex 34 22 4.90192
+      vertex 34 16 4.90192
+    endloop
+  endfacet
+  facet normal 0.207912 0 0.978148
+    outer loop
+      vertex 34.5729 22 4.64683
+      vertex 35.1864 16 4.51643
+      vertex 35.1864 22 4.51643
+    endloop
+  endfacet
+  facet normal 0.207912 0 0.978148
+    outer loop
+      vertex 35.1864 16 4.51643
+      vertex 34.5729 22 4.64683
+      vertex 34.5729 16 4.64683
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.1864 22 4.51643
+      vertex 35.5 16 4.51643
+      vertex 35.5 22 4.51643
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 35.5 16 4.51643
+      vertex 35.1864 22 4.51643
+      vertex 35.1864 16 4.51643
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -5.5 16 4.51643
+      vertex -5.5 22 4.5
+      vertex -5.5 22 4.51643
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -5.5 22 4.5
+      vertex -5.5 16 4.51643
+      vertex -5.5 16 4.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -5.5 16 10.5
+      vertex -5.5 22 10.4836
+      vertex -5.5 22 10.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -5.5 22 10.4836
+      vertex -5.5 16 10.5
+      vertex -5.5 16 10.4836
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -5.5 22 5.90876
+      vertex -5.5 26 5.9
+      vertex -5.5 26 5.90876
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -5.5 26 5.9
+      vertex -5.5 22 5.90876
+      vertex -5.5 22 5.9
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -5.5 22 9.1
+      vertex -5.5 26 9.09123
+      vertex -5.5 26 9.1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -5.5 26 9.09123
+      vertex -5.5 22 9.1
+      vertex -5.5 22 9.09123
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.5 22 9.1
+      vertex -2.5 26 9.1
+      vertex -2.5 22 9.1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.5 26 9.1
+      vertex -5.5 22 9.1
+      vertex -5.5 26 9.1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -2.5 16 10.4836
+      vertex -2.5 22 10.5
+      vertex -2.5 22 10.4836
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -2.5 22 10.5
+      vertex -2.5 16 10.4836
+      vertex -2.5 16 10.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -2.5 16 4.5
+      vertex -2.5 22 4.51643
+      vertex -2.5 22 4.5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -2.5 22 4.51643
+      vertex -2.5 16 4.5
+      vertex -2.5 16 4.51643
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -2.5 22 9.09123
+      vertex -2.5 26 9.1
+      vertex -2.5 26 9.09123
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -2.5 26 9.1
+      vertex -2.5 22 9.09123
+      vertex -2.5 22 9.1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -2.5 22 5.9
+      vertex -2.5 26 5.90876
+      vertex -2.5 26 5.9
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -2.5 26 5.90876
+      vertex -2.5 22 5.9
+      vertex -2.5 22 5.90876
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.5 26 5.9
+      vertex -2.5 22 5.9
+      vertex -2.5 26 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.5 22 5.9
+      vertex -5.5 26 5.9
+      vertex -5.5 22 5.9
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 35.5 16 4.51643
+      vertex 35.5 22 4.5
+      vertex 35.5 22 4.51643
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 35.5 22 4.5
+      vertex 35.5 16 4.51643
+      vertex 35.5 16 4.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 35.5 16 10.5
+      vertex 35.5 22 10.4836
+      vertex 35.5 22 10.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 35.5 22 10.4836
+      vertex 35.5 16 10.5
+      vertex 35.5 16 10.4836
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 35.5 22 9.1
+      vertex 35.5 26 9.09123
+      vertex 35.5 26 9.1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 35.5 26 9.09123
+      vertex 35.5 22 9.1
+      vertex 35.5 22 9.09123
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 35.5 22 5.90876
+      vertex 35.5 26 5.9
+      vertex 35.5 26 5.90876
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 35.5 26 5.9
+      vertex 35.5 22 5.90876
+      vertex 35.5 22 5.9
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.5 22 9.1
+      vertex 38.5 26 9.1
+      vertex 38.5 22 9.1
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 38.5 26 9.1
+      vertex 35.5 22 9.1
+      vertex 35.5 26 9.1
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 38.5 22 5.9
+      vertex 38.5 26 5.90876
+      vertex 38.5 26 5.9
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 38.5 26 5.90876
+      vertex 38.5 22 5.9
+      vertex 38.5 22 5.90876
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 38.5 22 9.09123
+      vertex 38.5 26 9.1
+      vertex 38.5 26 9.09123
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 38.5 26 9.1
+      vertex 38.5 22 9.09123
+      vertex 38.5 22 9.1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.5 26 5.9
+      vertex 38.5 22 5.9
+      vertex 38.5 26 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.5 22 5.9
+      vertex 35.5 26 5.9
+      vertex 35.5 22 5.9
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.5 16 10.5
+      vertex -2.5 22 10.5
+      vertex -2.5 16 10.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.5 22 10.5
+      vertex -5.5 16 10.5
+      vertex -5.5 22 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.5 22 4.5
+      vertex -2.5 16 4.5
+      vertex -2.5 22 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.5 16 4.5
+      vertex -5.5 22 4.5
+      vertex -5.5 16 4.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 35.5 16 10.5
+      vertex 40.5 22 10.5
+      vertex 40.5 16 10.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 40.5 22 10.5
+      vertex 35.5 16 10.5
+      vertex 35.5 22 10.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 35.5 22 4.5
+      vertex 40.5 16 4.5
+      vertex 40.5 22 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 40.5 16 4.5
+      vertex 35.5 22 4.5
+      vertex 35.5 16 4.5
     endloop
   endfacet
   facet normal 0 -1 0
@@ -8182,7 +8084,21 @@ solid OpenSCAD_Model
       vertex 5.44984 11.1 2
     endloop
   endfacet
-  facet normal 0.642788 -0.766044 -3.68765e-008
+  facet normal 0 1 -0
+    outer loop
+      vertex 6.0411 9 2
+      vertex -1 9 12
+      vertex 6.0411 9 12
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1 9 12
+      vertex 6.0411 9 2
+      vertex -1 9 2
+    endloop
+  endfacet
+  facet normal 0.642788 -0.766044 -3.68765e-08
     outer loop
       vertex 5.44984 11.1 12.1
       vertex 9.67064 14.6417 14
@@ -8231,27 +8147,6 @@ solid OpenSCAD_Model
       vertex 18.8792 7 2
     endloop
   endfacet
-  facet normal -3.28117e-014 0.707107 0.707107
-    outer loop
-      vertex 29 7 12
-      vertex 19.2 5 14
-      vertex 29 5 14
-    endloop
-  endfacet
-  facet normal 2.26376e-008 0.707107 0.707107
-    outer loop
-      vertex 29 7 12
-      vertex 19.0427 6.49696 12.503
-      vertex 19.2 5 14
-    endloop
-  endfacet
-  facet normal 0 0.707107 0.707107
-    outer loop
-      vertex 19.0427 6.49696 12.503
-      vertex 29 7 12
-      vertex 18.8792 7 12
-    endloop
-  endfacet
   facet normal 0 -0.707107 0.707107
     outer loop
       vertex 16.145 10.8394 13.8394
@@ -8294,6 +8189,27 @@ solid OpenSCAD_Model
       vertex 29 9.1 12.1
     endloop
   endfacet
+  facet normal -3.28117e-14 0.707107 0.707107
+    outer loop
+      vertex 29 7 12
+      vertex 19.2 5 14
+      vertex 29 5 14
+    endloop
+  endfacet
+  facet normal 2.26376e-08 0.707107 0.707107
+    outer loop
+      vertex 29 7 12
+      vertex 19.0427 6.49696 12.503
+      vertex 19.2 5 14
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex 19.0427 6.49696 12.503
+      vertex 29 7 12
+      vertex 18.8792 7 12
+    endloop
+  endfacet
   facet normal 0 -0.707107 0.707107
     outer loop
       vertex 5.44984 11.1 12.1
@@ -8315,7 +8231,7 @@ solid OpenSCAD_Model
       vertex 6.0411 9 12
     endloop
   endfacet
-  facet normal 9.95994e-008 0.707107 0.707107
+  facet normal 9.95994e-08 0.707107 0.707107
     outer loop
       vertex -1 9 12
       vertex 5.12078 7 14
@@ -8371,6 +8287,20 @@ solid OpenSCAD_Model
       vertex 1.1 0.5 12.5
     endloop
   endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1 5.5 -0.5
+      vertex 1.1 5.5 12.5
+      vertex 1 5.5 12.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1.1 5.5 12.5
+      vertex 1 5.5 -0.5
+      vertex 1.1 5.5 -0.5
+    endloop
+  endfacet
   facet normal -0 0 1
     outer loop
       vertex 1 5.5 -0.5
@@ -8399,20 +8329,6 @@ solid OpenSCAD_Model
       vertex 1 0.5 -0.5
     endloop
   endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1 5.5 -0.5
-      vertex 1.1 5.5 12.5
-      vertex 1 5.5 12.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 1.1 5.5 12.5
-      vertex 1 5.5 -0.5
-      vertex 1.1 5.5 -0.5
-    endloop
-  endfacet
   facet normal 1 -0 0
     outer loop
       vertex 3 0.5 12.5
@@ -8623,20 +8539,6 @@ solid OpenSCAD_Model
       vertex 23.6 0.5 11.5
     endloop
   endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 23.5 4.5 -0.5
-      vertex 23.6 4.5 11.5
-      vertex 23.5 4.5 11.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 23.6 4.5 11.5
-      vertex 23.5 4.5 -0.5
-      vertex 23.6 4.5 -0.5
-    endloop
-  endfacet
   facet normal -0 0 1
     outer loop
       vertex 23.5 4.5 -0.5
@@ -8663,6 +8565,20 @@ solid OpenSCAD_Model
       vertex 23.5 0.5 11.5
       vertex 23.6 0.5 -0.5
       vertex 23.5 0.5 -0.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 23.5 4.5 -0.5
+      vertex 23.6 4.5 11.5
+      vertex 23.5 4.5 11.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 23.6 4.5 11.5
+      vertex 23.5 4.5 -0.5
+      vertex 23.6 4.5 -0.5
     endloop
   endfacet
   facet normal 1 -0 0
@@ -8707,20 +8623,6 @@ solid OpenSCAD_Model
       vertex 25.6 0.5 11.5
     endloop
   endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 25.5 4.5 -0.5
-      vertex 25.6 4.5 11.5
-      vertex 25.5 4.5 11.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 25.6 4.5 11.5
-      vertex 25.5 4.5 -0.5
-      vertex 25.6 4.5 -0.5
-    endloop
-  endfacet
   facet normal -0 0 1
     outer loop
       vertex 25.5 4.5 -0.5
@@ -8749,32 +8651,60 @@ solid OpenSCAD_Model
       vertex 25.5 0.5 -0.5
     endloop
   endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 25.5 4.5 -0.5
+      vertex 25.6 4.5 11.5
+      vertex 25.5 4.5 11.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 25.6 4.5 11.5
+      vertex 25.5 4.5 -0.5
+      vertex 25.6 4.5 -0.5
+    endloop
+  endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 11.5 3 0
+      vertex 11.5 3 11.5
       vertex 11.5 3.3 -0.5
-      vertex 11.5 3.3 0
+      vertex 11.5 3.3 11.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 11.5 3.3 -0.5
-      vertex 11.5 3 0
+      vertex 11.5 3 11.5
       vertex 11.5 3 -0.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5 3 11.5
+      vertex 12.5 3.3 11.5
+      vertex 12.5 3 11.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.5 3.3 11.5
+      vertex 11.5 3 11.5
+      vertex 11.5 3.3 11.5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 12.5 3 -0.5
-      vertex 12.5 3.3 0
+      vertex 12.5 3.3 11.5
       vertex 12.5 3.3 -0.5
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 12.5 3.3 0
+      vertex 12.5 3.3 11.5
       vertex 12.5 3 -0.5
-      vertex 12.5 3 0
+      vertex 12.5 3 11.5
     endloop
   endfacet
   facet normal -0 0 1
@@ -8794,13 +8724,13 @@ solid OpenSCAD_Model
   facet normal 0 1 -0
     outer loop
       vertex 12.5 3 -0.5
-      vertex 11.5 3 0
-      vertex 12.5 3 0
+      vertex 11.5 3 11.5
+      vertex 12.5 3 11.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.5 3 0
+      vertex 11.5 3 11.5
       vertex 12.5 3 -0.5
       vertex 11.5 3 -0.5
     endloop
@@ -8808,57 +8738,57 @@ solid OpenSCAD_Model
   facet normal 0 -1 0
     outer loop
       vertex 11.5 3.3 -0.5
-      vertex 12.5 3.3 0
-      vertex 11.5 3.3 0
+      vertex 12.5 3.3 11.5
+      vertex 11.5 3.3 11.5
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 12.5 3.3 0
+      vertex 12.5 3.3 11.5
       vertex 11.5 3.3 -0.5
       vertex 12.5 3.3 -0.5
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 10 5 0
+      vertex 10 5 11.5
       vertex 10 5.3 -0.5
-      vertex 10 5.3 0
+      vertex 10 5.3 11.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 10 5.3 -0.5
-      vertex 10 5 0
+      vertex 10 5 11.5
       vertex 10 5 -0.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 5 11.5
+      vertex 14 5.3 11.5
+      vertex 14 5 11.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14 5.3 11.5
+      vertex 10 5 11.5
+      vertex 10 5.3 11.5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 14 5 -0.5
-      vertex 14 5.3 0
+      vertex 14 5.3 11.5
       vertex 14 5.3 -0.5
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 14 5.3 0
+      vertex 14 5.3 11.5
       vertex 14 5 -0.5
-      vertex 14 5 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 10 5.3 -0.5
-      vertex 14 5.3 0
-      vertex 10 5.3 0
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 14 5.3 0
-      vertex 10 5.3 -0.5
-      vertex 14 5.3 -0.5
+      vertex 14 5 11.5
     endloop
   endfacet
   facet normal -0 0 1
@@ -8878,55 +8808,83 @@ solid OpenSCAD_Model
   facet normal 0 1 -0
     outer loop
       vertex 14 5 -0.5
-      vertex 10 5 0
-      vertex 14 5 0
+      vertex 10 5 11.5
+      vertex 14 5 11.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10 5 0
+      vertex 10 5 11.5
       vertex 14 5 -0.5
       vertex 10 5 -0.5
     endloop
   endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10 5.3 -0.5
+      vertex 14 5.3 11.5
+      vertex 10 5.3 11.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 14 5.3 11.5
+      vertex 10 5.3 -0.5
+      vertex 14 5.3 -0.5
+    endloop
+  endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 11.5 6.5 0
+      vertex 11.5 6.5 11.5
       vertex 11.5 6.8 -0.5
-      vertex 11.5 6.8 0
+      vertex 11.5 6.8 11.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 11.5 6.8 -0.5
-      vertex 11.5 6.5 0
+      vertex 11.5 6.5 11.5
       vertex 11.5 6.5 -0.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5 6.5 11.5
+      vertex 12.5 6.8 11.5
+      vertex 12.5 6.5 11.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.5 6.8 11.5
+      vertex 11.5 6.5 11.5
+      vertex 11.5 6.8 11.5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 12.5 6.5 -0.5
-      vertex 12.5 6.8 0
+      vertex 12.5 6.8 11.5
       vertex 12.5 6.8 -0.5
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 12.5 6.8 0
+      vertex 12.5 6.8 11.5
       vertex 12.5 6.5 -0.5
-      vertex 12.5 6.5 0
+      vertex 12.5 6.5 11.5
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
       vertex 11.5 6.8 -0.5
-      vertex 12.5 6.8 0
-      vertex 11.5 6.8 0
+      vertex 12.5 6.8 11.5
+      vertex 11.5 6.8 11.5
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 12.5 6.8 0
+      vertex 12.5 6.8 11.5
       vertex 11.5 6.8 -0.5
       vertex 12.5 6.8 -0.5
     endloop
@@ -8948,57 +8906,57 @@ solid OpenSCAD_Model
   facet normal 0 1 -0
     outer loop
       vertex 12.5 6.5 -0.5
-      vertex 11.5 6.5 0
-      vertex 12.5 6.5 0
+      vertex 11.5 6.5 11.5
+      vertex 12.5 6.5 11.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 11.5 6.5 0
+      vertex 11.5 6.5 11.5
       vertex 12.5 6.5 -0.5
       vertex 11.5 6.5 -0.5
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 15.5 16 0
+      vertex 15.5 16 11.5
       vertex 15.5 16.3 -0.5
-      vertex 15.5 16.3 0
+      vertex 15.5 16.3 11.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 15.5 16.3 -0.5
-      vertex 15.5 16 0
+      vertex 15.5 16 11.5
       vertex 15.5 16 -0.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.5 16 11.5
+      vertex 16.5 16.3 11.5
+      vertex 16.5 16 11.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.5 16.3 11.5
+      vertex 15.5 16 11.5
+      vertex 15.5 16.3 11.5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 16.5 16 -0.5
-      vertex 16.5 16.3 0
+      vertex 16.5 16.3 11.5
       vertex 16.5 16.3 -0.5
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 16.5 16.3 0
+      vertex 16.5 16.3 11.5
       vertex 16.5 16 -0.5
-      vertex 16.5 16 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 15.5 16.3 -0.5
-      vertex 16.5 16.3 0
-      vertex 15.5 16.3 0
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 16.5 16.3 0
-      vertex 15.5 16.3 -0.5
-      vertex 16.5 16.3 -0.5
+      vertex 16.5 16 11.5
     endloop
   endfacet
   facet normal -0 0 1
@@ -9018,57 +8976,71 @@ solid OpenSCAD_Model
   facet normal 0 1 -0
     outer loop
       vertex 16.5 16 -0.5
-      vertex 15.5 16 0
-      vertex 16.5 16 0
+      vertex 15.5 16 11.5
+      vertex 16.5 16 11.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 15.5 16 0
+      vertex 15.5 16 11.5
       vertex 16.5 16 -0.5
       vertex 15.5 16 -0.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.5 16.3 -0.5
+      vertex 16.5 16.3 11.5
+      vertex 15.5 16.3 11.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 16.5 16.3 11.5
+      vertex 15.5 16.3 -0.5
+      vertex 16.5 16.3 -0.5
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 14 18 0
+      vertex 14 18 11.5
       vertex 14 18.3 -0.5
-      vertex 14 18.3 0
+      vertex 14 18.3 11.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 14 18.3 -0.5
-      vertex 14 18 0
+      vertex 14 18 11.5
       vertex 14 18 -0.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14 18 11.5
+      vertex 18 18.3 11.5
+      vertex 18 18 11.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18 18.3 11.5
+      vertex 14 18 11.5
+      vertex 14 18.3 11.5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 18 18 -0.5
-      vertex 18 18.3 0
+      vertex 18 18.3 11.5
       vertex 18 18.3 -0.5
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 18 18.3 0
+      vertex 18 18.3 11.5
       vertex 18 18 -0.5
-      vertex 18 18 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 14 18.3 -0.5
-      vertex 18 18.3 0
-      vertex 14 18.3 0
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 18 18.3 0
-      vertex 14 18.3 -0.5
-      vertex 18 18.3 -0.5
+      vertex 18 18 11.5
     endloop
   endfacet
   facet normal -0 0 1
@@ -9088,57 +9060,71 @@ solid OpenSCAD_Model
   facet normal 0 1 -0
     outer loop
       vertex 18 18 -0.5
-      vertex 14 18 0
-      vertex 18 18 0
+      vertex 14 18 11.5
+      vertex 18 18 11.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 14 18 0
+      vertex 14 18 11.5
       vertex 18 18 -0.5
       vertex 14 18 -0.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 14 18.3 -0.5
+      vertex 18 18.3 11.5
+      vertex 14 18.3 11.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 18 18.3 11.5
+      vertex 14 18.3 -0.5
+      vertex 18 18.3 -0.5
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 15.5 20 0
+      vertex 15.5 20 11.5
       vertex 15.5 20.3 -0.5
-      vertex 15.5 20.3 0
+      vertex 15.5 20.3 11.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
       vertex 15.5 20.3 -0.5
-      vertex 15.5 20 0
+      vertex 15.5 20 11.5
       vertex 15.5 20 -0.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.5 20 11.5
+      vertex 16.5 20.3 11.5
+      vertex 16.5 20 11.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 16.5 20.3 11.5
+      vertex 15.5 20 11.5
+      vertex 15.5 20.3 11.5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 16.5 20 -0.5
-      vertex 16.5 20.3 0
+      vertex 16.5 20.3 11.5
       vertex 16.5 20.3 -0.5
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 16.5 20.3 0
+      vertex 16.5 20.3 11.5
       vertex 16.5 20 -0.5
-      vertex 16.5 20 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 15.5 20.3 -0.5
-      vertex 16.5 20.3 0
-      vertex 15.5 20.3 0
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 16.5 20.3 0
-      vertex 15.5 20.3 -0.5
-      vertex 16.5 20.3 -0.5
+      vertex 16.5 20 11.5
     endloop
   endfacet
   facet normal -0 0 1
@@ -9158,15 +9144,29 @@ solid OpenSCAD_Model
   facet normal 0 1 -0
     outer loop
       vertex 16.5 20 -0.5
-      vertex 15.5 20 0
-      vertex 16.5 20 0
+      vertex 15.5 20 11.5
+      vertex 16.5 20 11.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 15.5 20 0
+      vertex 15.5 20 11.5
       vertex 16.5 20 -0.5
       vertex 15.5 20 -0.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 15.5 20.3 -0.5
+      vertex 16.5 20.3 11.5
+      vertex 15.5 20.3 11.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 16.5 20.3 11.5
+      vertex 15.5 20.3 -0.5
+      vertex 16.5 20.3 -0.5
     endloop
   endfacet
   facet normal 0.707107 -0.707107 0


### PR DESCRIPTION
The order that the Y-belt holder was assembled in cause the internal reinforcement cuts to only cut into the flat base part, and not extend up into the belt holders.  I moved a few things around so that the reinforcement cuts work as designed.