### PR TITLE
MK3 fan nozzle fixed

### DIFF
--- a/Printed-Parts/scad/nozzle-fan.scad
+++ b/Printed-Parts/scad/nozzle-fan.scad
@@ -127,7 +127,7 @@ module inner_shape()
 
     // fan cut
     translate([-10,-46,-51]) cube([20,10,15.5]);    
-    translate([10,-52,-44]) cube([1,75,15,3]);    
+    translate([10,-52,-44]) cube([1.75,15,3]);    
 
 }
 

--- a/Printed-Parts/scad/nozzle-fan.scad
+++ b/Printed-Parts/scad/nozzle-fan.scad
@@ -172,7 +172,7 @@ module fan_nozzle()
     translate([-11.2,-53,-41.0]) rotate([0,-30,0]) cube([0.8,9,4.5]); 
 
 
-    translate([10,-51,-50.8]) rotate([0,180,0]) linear_extrude(height = 2) 
+    translate([10,-51,-52]) rotate([0,180,0]) linear_extrude(height = 0.8) 
     { text("HOT!2",font = "helvetica:style=Bold", size=5, center=true); }
 }
 

--- a/Printed-Parts/scad/nozzle-fan.scad
+++ b/Printed-Parts/scad/nozzle-fan.scad
@@ -126,8 +126,8 @@ module inner_shape()
     }
 
     // fan cut
-    translate([-10.25,-46,-51]) cube([20.5,10,15.5]);    
-    translate([10.25,-52,-44]) cube([2,15,3]);    
+    translate([-10,-46,-51]) cube([20,10,15.5]);    
+    translate([10,-52,-44]) cube([1,75,15,3]);    
 
 }
 

--- a/Printed-Parts/stl/nozzle-fan.stl
+++ b/Printed-Parts/stl/nozzle-fan.stl
@@ -15,9 +15,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.25 35.5 -44
+      vertex 10 35.5 -44
       vertex 10.5 36.4525 -44
-      vertex 10.25 36.5638 -44
+      vertex 10 36.6751 -44
     endloop
   endfacet
   facet normal -0 0 1
@@ -30,7 +30,7 @@ solid OpenSCAD_Model
   facet normal 0 0 1
     outer loop
       vertex 10.5 36.4525 -44
-      vertex 10.25 35.5 -44
+      vertex 10 35.5 -44
       vertex 10.5 35.5 -44
     endloop
   endfacet
@@ -38,7 +38,7 @@ solid OpenSCAD_Model
     outer loop
       vertex 9.07974 30 -44
       vertex 10.5 35.5 -44
-      vertex 10.25 35.5 -44
+      vertex 10 35.5 -44
     endloop
   endfacet
   facet normal 0 0 1
@@ -51,7 +51,7 @@ solid OpenSCAD_Model
   facet normal 0 -0 1
     outer loop
       vertex 9.07974 30 -44
-      vertex 10.25 35.5 -44
+      vertex 10 35.5 -44
       vertex 7.91068 35.5 -44
     endloop
   endfacet
@@ -671,27 +671,6 @@ solid OpenSCAD_Model
       vertex 23.7898 17 -47.6073
     endloop
   endfacet
-  facet normal 0.743137 0.66914 0
-    outer loop
-      vertex 18.6122 30 -44
-      vertex 18 30.6799 -53
-      vertex 18 30.6799 -44
-    endloop
-  endfacet
-  facet normal 0.743161 0.669112 -3.78246e-06
-    outer loop
-      vertex 19.4164 29.1068 -44.1575
-      vertex 18 30.6799 -53
-      vertex 18.6122 30 -44
-    endloop
-  endfacet
-  facet normal 0.743151 0.669124 0
-    outer loop
-      vertex 18 30.6799 -53
-      vertex 19.4164 29.1068 -44.1575
-      vertex 19.4164 29.1068 -53
-    endloop
-  endfacet
   facet normal -0.99452 0.104545 0
     outer loop
       vertex -23.7898 17 -46.2923
@@ -874,16 +853,37 @@ solid OpenSCAD_Model
       vertex -9.07974 30 -44
     endloop
   endfacet
+  facet normal 0.743137 0.66914 0
+    outer loop
+      vertex 18.6122 30 -44
+      vertex 18 30.6799 -53
+      vertex 18 30.6799 -44
+    endloop
+  endfacet
+  facet normal 0.743161 0.669112 -3.78246e-06
+    outer loop
+      vertex 19.4164 29.1068 -44.1575
+      vertex 18 30.6799 -53
+      vertex 18.6122 30 -44
+    endloop
+  endfacet
+  facet normal 0.743151 0.669124 0
+    outer loop
+      vertex 18 30.6799 -53
+      vertex 19.4164 29.1068 -44.1575
+      vertex 19.4164 29.1068 -53
+    endloop
+  endfacet
   facet normal 0 0 1
     outer loop
-      vertex -10.25 36.5638 -44
+      vertex -10 36.6751 -44
       vertex -12 35.7846 -44
-      vertex -10.25 35.5 -44
+      vertex -10 35.5 -44
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -10.25 35.5 -44
+      vertex -10 35.5 -44
       vertex -9.07974 30 -44
       vertex -7.91068 35.5 -44
     endloop
@@ -891,92 +891,36 @@ solid OpenSCAD_Model
   facet normal 0 0 1
     outer loop
       vertex -12.608 30 -44
-      vertex -10.25 35.5 -44
+      vertex -10 35.5 -44
       vertex -12 35.7846 -44
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -10.25 35.5 -44
+      vertex -10 35.5 -44
       vertex -12.608 30 -44
       vertex -9.07974 30 -44
     endloop
   endfacet
-  facet normal -0.207831 -0.978165 0
+  facet normal -0.994572 -0.104048 0
     outer loop
-      vertex 2.1049 28.787 -49
-      vertex 1.4634 28.9233 -44.1898
-      vertex 1.4634 28.9233 -49
-    endloop
-  endfacet
-  facet normal -0.207907 -0.978149 -1.05409e-05
-    outer loop
-      vertex 1.4634 28.9233 -44.1898
-      vertex 2.1049 28.787 -49
-      vertex 4.32624 28.3148 -44.2971
-    endloop
-  endfacet
-  facet normal -0.207928 -0.978144 -0
-    outer loop
-      vertex 4.32624 28.3148 -44.2971
-      vertex 2.1049 28.787 -49
-      vertex 4.32624 28.3148 -49
-    endloop
-  endfacet
-  facet normal -0.866007 -0.500033 -3.52396e-05
-    outer loop
-      vertex 12.7896 20.6943 -45.6408
-      vertex 11.3262 23.229 -49
-      vertex 12.5127 21.1741 -49
-    endloop
-  endfacet
-  facet normal -0.866113 -0.499847 -0
-    outer loop
-      vertex 12.7896 20.6943 -45.6408
-      vertex 12.5127 21.1741 -49
-      vertex 12.7896 20.6943 -49
-    endloop
-  endfacet
-  facet normal -0.866027 -0.499998 0
-    outer loop
-      vertex 11.3262 23.229 -49
-      vertex 12.7896 20.6943 -45.6408
-      vertex 11.3262 23.229 -45.1939
-    endloop
-  endfacet
-  facet normal -0.951048 -0.309044 -0
-    outer loop
+      vertex 13.7043 17.8133 -49
       vertex 13.6941 17.9108 -46.1317
-      vertex 12.7896 20.6943 -49
       vertex 13.6941 17.9108 -49
     endloop
   endfacet
-  facet normal -0.951048 -0.309044 0
+  facet normal -0.99452 -0.104551 -0
     outer loop
-      vertex 12.7896 20.6943 -49
+      vertex 13.7898 17 -46.2923
+      vertex 13.7043 17.8133 -49
+      vertex 13.7898 17 -49
+    endloop
+  endfacet
+  facet normal -0.994525 -0.1045 1.55453e-05
+    outer loop
+      vertex 13.7043 17.8133 -49
+      vertex 13.7898 17 -46.2923
       vertex 13.6941 17.9108 -46.1317
-      vertex 12.7896 20.6943 -45.6408
-    endloop
-  endfacet
-  facet normal 0.406699 -0.913562 0
-    outer loop
-      vertex -5.25329 27.902 -49
-      vertex -7 27.1244 -44.5071
-      vertex -7 27.1244 -49
-    endloop
-  endfacet
-  facet normal 0.406726 -0.91355 1.23832e-05
-    outer loop
-      vertex -7 27.1244 -44.5071
-      vertex -5.25329 27.902 -49
-      vertex -4.32624 28.3148 -44.2971
-    endloop
-  endfacet
-  facet normal 0.406778 -0.913527 0
-    outer loop
-      vertex -4.32624 28.3148 -44.2971
-      vertex -5.25329 27.902 -49
-      vertex -4.32624 28.3148 -49
     endloop
   endfacet
   facet normal 0 -1 0
@@ -991,20 +935,6 @@ solid OpenSCAD_Model
       vertex 1.4634 28.9233 -44.1898
       vertex -1.4634 28.9233 -49
       vertex 1.4634 28.9233 -49
-    endloop
-  endfacet
-  facet normal 0.951048 -0.309044 0
-    outer loop
-      vertex -13.6941 17.9108 -46.1317
-      vertex -12.7896 20.6943 -49
-      vertex -12.7896 20.6943 -45.6408
-    endloop
-  endfacet
-  facet normal 0.951048 -0.309044 0
-    outer loop
-      vertex -12.7896 20.6943 -49
-      vertex -13.6941 17.9108 -46.1317
-      vertex -13.6941 17.9108 -49
     endloop
   endfacet
   facet normal 0.994572 -0.104048 0
@@ -1028,6 +958,27 @@ solid OpenSCAD_Model
       vertex -13.7898 17 -49
     endloop
   endfacet
+  facet normal -0.866007 -0.500033 -3.52396e-05
+    outer loop
+      vertex 12.7896 20.6943 -45.6408
+      vertex 11.3262 23.229 -49
+      vertex 12.5127 21.1741 -49
+    endloop
+  endfacet
+  facet normal -0.866113 -0.499847 -0
+    outer loop
+      vertex 12.7896 20.6943 -45.6408
+      vertex 12.5127 21.1741 -49
+      vertex 12.7896 20.6943 -49
+    endloop
+  endfacet
+  facet normal -0.866027 -0.499998 0
+    outer loop
+      vertex 11.3262 23.229 -49
+      vertex 12.7896 20.6943 -45.6408
+      vertex 11.3262 23.229 -45.1939
+    endloop
+  endfacet
   facet normal -0.406778 -0.913527 0
     outer loop
       vertex 5.25329 27.902 -49
@@ -1047,6 +998,69 @@ solid OpenSCAD_Model
       vertex 7 27.1244 -44.5071
       vertex 5.25329 27.902 -49
       vertex 7 27.1244 -49
+    endloop
+  endfacet
+  facet normal 0.406699 -0.913562 0
+    outer loop
+      vertex -5.25329 27.902 -49
+      vertex -7 27.1244 -44.5071
+      vertex -7 27.1244 -49
+    endloop
+  endfacet
+  facet normal 0.406726 -0.91355 1.23832e-05
+    outer loop
+      vertex -7 27.1244 -44.5071
+      vertex -5.25329 27.902 -49
+      vertex -4.32624 28.3148 -44.2971
+    endloop
+  endfacet
+  facet normal 0.406778 -0.913527 0
+    outer loop
+      vertex -4.32624 28.3148 -44.2971
+      vertex -5.25329 27.902 -49
+      vertex -4.32624 28.3148 -49
+    endloop
+  endfacet
+  facet normal 0.74312 -0.669158 0
+    outer loop
+      vertex -9.36783 25.404 -44.8104
+      vertex -10.6085 24.0262 -49
+      vertex -9.36783 25.404 -49
+    endloop
+  endfacet
+  facet normal 0.743148 -0.669127 -1.86189e-05
+    outer loop
+      vertex -11.3262 23.229 -45.1939
+      vertex -10.6085 24.0262 -49
+      vertex -9.36783 25.404 -44.8104
+    endloop
+  endfacet
+  facet normal 0.743192 -0.669078 0
+    outer loop
+      vertex -10.6085 24.0262 -49
+      vertex -11.3262 23.229 -45.1939
+      vertex -11.3262 23.229 -49
+    endloop
+  endfacet
+  facet normal -0.207831 -0.978165 0
+    outer loop
+      vertex 2.1049 28.787 -49
+      vertex 1.4634 28.9233 -44.1898
+      vertex 1.4634 28.9233 -49
+    endloop
+  endfacet
+  facet normal -0.207907 -0.978149 -1.05409e-05
+    outer loop
+      vertex 1.4634 28.9233 -44.1898
+      vertex 2.1049 28.787 -49
+      vertex 4.32624 28.3148 -44.2971
+    endloop
+  endfacet
+  facet normal -0.207928 -0.978144 -0
+    outer loop
+      vertex 4.32624 28.3148 -44.2971
+      vertex 2.1049 28.787 -49
+      vertex 4.32624 28.3148 -49
     endloop
   endfacet
   facet normal -0.587795 -0.80901 0
@@ -1091,25 +1105,18 @@ solid OpenSCAD_Model
       vertex 9.36783 25.404 -44.8104
     endloop
   endfacet
-  facet normal -0.994572 -0.104048 0
+  facet normal -0.951048 -0.309044 -0
     outer loop
-      vertex 13.7043 17.8133 -49
       vertex 13.6941 17.9108 -46.1317
+      vertex 12.7896 20.6943 -49
       vertex 13.6941 17.9108 -49
     endloop
   endfacet
-  facet normal -0.99452 -0.104551 -0
+  facet normal -0.951048 -0.309044 0
     outer loop
-      vertex 13.7898 17 -46.2923
-      vertex 13.7043 17.8133 -49
-      vertex 13.7898 17 -49
-    endloop
-  endfacet
-  facet normal -0.994525 -0.1045 1.55453e-05
-    outer loop
-      vertex 13.7043 17.8133 -49
-      vertex 13.7898 17 -46.2923
+      vertex 12.7896 20.6943 -49
       vertex 13.6941 17.9108 -46.1317
+      vertex 12.7896 20.6943 -45.6408
     endloop
   endfacet
   facet normal 0.207928 -0.978144 0
@@ -1133,46 +1140,18 @@ solid OpenSCAD_Model
       vertex -1.4634 28.9233 -49
     endloop
   endfacet
-  facet normal 0.74312 -0.669158 0
+  facet normal 0.951048 -0.309044 0
     outer loop
-      vertex -9.36783 25.404 -44.8104
-      vertex -10.6085 24.0262 -49
-      vertex -9.36783 25.404 -49
+      vertex -13.6941 17.9108 -46.1317
+      vertex -12.7896 20.6943 -49
+      vertex -12.7896 20.6943 -45.6408
     endloop
   endfacet
-  facet normal 0.743148 -0.669127 -1.86189e-05
+  facet normal 0.951048 -0.309044 0
     outer loop
-      vertex -11.3262 23.229 -45.1939
-      vertex -10.6085 24.0262 -49
-      vertex -9.36783 25.404 -44.8104
-    endloop
-  endfacet
-  facet normal 0.743192 -0.669078 0
-    outer loop
-      vertex -10.6085 24.0262 -49
-      vertex -11.3262 23.229 -45.1939
-      vertex -11.3262 23.229 -49
-    endloop
-  endfacet
-  facet normal 0.587807 -0.809002 0
-    outer loop
-      vertex -8.13989 26.2962 -49
-      vertex -9.36783 25.404 -44.8104
-      vertex -9.36783 25.404 -49
-    endloop
-  endfacet
-  facet normal 0.587801 -0.809005 -2.35407e-06
-    outer loop
-      vertex -9.36783 25.404 -44.8104
-      vertex -8.13989 26.2962 -49
-      vertex -7 27.1244 -44.5071
-    endloop
-  endfacet
-  facet normal 0.587795 -0.80901 0
-    outer loop
-      vertex -7 27.1244 -44.5071
-      vertex -8.13989 26.2962 -49
-      vertex -7 27.1244 -49
+      vertex -12.7896 20.6943 -49
+      vertex -13.6941 17.9108 -46.1317
+      vertex -13.6941 17.9108 -49
     endloop
   endfacet
   facet normal 0.866027 -0.499998 0
@@ -1194,6 +1173,27 @@ solid OpenSCAD_Model
       vertex -12.5127 21.1741 -49
       vertex -12.7896 20.6943 -45.6408
       vertex -12.7896 20.6943 -49
+    endloop
+  endfacet
+  facet normal 0.587807 -0.809002 0
+    outer loop
+      vertex -8.13989 26.2962 -49
+      vertex -9.36783 25.404 -44.8104
+      vertex -9.36783 25.404 -49
+    endloop
+  endfacet
+  facet normal 0.587801 -0.809005 -2.35407e-06
+    outer loop
+      vertex -9.36783 25.404 -44.8104
+      vertex -8.13989 26.2962 -49
+      vertex -7 27.1244 -44.5071
+    endloop
+  endfacet
+  facet normal 0.587795 -0.80901 0
+    outer loop
+      vertex -7 27.1244 -44.5071
+      vertex -8.13989 26.2962 -49
+      vertex -7 27.1244 -49
     endloop
   endfacet
   facet normal 0 1 0
@@ -1285,6 +1285,97 @@ solid OpenSCAD_Model
       vertex 18 35.5 -53
       vertex 18 30.6799 -44
       vertex 18 30.6799 -53
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18 35.5 -44
+      vertex 16.0591 32.8355 -44
+      vertex 18 30.6799 -44
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 16.0591 32.8355 -44
+      vertex 18 35.5 -44
+      vertex 12.3917 35.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10 51 -44
+      vertex 17.8395 40.5 -44
+      vertex 11.2 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 36.6751 -44
+      vertex 10.5 40.5 -44
+      vertex 10 51 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8395 40.5 -44
+      vertex 10 51 -44
+      vertex 10.5 40.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.1397 52 -44
+      vertex 10 51 -44
+      vertex 11.2 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 51 -44
+      vertex -11.1397 52 -44
+      vertex -10 51 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18 40.1177 -44
+      vertex -10 51 -44
+      vertex -11.1397 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 51 -44
+      vertex -18 40.1177 -44
+      vertex -10 36.6751 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 36.6751 -44
+      vertex -18 40.1177 -44
+      vertex -12 35.7846 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 35.7846 -44
+      vertex -18 40.1177 -44
+      vertex -16.0591 32.8355 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0591 32.8355 -44
+      vertex -18 40.1177 -44
+      vertex -18 30.6799 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 40.5 -44
+      vertex 10 36.6751 -44
+      vertex 10.5 36.4525 -44
     endloop
   endfacet
   facet normal 0 1 0
@@ -2288,125 +2379,6 @@ solid OpenSCAD_Model
       vertex 6.49101 52 -51
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18 35.5 -44
-      vertex 16.0591 32.8355 -44
-      vertex 18 30.6799 -44
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 16.0591 32.8355 -44
-      vertex 18 35.5 -44
-      vertex 12.3917 35.5 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.1397 52 -44
-      vertex 10.25 51 -44
-      vertex 11.2 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.25 51 -44
-      vertex -11.1397 52 -44
-      vertex -10.25 51 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18 40.1177 -44
-      vertex -10.25 51 -44
-      vertex -11.1397 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.25 51 -44
-      vertex -18 40.1177 -44
-      vertex -10.25 36.5638 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.25 36.5638 -44
-      vertex -18 40.1177 -44
-      vertex -12 35.7846 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12 35.7846 -44
-      vertex -18 40.1177 -44
-      vertex -16.0591 32.8355 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0591 32.8355 -44
-      vertex -18 40.1177 -44
-      vertex -18 30.6799 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.2 52 -44
-      vertex 12.25 44 -44
-      vertex 17.8395 40.5 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.25 51 -44
-      vertex 12.25 44 -44
-      vertex 11.2 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.25 44 -44
-      vertex 10.25 51 -44
-      vertex 10.25 44 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.25 41 -44
-      vertex 17.8395 40.5 -44
-      vertex 12.25 44 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.25 41 -44
-      vertex 10.5 40.5 -44
-      vertex 17.8395 40.5 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.25 41 -44
-      vertex 10.5 40.5 -44
-      vertex 12.25 41 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.25 36.5638 -44
-      vertex 10.5 40.5 -44
-      vertex 10.25 41 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 40.5 -44
-      vertex 10.25 36.5638 -44
-      vertex 10.5 36.4525 -44
-    endloop
-  endfacet
   facet normal 0 -1 0
     outer loop
       vertex -17.8 11 -47.3502
@@ -2687,6 +2659,20 @@ solid OpenSCAD_Model
       vertex 18.4272 11.0329 -53
     endloop
   endfacet
+  facet normal 0.587788 -0.809015 0
+    outer loop
+      vertex 21.8148 12.5411 -53
+      vertex 20.8 11.8038 -47.2085
+      vertex 20.8 11.8038 -53
+    endloop
+  endfacet
+  facet normal 0.587788 -0.809015 0
+    outer loop
+      vertex 20.8 11.8038 -47.2085
+      vertex 21.8148 12.5411 -53
+      vertex 21.8148 12.5411 -47.0785
+    endloop
+  endfacet
   facet normal 0.866017 -0.500015 0
     outer loop
       vertex 22.6541 13.4733 -46.9141
@@ -2729,20 +2715,6 @@ solid OpenSCAD_Model
       vertex 21.8148 12.5411 -53
     endloop
   endfacet
-  facet normal 0.587788 -0.809015 0
-    outer loop
-      vertex 21.8148 12.5411 -53
-      vertex 20.8 11.8038 -47.2085
-      vertex 20.8 11.8038 -53
-    endloop
-  endfacet
-  facet normal 0.587788 -0.809015 0
-    outer loop
-      vertex 20.8 11.8038 -47.2085
-      vertex 21.8148 12.5411 -53
-      vertex 21.8148 12.5411 -47.0785
-    endloop
-  endfacet
   facet normal 0.207923 -0.978145 0
     outer loop
       vertex 19.6541 11.2937 -53
@@ -2773,9 +2745,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 0
     outer loop
-      vertex 5.39024 30 -44
-      vertex -5.39024 30 -44
-      vertex -9.07974 30 -44
+      vertex 18.6122 30 -44
+      vertex 16.0591 30 -44
+      vertex 12.608 30 -44
     endloop
   endfacet
   facet normal 0 0 0
@@ -2787,29 +2759,22 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 0
     outer loop
-      vertex 9.07974 30 -44
-      vertex 5.39024 30 -44
-      vertex -9.07974 30 -44
+      vertex -11.3909 30 -44
+      vertex 11.1204 30 -44
+      vertex 18.6122 30 -44
     endloop
   endfacet
-  facet normal 0 0 0
+  facet normal 0 0 -0
     outer loop
-      vertex 12.608 30 -44
-      vertex 9.07974 30 -44
-      vertex -9.07974 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
+      vertex -16.0591 30 -44
       vertex -18.6122 30 -44
       vertex -12.6355 30 -44
-      vertex -11.3909 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
+      vertex -11.3909 30 -44
       vertex 18.6122 30 -44
-      vertex 16.0591 30 -44
       vertex 12.608 30 -44
     endloop
   endfacet
@@ -2822,37 +2787,44 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 0
     outer loop
+      vertex -12.6355 30 -44
+      vertex -11.3909 30 -44
+      vertex 12.608 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -5.39024 30 -44
       vertex -9.07974 30 -44
       vertex -16.0591 30 -44
-      vertex -18.6122 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
-      vertex -18.6122 30 -44
-      vertex -11.3909 30 -44
-      vertex 11.1204 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex 18.6122 30 -44
+      vertex -12.6355 30 -44
       vertex 12.608 30 -44
-      vertex -9.07974 30 -44
+      vertex 9.07974 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
-      vertex 18.6122 30 -44
-      vertex -9.07974 30 -44
-      vertex -18.6122 30 -44
+      vertex -12.6355 30 -44
+      vertex 9.07974 30 -44
+      vertex 5.39024 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
-      vertex -18.6122 30 -44
-      vertex 11.1204 30 -44
-      vertex 18.6122 30 -44
+      vertex 5.39024 30 -44
+      vertex -5.39024 30 -44
+      vertex -16.0591 30 -44
+    endloop
+  endfacet
+  facet normal 0 -0 0
+    outer loop
+      vertex -12.6355 30 -44
+      vertex 5.39024 30 -44
+      vertex -16.0591 30 -44
     endloop
   endfacet
   facet normal 5.89577e-06 -0.173638 0.98481
@@ -3597,20 +3569,6 @@ solid OpenSCAD_Model
       vertex 18.5 35.5 -53
     endloop
   endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.5 40.5 -36
-      vertex 18.5 35.5 -36
-      vertex 18.5 40.5 -36
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5 35.5 -36
-      vertex 10.5 40.5 -36
-      vertex 10.5 35.5 -36
-    endloop
-  endfacet
   facet normal 0 1 0
     outer loop
       vertex 18.5 40.5 -36
@@ -3863,6 +3821,20 @@ solid OpenSCAD_Model
       vertex 17.8395 40.5 -44
     endloop
   endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.5 40.5 -36
+      vertex 18.5 35.5 -36
+      vertex 18.5 40.5 -36
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 35.5 -36
+      vertex 10.5 40.5 -36
+      vertex 10.5 35.5 -36
+    endloop
+  endfacet
   facet normal -0.99451 0 -0.10464
     outer loop
       vertex 16.15 35.5 -40.5
@@ -4101,6 +4073,20 @@ solid OpenSCAD_Model
       vertex 13.9901 38 -38.9308
     endloop
   endfacet
+  facet normal -0.951119 0 0.308824
+    outer loop
+      vertex 16.0074 35.5 -41.1711
+      vertex 16.1139 38 -40.8431
+      vertex 16.0074 38 -41.1711
+    endloop
+  endfacet
+  facet normal -0.951119 0 0.308824
+    outer loop
+      vertex 16.1139 38 -40.8431
+      vertex 16.0074 35.5 -41.1711
+      vertex 16.1139 35.5 -40.8431
+    endloop
+  endfacet
   facet normal -0.99451 0 0.10464
     outer loop
       vertex 16.1139 35.5 -40.8431
@@ -4115,18 +4101,18 @@ solid OpenSCAD_Model
       vertex 16.15 35.5 -40.5
     endloop
   endfacet
-  facet normal -0.951119 0 0.308824
+  facet normal 0.587637 0 0.809125
     outer loop
-      vertex 16.0074 35.5 -41.1711
-      vertex 16.1139 38 -40.8431
-      vertex 16.0074 38 -41.1711
+      vertex 13.3959 38 -41.7262
+      vertex 13.675 35.5 -41.9289
+      vertex 13.675 38 -41.9289
     endloop
   endfacet
-  facet normal -0.951119 0 0.308824
+  facet normal 0.587637 0 0.809125
     outer loop
-      vertex 16.1139 38 -40.8431
-      vertex 16.0074 35.5 -41.1711
-      vertex 16.1139 35.5 -40.8431
+      vertex 13.675 35.5 -41.9289
+      vertex 13.3959 38 -41.7262
+      vertex 13.3959 35.5 -41.7262
     endloop
   endfacet
   facet normal 0.865968 -0 0.500099
@@ -4253,20 +4239,6 @@ solid OpenSCAD_Model
       vertex 13.9901 35.5 -42.0692
       vertex 13.675 38 -41.9289
       vertex 13.675 35.5 -41.9289
-    endloop
-  endfacet
-  facet normal 0.587637 0 0.809125
-    outer loop
-      vertex 13.3959 38 -41.7262
-      vertex 13.675 35.5 -41.9289
-      vertex 13.675 38 -41.9289
-    endloop
-  endfacet
-  facet normal 0.587637 0 0.809125
-    outer loop
-      vertex 13.675 35.5 -41.9289
-      vertex 13.3959 38 -41.7262
-      vertex 13.3959 35.5 -41.7262
     endloop
   endfacet
   facet normal 0.208143 0 0.978098
@@ -4941,6 +4913,20 @@ solid OpenSCAD_Model
       vertex 12.95 40.5 -37.8153
     endloop
   endfacet
+  facet normal -0.994528 0 0.104468
+    outer loop
+      vertex 17.5323 38 -41.1445
+      vertex 17.6 40.5 -40.5
+      vertex 17.5323 40.5 -41.1445
+    endloop
+  endfacet
+  facet normal -0.994528 0 0.104468
+    outer loop
+      vertex 17.6 40.5 -40.5
+      vertex 17.5323 38 -41.1445
+      vertex 17.6 38 -40.5
+    endloop
+  endfacet
   facet normal -0.207822 0 0.978167
     outer loop
       vertex 14.824 40.5 -43.583
@@ -4997,18 +4983,18 @@ solid OpenSCAD_Model
       vertex 17.5323 38 -41.1445
     endloop
   endfacet
-  facet normal -0.994528 0 0.104468
+  facet normal 0.58786 0 0.808963
     outer loop
-      vertex 17.5323 38 -41.1445
-      vertex 17.6 40.5 -40.5
-      vertex 17.5323 40.5 -41.1445
+      vertex 12.4257 40.5 -42.8037
+      vertex 12.95 38 -43.1847
+      vertex 12.95 40.5 -43.1847
     endloop
   endfacet
-  facet normal -0.994528 0 0.104468
+  facet normal 0.58786 0 0.808963
     outer loop
-      vertex 17.6 40.5 -40.5
-      vertex 17.5323 38 -41.1445
-      vertex 17.6 38 -40.5
+      vertex 12.95 38 -43.1847
+      vertex 12.4257 40.5 -42.8037
+      vertex 12.4257 38 -42.8037
     endloop
   endfacet
   facet normal 0.866031 -0 0.49999
@@ -5025,18 +5011,18 @@ solid OpenSCAD_Model
       vertex 11.992 38 -42.3221
     endloop
   endfacet
-  facet normal 0.994528 -0 0.104468
+  facet normal 0.743095 -0 0.669186
     outer loop
-      vertex 11.4 38 -40.5
-      vertex 11.4677 40.5 -41.1445
-      vertex 11.4 40.5 -40.5
+      vertex 11.992 38 -42.3221
+      vertex 12.4257 40.5 -42.8037
+      vertex 11.992 40.5 -42.3221
     endloop
   endfacet
-  facet normal 0.994528 0 0.104468
+  facet normal 0.743095 0 0.669186
     outer loop
-      vertex 11.4677 40.5 -41.1445
-      vertex 11.4 38 -40.5
-      vertex 11.4677 38 -41.1445
+      vertex 12.4257 40.5 -42.8037
+      vertex 11.992 38 -42.3221
+      vertex 12.4257 38 -42.8037
     endloop
   endfacet
   facet normal -0.406768 0 0.913531
@@ -5067,34 +5053,6 @@ solid OpenSCAD_Model
       vertex 13.542 38 -43.4483
     endloop
   endfacet
-  facet normal 0.58786 0 0.808963
-    outer loop
-      vertex 12.4257 40.5 -42.8037
-      vertex 12.95 38 -43.1847
-      vertex 12.95 40.5 -43.1847
-    endloop
-  endfacet
-  facet normal 0.58786 0 0.808963
-    outer loop
-      vertex 12.95 38 -43.1847
-      vertex 12.4257 40.5 -42.8037
-      vertex 12.4257 38 -42.8037
-    endloop
-  endfacet
-  facet normal 0.743095 -0 0.669186
-    outer loop
-      vertex 11.992 38 -42.3221
-      vertex 12.4257 40.5 -42.8037
-      vertex 11.992 40.5 -42.3221
-    endloop
-  endfacet
-  facet normal 0.743095 0 0.669186
-    outer loop
-      vertex 12.4257 40.5 -42.8037
-      vertex 11.992 38 -42.3221
-      vertex 12.4257 38 -42.8037
-    endloop
-  endfacet
   facet normal 0.951048 -0 0.309044
     outer loop
       vertex 11.4677 38 -41.1445
@@ -5107,6 +5065,20 @@ solid OpenSCAD_Model
       vertex 11.668 40.5 -41.7609
       vertex 11.4677 38 -41.1445
       vertex 11.668 38 -41.7609
+    endloop
+  endfacet
+  facet normal 0.994528 -0 0.104468
+    outer loop
+      vertex 11.4 38 -40.5
+      vertex 11.4677 40.5 -41.1445
+      vertex 11.4 40.5 -40.5
+    endloop
+  endfacet
+  facet normal 0.994528 0 0.104468
+    outer loop
+      vertex 11.4677 40.5 -41.1445
+      vertex 11.4 38 -40.5
+      vertex 11.4677 38 -41.1445
     endloop
   endfacet
   facet normal 0.406768 0 0.913531
@@ -5244,62 +5216,6 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -0.4 30.9123 -45
-      vertex -1.67245 30.9123 -45
-      vertex -0.4 35.4 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.67245 30.9123 -45
-      vertex 3.17551 35.5 -45
-      vertex 4.88823 30.2288 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.4 35.4 -45
-      vertex 1.67245 30.9123 -45
-      vertex 0.4 30.9123 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.67245 30.9123 -45
-      vertex 0.4 35.4 -45
-      vertex 3.17551 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.4 35.4 -45
-      vertex 3.17551 35.5 -45
-      vertex 0.4 35.4 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.4 35.4 -45
-      vertex -3.17551 35.5 -45
-      vertex 3.17551 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.67245 30.9123 -45
-      vertex -3.17551 35.5 -45
-      vertex -0.4 35.4 -45
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -3.17551 35.5 -45
-      vertex -1.67245 30.9123 -45
-      vertex -4.88823 30.2288 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
       vertex 7.74447 33.8771 -45
       vertex 11.5 34.9186 -45
       vertex 11.9833 30.3203 -45
@@ -5309,14 +5225,21 @@ solid OpenSCAD_Model
     outer loop
       vertex 11.5 34.9186 -45
       vertex 7.74447 33.8771 -45
-      vertex 10.1941 35.5 -45
+      vertex 10 35.5 -45
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 10.1941 35.5 -45
+      vertex 10 35.5 -45
       vertex 7.74447 33.8771 -45
       vertex 7.39951 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5 34.9186 -45
+      vertex 10 35.5 -45
+      vertex 10 35.5864 -45
     endloop
   endfacet
   facet normal 0 0 -1
@@ -6113,15 +6036,22 @@ solid OpenSCAD_Model
   facet normal 0 0 -1
     outer loop
       vertex -7.68576 34.1533 -45
-      vertex -10.1941 35.5 -45
+      vertex -10 35.5 -45
       vertex -7.39951 35.5 -45
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10 35.5 -45
+      vertex -11.5 34.9186 -45
+      vertex -10 35.5864 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
       vertex -7.68576 34.1533 -45
       vertex -11.5 34.9186 -45
-      vertex -10.1941 35.5 -45
+      vertex -10 35.5 -45
     endloop
   endfacet
   facet normal 0 -0 -1
@@ -6271,6 +6201,62 @@ solid OpenSCAD_Model
       vertex -7.68576 34.1533 -45
     endloop
   endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.4 30.9123 -45
+      vertex -1.67245 30.9123 -45
+      vertex -0.4 35.4 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.67245 30.9123 -45
+      vertex 3.17551 35.5 -45
+      vertex 4.88823 30.2288 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.4 35.4 -45
+      vertex 1.67245 30.9123 -45
+      vertex 0.4 30.9123 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.67245 30.9123 -45
+      vertex 0.4 35.4 -45
+      vertex 3.17551 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.4 35.4 -45
+      vertex 3.17551 35.5 -45
+      vertex 0.4 35.4 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.4 35.4 -45
+      vertex -3.17551 35.5 -45
+      vertex 3.17551 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.67245 30.9123 -45
+      vertex -3.17551 35.5 -45
+      vertex -0.4 35.4 -45
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -3.17551 35.5 -45
+      vertex -1.67245 30.9123 -45
+      vertex -4.88823 30.2288 -45
+    endloop
+  endfacet
   facet normal 0.866035 -0.499984 0
     outer loop
       vertex -21.0115 24.3549 -45.877
@@ -6306,6 +6292,41 @@ solid OpenSCAD_Model
       vertex -18.6074 28.5191 -52
     endloop
   endfacet
+  facet normal 0.74319 0.669081 0
+    outer loop
+      vertex 10.7061 26.8903 -45.43
+      vertex 11.1196 26.431 -49
+      vertex 10.7061 26.8903 -49
+    endloop
+  endfacet
+  facet normal 0.743134 0.669142 -1.43392e-05
+    outer loop
+      vertex 10.7061 26.8903 -45.43
+      vertex 12.5351 24.859 -48
+      vertex 11.1196 26.431 -49
+    endloop
+  endfacet
+  facet normal 0.743134 0.669143 -1.49169e-05
+    outer loop
+      vertex 12.9443 24.4046 -45.8683
+      vertex 12.5351 24.859 -48
+      vertex 10.7061 26.8903 -45.43
+    endloop
+  endfacet
+  facet normal 0.743099 0.669182 0
+    outer loop
+      vertex 12.5351 24.859 -48
+      vertex 12.9443 24.4046 -45.8683
+      vertex 12.9443 24.4046 -48
+    endloop
+  endfacet
+  facet normal 0.74313 0.669148 0
+    outer loop
+      vertex 11.1196 26.431 -49
+      vertex 12.5351 24.859 -48
+      vertex 12.5351 24.859 -49
+    endloop
+  endfacet
   facet normal -0.994527 0.104483 -1.6329e-05
     outer loop
       vertex -15.7898 17 -47.1739
@@ -6325,6 +6346,90 @@ solid OpenSCAD_Model
       vertex -15.6504 18.3266 -49
       vertex -15.7898 17 -47.1739
       vertex -15.6504 18.3266 -46.94
+    endloop
+  endfacet
+  facet normal 0.951066 0.308989 0
+    outer loop
+      vertex 14.6167 21.5078 -46.379
+      vertex 14.9257 20.5567 -49
+      vertex 14.6167 21.5078 -49
+    endloop
+  endfacet
+  facet normal 0.95105 0.309038 -1.96526e-05
+    outer loop
+      vertex 15.6504 18.3266 -46.94
+      vertex 14.9257 20.5567 -49
+      vertex 14.6167 21.5078 -46.379
+    endloop
+  endfacet
+  facet normal 0.951044 0.309054 0
+    outer loop
+      vertex 14.9257 20.5567 -49
+      vertex 15.6504 18.3266 -46.94
+      vertex 15.6504 18.3266 -49
+    endloop
+  endfacet
+  facet normal 0.406731 0.913548 -0
+    outer loop
+      vertex 8 28.8564 -49
+      vertex 6.14856 29.6807 -48
+      vertex 8 28.8564 -45.0833
+    endloop
+  endfacet
+  facet normal 0.406731 0.913548 0
+    outer loop
+      vertex 6.14856 29.6807 -48
+      vertex 8 28.8564 -49
+      vertex 6.14856 29.6807 -49
+    endloop
+  endfacet
+  facet normal 0.406728 0.913549 1.98468e-06
+    outer loop
+      vertex 6.14856 29.6807 -48
+      vertex 6.93917 29.3287 -45
+      vertex 8 28.8564 -45.0833
+    endloop
+  endfacet
+  facet normal 0.406747 0.913541 -3.84813e-06
+    outer loop
+      vertex 6.93917 29.3287 -45
+      vertex 6.14856 29.6807 -48
+      vertex 5.43145 30 -45
+    endloop
+  endfacet
+  facet normal 0.40676 0.913535 0
+    outer loop
+      vertex 5.43145 30 -45
+      vertex 6.14856 29.6807 -48
+      vertex 5.43145 30 -48
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.43145 30 -45
+      vertex 4.94427 30.2169 -45
+      vertex 6.93917 29.3287 -45
+    endloop
+  endfacet
+  facet normal 0.587776 0.809024 0
+    outer loop
+      vertex 8.37996 28.5803 -49
+      vertex 10.7061 26.8903 -45.43
+      vertex 10.7061 26.8903 -49
+    endloop
+  endfacet
+  facet normal 0.587785 0.809017 -8.8771e-06
+    outer loop
+      vertex 10.7061 26.8903 -45.43
+      vertex 8.37996 28.5803 -49
+      vertex 8 28.8564 -45.0833
+    endloop
+  endfacet
+  facet normal 0.587845 0.808974 0
+    outer loop
+      vertex 8 28.8564 -45.0833
+      vertex 8.37996 28.5803 -49
+      vertex 8 28.8564 -49
     endloop
   endfacet
   facet normal -0.74319 0.669081 0
@@ -6360,6 +6465,111 @@ solid OpenSCAD_Model
       vertex -12.5351 24.859 -48
       vertex -12.9443 24.4046 -45.8683
       vertex -10.7061 26.8903 -45.43
+    endloop
+  endfacet
+  facet normal -0.866076 0.499912 0
+    outer loop
+      vertex -13.1416 24.0628 -49
+      vertex -13.3397 23.7196 -49
+      vertex -13.1416 24.0628 -48
+    endloop
+  endfacet
+  facet normal -0.866067 0.499927 0
+    outer loop
+      vertex -13.1416 24.0628 -48
+      vertex -12.9443 24.4046 -45.8683
+      vertex -12.9443 24.4046 -48
+    endloop
+  endfacet
+  facet normal -0.866023 0.500005 -4.26081e-05
+    outer loop
+      vertex -14.6167 21.5078 -49
+      vertex -13.1416 24.0628 -48
+      vertex -13.3397 23.7196 -49
+    endloop
+  endfacet
+  facet normal -0.86603 0.499992 0
+    outer loop
+      vertex -13.1416 24.0628 -48
+      vertex -14.6167 21.5078 -49
+      vertex -14.6167 21.5078 -46.379
+    endloop
+  endfacet
+  facet normal -0.866033 0.499986 -1.26545e-05
+    outer loop
+      vertex -13.1416 24.0628 -48
+      vertex -14.6167 21.5078 -46.379
+      vertex -12.9443 24.4046 -45.8683
+    endloop
+  endfacet
+  facet normal -0.587845 0.808974 0
+    outer loop
+      vertex -8.37996 28.5803 -49
+      vertex -8 28.8564 -45.0833
+      vertex -8 28.8564 -49
+    endloop
+  endfacet
+  facet normal -0.587785 0.809017 -8.8771e-06
+    outer loop
+      vertex -8 28.8564 -45.0833
+      vertex -8.37996 28.5803 -49
+      vertex -10.7061 26.8903 -45.43
+    endloop
+  endfacet
+  facet normal -0.587776 0.809024 0
+    outer loop
+      vertex -10.7061 26.8903 -45.43
+      vertex -8.37996 28.5803 -49
+      vertex -10.7061 26.8903 -49
+    endloop
+  endfacet
+  facet normal -0.951066 0.308989 0
+    outer loop
+      vertex -14.9257 20.5567 -49
+      vertex -14.6167 21.5078 -46.379
+      vertex -14.6167 21.5078 -49
+    endloop
+  endfacet
+  facet normal -0.951044 0.309054 0
+    outer loop
+      vertex -15.6504 18.3266 -46.94
+      vertex -14.9257 20.5567 -49
+      vertex -15.6504 18.3266 -49
+    endloop
+  endfacet
+  facet normal -0.95105 0.309038 -1.96526e-05
+    outer loop
+      vertex -14.9257 20.5567 -49
+      vertex -15.6504 18.3266 -46.94
+      vertex -14.6167 21.5078 -46.379
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.94427 30.2169 -45
+      vertex 1.67245 30.9123 -45
+      vertex 4.88823 30.2288 -45
+    endloop
+  endfacet
+  facet normal 0.994524 0.104505 0
+    outer loop
+      vertex 15.7898 17 -47.1739
+      vertex 15.6504 18.3266 -49
+      vertex 15.6504 18.3266 -46.94
+    endloop
+  endfacet
+  facet normal 0.994527 0.104483 -1.6329e-05
+    outer loop
+      vertex 15.6504 18.3266 -49
+      vertex 15.7898 17 -47.1739
+      vertex 15.7825 17.0692 -49
+    endloop
+  endfacet
+  facet normal 0.994482 0.104909 0
+    outer loop
+      vertex 15.7825 17.0692 -49
+      vertex 15.7898 17 -47.1739
+      vertex 15.7898 17 -49
     endloop
   endfacet
   facet normal -0.406747 0.913541 -3.84813e-06
@@ -6402,230 +6612,6 @@ solid OpenSCAD_Model
       vertex -4.94427 30.2169 -45
       vertex -5.43145 30 -45
       vertex -6.93917 29.3287 -45
-    endloop
-  endfacet
-  facet normal -0.951066 0.308989 0
-    outer loop
-      vertex -14.9257 20.5567 -49
-      vertex -14.6167 21.5078 -46.379
-      vertex -14.6167 21.5078 -49
-    endloop
-  endfacet
-  facet normal -0.951044 0.309054 0
-    outer loop
-      vertex -15.6504 18.3266 -46.94
-      vertex -14.9257 20.5567 -49
-      vertex -15.6504 18.3266 -49
-    endloop
-  endfacet
-  facet normal -0.95105 0.309038 -1.96526e-05
-    outer loop
-      vertex -14.9257 20.5567 -49
-      vertex -15.6504 18.3266 -46.94
-      vertex -14.6167 21.5078 -46.379
-    endloop
-  endfacet
-  facet normal -0.587845 0.808974 0
-    outer loop
-      vertex -8.37996 28.5803 -49
-      vertex -8 28.8564 -45.0833
-      vertex -8 28.8564 -49
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 -8.8771e-06
-    outer loop
-      vertex -8 28.8564 -45.0833
-      vertex -8.37996 28.5803 -49
-      vertex -10.7061 26.8903 -45.43
-    endloop
-  endfacet
-  facet normal -0.587776 0.809024 0
-    outer loop
-      vertex -10.7061 26.8903 -45.43
-      vertex -8.37996 28.5803 -49
-      vertex -10.7061 26.8903 -49
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 4.94427 30.2169 -45
-      vertex 1.67245 30.9123 -45
-      vertex 4.88823 30.2288 -45
-    endloop
-  endfacet
-  facet normal 0.406731 0.913548 -0
-    outer loop
-      vertex 8 28.8564 -49
-      vertex 6.14856 29.6807 -48
-      vertex 8 28.8564 -45.0833
-    endloop
-  endfacet
-  facet normal 0.406731 0.913548 0
-    outer loop
-      vertex 6.14856 29.6807 -48
-      vertex 8 28.8564 -49
-      vertex 6.14856 29.6807 -49
-    endloop
-  endfacet
-  facet normal 0.406728 0.913549 1.98468e-06
-    outer loop
-      vertex 6.14856 29.6807 -48
-      vertex 6.93917 29.3287 -45
-      vertex 8 28.8564 -45.0833
-    endloop
-  endfacet
-  facet normal 0.406747 0.913541 -3.84813e-06
-    outer loop
-      vertex 6.93917 29.3287 -45
-      vertex 6.14856 29.6807 -48
-      vertex 5.43145 30 -45
-    endloop
-  endfacet
-  facet normal 0.40676 0.913535 0
-    outer loop
-      vertex 5.43145 30 -45
-      vertex 6.14856 29.6807 -48
-      vertex 5.43145 30 -48
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.93917 29.3287 -45
-      vertex 5.43145 30 -45
-      vertex 4.94427 30.2169 -45
-    endloop
-  endfacet
-  facet normal 0.587776 0.809024 0
-    outer loop
-      vertex 8.37996 28.5803 -49
-      vertex 10.7061 26.8903 -45.43
-      vertex 10.7061 26.8903 -49
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 -8.8771e-06
-    outer loop
-      vertex 10.7061 26.8903 -45.43
-      vertex 8.37996 28.5803 -49
-      vertex 8 28.8564 -45.0833
-    endloop
-  endfacet
-  facet normal 0.587845 0.808974 0
-    outer loop
-      vertex 8 28.8564 -45.0833
-      vertex 8.37996 28.5803 -49
-      vertex 8 28.8564 -49
-    endloop
-  endfacet
-  facet normal 0.74319 0.669081 0
-    outer loop
-      vertex 10.7061 26.8903 -45.43
-      vertex 11.1196 26.431 -49
-      vertex 10.7061 26.8903 -49
-    endloop
-  endfacet
-  facet normal 0.743134 0.669142 -1.43392e-05
-    outer loop
-      vertex 10.7061 26.8903 -45.43
-      vertex 12.5351 24.859 -48
-      vertex 11.1196 26.431 -49
-    endloop
-  endfacet
-  facet normal 0.743134 0.669143 -1.49169e-05
-    outer loop
-      vertex 12.9443 24.4046 -45.8683
-      vertex 12.5351 24.859 -48
-      vertex 10.7061 26.8903 -45.43
-    endloop
-  endfacet
-  facet normal 0.743099 0.669182 0
-    outer loop
-      vertex 12.5351 24.859 -48
-      vertex 12.9443 24.4046 -45.8683
-      vertex 12.9443 24.4046 -48
-    endloop
-  endfacet
-  facet normal 0.74313 0.669148 0
-    outer loop
-      vertex 11.1196 26.431 -49
-      vertex 12.5351 24.859 -48
-      vertex 12.5351 24.859 -49
-    endloop
-  endfacet
-  facet normal 0.951066 0.308989 0
-    outer loop
-      vertex 14.6167 21.5078 -46.379
-      vertex 14.9257 20.5567 -49
-      vertex 14.6167 21.5078 -49
-    endloop
-  endfacet
-  facet normal 0.95105 0.309038 -1.96526e-05
-    outer loop
-      vertex 15.6504 18.3266 -46.94
-      vertex 14.9257 20.5567 -49
-      vertex 14.6167 21.5078 -46.379
-    endloop
-  endfacet
-  facet normal 0.951044 0.309054 0
-    outer loop
-      vertex 14.9257 20.5567 -49
-      vertex 15.6504 18.3266 -46.94
-      vertex 15.6504 18.3266 -49
-    endloop
-  endfacet
-  facet normal 0.994524 0.104505 0
-    outer loop
-      vertex 15.7898 17 -47.1739
-      vertex 15.6504 18.3266 -49
-      vertex 15.6504 18.3266 -46.94
-    endloop
-  endfacet
-  facet normal 0.994527 0.104483 -1.6329e-05
-    outer loop
-      vertex 15.6504 18.3266 -49
-      vertex 15.7898 17 -47.1739
-      vertex 15.7825 17.0692 -49
-    endloop
-  endfacet
-  facet normal 0.994482 0.104909 0
-    outer loop
-      vertex 15.7825 17.0692 -49
-      vertex 15.7898 17 -47.1739
-      vertex 15.7898 17 -49
-    endloop
-  endfacet
-  facet normal -0.866076 0.499912 0
-    outer loop
-      vertex -13.1416 24.0628 -49
-      vertex -13.3397 23.7196 -49
-      vertex -13.1416 24.0628 -48
-    endloop
-  endfacet
-  facet normal -0.866067 0.499927 0
-    outer loop
-      vertex -13.1416 24.0628 -48
-      vertex -12.9443 24.4046 -45.8683
-      vertex -12.9443 24.4046 -48
-    endloop
-  endfacet
-  facet normal -0.866023 0.500005 -4.26081e-05
-    outer loop
-      vertex -14.6167 21.5078 -49
-      vertex -13.1416 24.0628 -48
-      vertex -13.3397 23.7196 -49
-    endloop
-  endfacet
-  facet normal -0.86603 0.499992 0
-    outer loop
-      vertex -13.1416 24.0628 -48
-      vertex -14.6167 21.5078 -49
-      vertex -14.6167 21.5078 -46.379
-    endloop
-  endfacet
-  facet normal -0.866033 0.499986 -1.26545e-05
-    outer loop
-      vertex -13.1416 24.0628 -48
-      vertex -14.6167 21.5078 -46.379
-      vertex -12.9443 24.4046 -45.8683
     endloop
   endfacet
   facet normal 0.866067 0.499927 0
@@ -6834,76 +6820,69 @@ solid OpenSCAD_Model
   facet normal 0 -1 0
     outer loop
       vertex -10.4798 51 -46
-      vertex -10.25 51 -45
+      vertex -10 51 -45
       vertex -10.4798 51 -45
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex -10.25 51 -45
+      vertex -10 51 -45
       vertex -10.4798 51 -46
-      vertex 10.25 51 -45
+      vertex 10 51 -45
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
       vertex 10.5 51 -46
-      vertex 10.25 51 -45
+      vertex 10 51 -45
       vertex -10.4798 51 -46
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 10.25 51 -45
+      vertex 10 51 -45
       vertex 10.5 51 -46
       vertex 10.5 51 -45
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -10.25 51 -45
-      vertex 10.25 51 -44
-      vertex -10.25 51 -44
+      vertex -10 51 -45
+      vertex 10 51 -44
+      vertex -10 51 -44
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 10.25 51 -44
-      vertex -10.25 51 -45
-      vertex 10.25 51 -45
+      vertex 10 51 -44
+      vertex -10 51 -45
+      vertex 10 51 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
       vertex -10.5072 40.6 -45
-      vertex -10.25 51 -45
-      vertex -10.25 35.5 -45
+      vertex -10 51 -45
+      vertex -10 35.5864 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
       vertex -11.2 41 -45
-      vertex -10.25 51 -45
+      vertex -10 51 -45
       vertex -10.5072 40.6 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -11.5 34.9186 -45
-      vertex -10.25 35.5 -45
-      vertex -10.1941 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
       vertex -12.7572 36.7029 -45
-      vertex -10.25 35.5 -45
+      vertex -10 35.5864 -45
       vertex -11.5 34.9186 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10.25 35.5 -45
+      vertex -10 35.5864 -45
       vertex -12.7572 36.7029 -45
       vertex -10.5072 40.6 -45
     endloop
@@ -6924,7 +6903,7 @@ solid OpenSCAD_Model
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -10.25 51 -45
+      vertex -10 51 -45
       vertex -11.2 41 -45
       vertex -10.4798 51 -45
     endloop
@@ -6959,34 +6938,6 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 11.0928 40.8 -45
-      vertex 12.25 41 -45
-      vertex 13.3428 36.9029 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.0928 40.8 -45
-      vertex 10.25 41 -45
-      vertex 12.25 41 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.4 40.4 -45
-      vertex 10.25 41 -45
-      vertex 11.0928 40.8 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.25 41 -45
-      vertex 10.4 40.4 -45
-      vertex 10.25 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
       vertex 15.39 32.0923 -45
       vertex 12.65 36.5029 -45
       vertex 13.3428 36.9029 -45
@@ -7001,7 +6952,7 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 10.25 35.5 -45
+      vertex 10 35.5864 -45
       vertex 12.65 36.5029 -45
       vertex 11.5 34.9186 -45
     endloop
@@ -7009,15 +6960,8 @@ solid OpenSCAD_Model
   facet normal -0 0 -1
     outer loop
       vertex 12.65 36.5029 -45
-      vertex 10.25 35.5 -45
+      vertex 10 35.5864 -45
       vertex 10.4 40.4 -45
-    endloop
-  endfacet
-  facet normal -0 -0 -1
-    outer loop
-      vertex 10.25 35.5 -45
-      vertex 11.5 34.9186 -45
-      vertex 10.1941 35.5 -45
     endloop
   endfacet
   facet normal 0 0 -1
@@ -7036,37 +6980,37 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 12.25 41 -45
+      vertex 11.0928 40.8 -45
       vertex 17 36.4008 -45
       vertex 13.3428 36.9029 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 12.25 44 -45
-      vertex 17 36.4008 -45
-      vertex 12.25 41 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.25 44 -45
+      vertex 11.0928 40.8 -45
       vertex 10.5 51 -45
       vertex 17 36.4008 -45
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 10.25 44 -45
-      vertex 10.5 51 -45
-      vertex 12.25 44 -45
+      vertex 10 51 -45
+      vertex 11.0928 40.8 -45
+      vertex 10.4 40.4 -45
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 -1
     outer loop
+      vertex 10 51 -45
+      vertex 10.4 40.4 -45
+      vertex 10 35.5864 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.0928 40.8 -45
+      vertex 10 51 -45
       vertex 10.5 51 -45
-      vertex 10.25 44 -45
-      vertex 10.25 51 -45
     endloop
   endfacet
   facet normal 0 0 -1
@@ -7272,20 +7216,6 @@ solid OpenSCAD_Model
       vertex 15.8 12 -49
     endloop
   endfacet
-  facet normal 0 -0.743167 0.669106
-    outer loop
-      vertex -11.3637 49.0148 -50.4589
-      vertex 11.0102 49.8541 -49.5267
-      vertex -10.99 49.8541 -49.5267
-    endloop
-  endfacet
-  facet normal 0 -0.743167 0.669106
-    outer loop
-      vertex 11.0102 49.8541 -49.5267
-      vertex -11.3637 49.0148 -50.4589
-      vertex 11.3839 49.0148 -50.4589
-    endloop
-  endfacet
   facet normal 2.71289e-08 -0.406688 0.913567
     outer loop
       vertex -12.3257 46.8541 -51.7063
@@ -7396,6 +7326,20 @@ solid OpenSCAD_Model
       vertex 10.731 50.4813 -48.4404
       vertex -10.99 49.8541 -49.5267
       vertex 11.0102 49.8541 -49.5267
+    endloop
+  endfacet
+  facet normal 0 -0.743167 0.669106
+    outer loop
+      vertex -11.3637 49.0148 -50.4589
+      vertex 11.0102 49.8541 -49.5267
+      vertex -10.99 49.8541 -49.5267
+    endloop
+  endfacet
+  facet normal 0 -0.743167 0.669106
+    outer loop
+      vertex 11.0102 49.8541 -49.5267
+      vertex -11.3637 49.0148 -50.4589
+      vertex 11.3839 49.0148 -50.4589
     endloop
   endfacet
   facet normal 0 -0.207923 0.978145
@@ -7608,6 +7552,20 @@ solid OpenSCAD_Model
       vertex 22.8 17 -47.1739
     endloop
   endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 18.3226 12.0274 -52
+      vertex 17.8 12.0274 -48.0507
+      vertex 18.3226 12.0274 -48.0507
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.8 12.0274 -48.0507
+      vertex 18.3226 12.0274 -52
+      vertex 17.8 12.0274 -52
+    endloop
+  endfacet
   facet normal -0.743161 0.669113 0
     outer loop
       vertex 21.1457 13.2843 -47.8291
@@ -7676,20 +7634,6 @@ solid OpenSCAD_Model
       vertex 18.3226 12.0274 -48.0507
       vertex 19.3451 12.2447 -52
       vertex 18.3226 12.0274 -52
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 18.3226 12.0274 -52
-      vertex 17.8 12.0274 -48.0507
-      vertex 18.3226 12.0274 -48.0507
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.8 12.0274 -48.0507
-      vertex 18.3226 12.0274 -52
-      vertex 17.8 12.0274 -52
     endloop
   endfacet
   facet normal -1 0 0
@@ -8282,30 +8226,37 @@ solid OpenSCAD_Model
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex -10.25 36.5638 -44
-      vertex -10.25 51 -45
-      vertex -10.25 51 -44
+      vertex -10 36.6751 -44
+      vertex -10 51 -45
+      vertex -10 51 -44
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex -10.25 35.5 -45
-      vertex -10.25 36.5638 -44
-      vertex -10.25 35.5 -44
+      vertex -10 36.6751 -44
+      vertex -10 35.5864 -45
+      vertex -10 51 -45
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -10 35.5 -44
+      vertex -10 35.5864 -45
+      vertex -10 36.6751 -44
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex -10.25 36.5638 -44
-      vertex -10.25 35.5 -45
-      vertex -10.25 51 -45
+      vertex -10 35.5864 -45
+      vertex -10 35.5 -44
+      vertex -10 35.5 -45
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 10.1941 35.5 -45
+      vertex 10 35.5 -45
       vertex 7.91068 35.5 -44
-      vertex 10.25 35.5 -44
+      vertex 10 35.5 -44
     endloop
   endfacet
   facet normal 0 1 0
@@ -8331,15 +8282,8 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 10.1941 35.5 -45
-      vertex 10.25 35.5 -44
-      vertex 10.25 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
       vertex 7.91068 35.5 -44
-      vertex 10.1941 35.5 -45
+      vertex 10 35.5 -45
       vertex 7.39951 35.5 -45
     endloop
   endfacet
@@ -8366,7 +8310,7 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -10.1941 35.5 -45
+      vertex -10 35.5 -45
       vertex -7.91068 35.5 -44
       vertex -7.39951 35.5 -45
     endloop
@@ -8374,92 +8318,36 @@ solid OpenSCAD_Model
   facet normal 0 1 0
     outer loop
       vertex -7.91068 35.5 -44
-      vertex -10.1941 35.5 -45
-      vertex -10.25 35.5 -44
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.25 35.5 -44
-      vertex -10.1941 35.5 -45
-      vertex -10.25 35.5 -45
+      vertex -10 35.5 -45
+      vertex -10 35.5 -44
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 10.25 44 -45
-      vertex 10.25 51 -44
-      vertex 10.25 51 -45
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 10.25 51 -44
-      vertex 10.25 44 -45
-      vertex 10.25 44 -44
+      vertex 10 51 -45
+      vertex 10 36.6751 -44
+      vertex 10 51 -44
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 10.25 41 -45
-      vertex 10.25 36.5638 -44
-      vertex 10.25 41 -44
+      vertex 10 35.5864 -45
+      vertex 10 36.6751 -44
+      vertex 10 51 -45
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 10.25 35.5 -45
-      vertex 10.25 36.5638 -44
-      vertex 10.25 41 -45
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 10.25 36.5638 -44
-      vertex 10.25 35.5 -45
-      vertex 10.25 35.5 -44
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 12.25 41 -45
-      vertex 10.25 41 -44
-      vertex 12.25 41 -44
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 10.25 41 -44
-      vertex 12.25 41 -45
-      vertex 10.25 41 -45
+      vertex 10 35.5 -44
+      vertex 10 35.5864 -45
+      vertex 10 35.5 -45
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 12.25 41 -45
-      vertex 12.25 44 -44
-      vertex 12.25 44 -45
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 12.25 44 -44
-      vertex 12.25 41 -45
-      vertex 12.25 41 -44
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 10.25 44 -45
-      vertex 12.25 44 -44
-      vertex 10.25 44 -44
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 12.25 44 -44
-      vertex 10.25 44 -45
-      vertex 12.25 44 -45
+      vertex 10 35.5864 -45
+      vertex 10 35.5 -44
+      vertex 10 36.6751 -44
     endloop
   endfacet
   facet normal -0.994525 0.104495 -4.99444e-05
@@ -8635,6 +8523,62 @@ solid OpenSCAD_Model
       vertex -9.36783 25.404 -49
       vertex -11.1196 26.431 -49
       vertex -10.7061 26.8903 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4634 28.9233 -49
+      vertex -0.4 29 -49
+      vertex 0.4 29 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4634 28.9233 -49
+      vertex -0.4 29 -49
+      vertex 1.4634 28.9233 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4634 28.9233 -49
+      vertex -0.4 30 -49
+      vertex -0.4 29 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.4634 28.9233 -49
+      vertex -1.9774 30 -49
+      vertex -0.4 30 -49
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -1.9774 30 -49
+      vertex -1.4634 28.9233 -49
+      vertex -2.1049 28.787 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4634 28.9233 -49
+      vertex 1.9774 30 -49
+      vertex 2.1049 28.787 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.4 30 -49
+      vertex 1.4634 28.9233 -49
+      vertex 0.4 29 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.4634 28.9233 -49
+      vertex 0.4 30 -49
+      vertex 1.9774 30 -49
     endloop
   endfacet
   facet normal 0 0 -1
@@ -8852,34 +8796,6 @@ solid OpenSCAD_Model
       vertex -13.7043 17.8133 -49
       vertex -15.7825 17.0692 -49
       vertex -15.6504 18.3266 -49
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.77698 31.9069 -53
-      vertex -0.4 31.9069 -52
-      vertex -1.77698 31.9069 -52
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -0.4 31.9069 -52
-      vertex -1.77698 31.9069 -53
-      vertex -0.4 31.9069 -53
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 0.4 31.9069 -53
-      vertex 1.77698 31.9069 -52
-      vertex 0.4 31.9069 -52
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 1.77698 31.9069 -52
-      vertex 0.4 31.9069 -53
-      vertex 1.77698 31.9069 -53
     endloop
   endfacet
   facet normal 0 0 -1
@@ -9190,20 +9106,6 @@ solid OpenSCAD_Model
       vertex -8 28.8564 -49
     endloop
   endfacet
-  facet normal 0.866027 -0.499997 0
-    outer loop
-      vertex -15.5303 21.9145 -52
-      vertex -13.9594 24.6354 -53
-      vertex -13.9594 24.6354 -52
-    endloop
-  endfacet
-  facet normal 0.866027 -0.499997 0
-    outer loop
-      vertex -13.9594 24.6354 -53
-      vertex -15.5303 21.9145 -52
-      vertex -15.5303 21.9145 -53
-    endloop
-  endfacet
   facet normal 0.207908 -0.978148 0
     outer loop
       vertex -5.25329 31.168 -53
@@ -9216,6 +9118,34 @@ solid OpenSCAD_Model
       vertex -1.77698 31.9069 -52
       vertex -5.25329 31.168 -53
       vertex -1.77698 31.9069 -53
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.77698 31.9069 -53
+      vertex -0.4 31.9069 -52
+      vertex -1.77698 31.9069 -52
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.4 31.9069 -52
+      vertex -1.77698 31.9069 -53
+      vertex -0.4 31.9069 -53
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.4 31.9069 -53
+      vertex 1.77698 31.9069 -52
+      vertex 0.4 31.9069 -52
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1.77698 31.9069 -52
+      vertex 0.4 31.9069 -53
+      vertex 1.77698 31.9069 -53
     endloop
   endfacet
   facet normal 0.994518 0.104569 0
@@ -9372,48 +9302,6 @@ solid OpenSCAD_Model
       vertex 17 15 -53
     endloop
   endfacet
-  facet normal 0.406982 -0.913436 0
-    outer loop
-      vertex -5.48424 31.0651 -53
-      vertex -5.25329 31.168 -52
-      vertex -5.48424 31.0651 -52
-    endloop
-  endfacet
-  facet normal 0.406982 -0.913436 0
-    outer loop
-      vertex -5.25329 31.168 -52
-      vertex -5.48424 31.0651 -53
-      vertex -5.25329 31.168 -53
-    endloop
-  endfacet
-  facet normal 0.406738 -0.913545 0
-    outer loop
-      vertex -8.5 29.7224 -53
-      vertex -6.40917 30.6533 -52
-      vertex -8.5 29.7224 -52
-    endloop
-  endfacet
-  facet normal 0.406738 -0.913545 0
-    outer loop
-      vertex -6.40917 30.6533 -52
-      vertex -8.5 29.7224 -53
-      vertex -6.40917 30.6533 -53
-    endloop
-  endfacet
-  facet normal 0.587775 -0.809024 0
-    outer loop
-      vertex -11.3752 27.6335 -53
-      vertex -8.5 29.7224 -52
-      vertex -11.3752 27.6335 -52
-    endloop
-  endfacet
-  facet normal 0.587775 -0.809024 0
-    outer loop
-      vertex -8.5 29.7224 -52
-      vertex -11.3752 27.6335 -53
-      vertex -8.5 29.7224 -53
-    endloop
-  endfacet
   facet normal 0 0 -1
     outer loop
       vertex -14.6167 21.5078 -49
@@ -9498,20 +9386,6 @@ solid OpenSCAD_Model
       vertex -11.1196 26.431 -49
     endloop
   endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex -13.3559 25.4337 -52
-      vertex -11.3752 27.6335 -53
-      vertex -11.3752 27.6335 -52
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex -11.3752 27.6335 -53
-      vertex -13.3559 25.4337 -52
-      vertex -13.3559 25.4337 -53
-    endloop
-  endfacet
   facet normal 0 0 -1
     outer loop
       vertex -5.25329 27.902 -49
@@ -9547,60 +9421,74 @@ solid OpenSCAD_Model
       vertex -1.9774 30 -49
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0.587775 -0.809024 0
     outer loop
-      vertex 1.4634 28.9233 -49
-      vertex -0.4 29 -49
-      vertex 0.4 29 -49
+      vertex -11.3752 27.6335 -53
+      vertex -8.5 29.7224 -52
+      vertex -11.3752 27.6335 -52
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0.587775 -0.809024 0
     outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -0.4 29 -49
-      vertex 1.4634 28.9233 -49
+      vertex -8.5 29.7224 -52
+      vertex -11.3752 27.6335 -53
+      vertex -8.5 29.7224 -53
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0.406738 -0.913545 0
     outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -0.4 30 -49
-      vertex -0.4 29 -49
+      vertex -8.5 29.7224 -53
+      vertex -6.40917 30.6533 -52
+      vertex -8.5 29.7224 -52
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0.406738 -0.913545 0
     outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -1.9774 30 -49
-      vertex -0.4 30 -49
+      vertex -6.40917 30.6533 -52
+      vertex -8.5 29.7224 -53
+      vertex -6.40917 30.6533 -53
     endloop
   endfacet
-  facet normal 0 -0 -1
+  facet normal 0.406982 -0.913436 0
     outer loop
-      vertex -1.9774 30 -49
-      vertex -1.4634 28.9233 -49
-      vertex -2.1049 28.787 -49
+      vertex -5.48424 31.0651 -53
+      vertex -5.25329 31.168 -52
+      vertex -5.48424 31.0651 -52
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0.406982 -0.913436 0
     outer loop
-      vertex 1.4634 28.9233 -49
-      vertex 1.9774 30 -49
-      vertex 2.1049 28.787 -49
+      vertex -5.25329 31.168 -52
+      vertex -5.48424 31.0651 -53
+      vertex -5.25329 31.168 -53
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0.866027 -0.499997 0
     outer loop
-      vertex 0.4 30 -49
-      vertex 1.4634 28.9233 -49
-      vertex 0.4 29 -49
+      vertex -15.5303 21.9145 -52
+      vertex -13.9594 24.6354 -53
+      vertex -13.9594 24.6354 -52
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0.866027 -0.499997 0
     outer loop
-      vertex 1.4634 28.9233 -49
-      vertex 0.4 30 -49
-      vertex 1.9774 30 -49
+      vertex -13.9594 24.6354 -53
+      vertex -15.5303 21.9145 -52
+      vertex -15.5303 21.9145 -53
+    endloop
+  endfacet
+  facet normal 0.743146 -0.669129 0
+    outer loop
+      vertex -13.3559 25.4337 -52
+      vertex -11.3752 27.6335 -53
+      vertex -11.3752 27.6335 -52
+    endloop
+  endfacet
+  facet normal 0.743146 -0.669129 0
+    outer loop
+      vertex -11.3752 27.6335 -53
+      vertex -13.3559 25.4337 -52
+      vertex -13.3559 25.4337 -53
     endloop
   endfacet
   facet normal -0.939696 -0.342011 0
@@ -10373,48 +10261,6 @@ solid OpenSCAD_Model
       vertex 5.67638 27.9185 -49
     endloop
   endfacet
-  facet normal 0.965925 -0.258821 0
-    outer loop
-      vertex 6.14856 29.6807 -49
-      vertex 6.71166 31.7822 -52
-      vertex 6.71166 31.7822 -48
-    endloop
-  endfacet
-  facet normal 0.965925 -0.258821 0
-    outer loop
-      vertex 6.14856 29.6807 -49
-      vertex 6.71166 31.7822 -48
-      vertex 6.14856 29.6807 -48
-    endloop
-  endfacet
-  facet normal 0.965925 -0.258821 2.43856e-07
-    outer loop
-      vertex 6.71166 31.7822 -52
-      vertex 6.14856 29.6807 -49
-      vertex 6.40917 30.6533 -52
-    endloop
-  endfacet
-  facet normal 0.965926 -0.258819 8.53996e-07
-    outer loop
-      vertex 5.67638 27.9185 -49
-      vertex 6.40917 30.6533 -52
-      vertex 6.14856 29.6807 -49
-    endloop
-  endfacet
-  facet normal 0.965926 -0.25882 0
-    outer loop
-      vertex 6.40917 30.6533 -52
-      vertex 5.67638 27.9185 -49
-      vertex 5.67638 27.9185 -53
-    endloop
-  endfacet
-  facet normal 0.965926 -0.25882 0
-    outer loop
-      vertex 6.40917 30.6533 -52
-      vertex 5.67638 27.9185 -53
-      vertex 6.40917 30.6533 -53
-    endloop
-  endfacet
   facet normal 0 0 1
     outer loop
       vertex 5.43145 30 -48
@@ -10490,6 +10336,48 @@ solid OpenSCAD_Model
       vertex 5.74573 32.041 -48
       vertex 6.71166 31.7822 -52
       vertex 5.74573 32.041 -52
+    endloop
+  endfacet
+  facet normal 0.965925 -0.258821 0
+    outer loop
+      vertex 6.14856 29.6807 -49
+      vertex 6.71166 31.7822 -52
+      vertex 6.71166 31.7822 -48
+    endloop
+  endfacet
+  facet normal 0.965925 -0.258821 0
+    outer loop
+      vertex 6.14856 29.6807 -49
+      vertex 6.71166 31.7822 -48
+      vertex 6.14856 29.6807 -48
+    endloop
+  endfacet
+  facet normal 0.965925 -0.258821 2.43856e-07
+    outer loop
+      vertex 6.71166 31.7822 -52
+      vertex 6.14856 29.6807 -49
+      vertex 6.40917 30.6533 -52
+    endloop
+  endfacet
+  facet normal 0.965926 -0.258819 8.53996e-07
+    outer loop
+      vertex 5.67638 27.9185 -49
+      vertex 6.40917 30.6533 -52
+      vertex 6.14856 29.6807 -49
+    endloop
+  endfacet
+  facet normal 0.965926 -0.25882 0
+    outer loop
+      vertex 6.40917 30.6533 -52
+      vertex 5.67638 27.9185 -49
+      vertex 5.67638 27.9185 -53
+    endloop
+  endfacet
+  facet normal 0.965926 -0.25882 0
+    outer loop
+      vertex 6.40917 30.6533 -52
+      vertex 5.67638 27.9185 -53
+      vertex 6.40917 30.6533 -53
     endloop
   endfacet
   facet normal -1 0 0
@@ -10968,20 +10856,6 @@ solid OpenSCAD_Model
       vertex -12.7572 36.7029 -52
     endloop
   endfacet
-  facet normal 0.500011 0.866019 -0
-    outer loop
-      vertex -10.5072 40.6 -52
-      vertex -11.2 41 -45
-      vertex -10.5072 40.6 -45
-    endloop
-  endfacet
-  facet normal 0.500011 0.866019 0
-    outer loop
-      vertex -11.2 41 -45
-      vertex -10.5072 40.6 -52
-      vertex -11.2 41 -52
-    endloop
-  endfacet
   facet normal 0.866025 -0.500001 0
     outer loop
       vertex -12.7572 36.7029 -45
@@ -10994,6 +10868,20 @@ solid OpenSCAD_Model
       vertex -10.5072 40.6 -52
       vertex -12.7572 36.7029 -45
       vertex -12.7572 36.7029 -52
+    endloop
+  endfacet
+  facet normal 0.500011 0.866019 -0
+    outer loop
+      vertex -10.5072 40.6 -52
+      vertex -11.2 41 -45
+      vertex -10.5072 40.6 -45
+    endloop
+  endfacet
+  facet normal 0.500011 0.866019 0
+    outer loop
+      vertex -11.2 41 -45
+      vertex -10.5072 40.6 -52
+      vertex -11.2 41 -52
     endloop
   endfacet
   facet normal 0 1 -0

--- a/Printed-Parts/stl/nozzle-fan.stl
+++ b/Printed-Parts/stl/nozzle-fan.stl
@@ -1,114 +1,16 @@
 solid OpenSCAD_Model
-  facet normal -0.994522 0.104528 0
-    outer loop
-      vertex -23.7898 17 -46.2923
-      vertex -23.4755 19.9899 -53
-      vertex -23.7898 17 -53
-    endloop
-  endfacet
-  facet normal -0.994522 0.104528 0
-    outer loop
-      vertex -23.4755 19.9899 -53
-      vertex -23.7898 17 -46.2923
-      vertex -23.4755 19.9899 -45.7651
-    endloop
-  endfacet
-  facet normal 0.994522 0.104528 -0
-    outer loop
-      vertex 23.7898 17 -47.6073
-      vertex 23.4755 19.9899 -45.7651
-      vertex 23.7898 17 -46.2923
-    endloop
-  endfacet
-  facet normal 0.994522 0.104528 0
-    outer loop
-      vertex 23.4755 19.9899 -45.7651
-      vertex 23.7898 17 -47.6073
-      vertex 23.4755 19.9899 -53
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 7.91068 35.5 -44
-      vertex 5.39024 30 -44
-      vertex 9.07974 30 -44
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 5.39024 30 -44
-      vertex 7.91068 35.5 -44
-      vertex 3.60318 35.5 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0591 30 -44
-      vertex 18 30.6799 -44
-      vertex 16.0591 32.8355 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18 30.6799 -44
-      vertex 16.0591 30 -44
-      vertex 18.6122 30 -44
-    endloop
-  endfacet
-  facet normal 0.994522 0.104528 -0
-    outer loop
-      vertex 23.7898 17 -53
-      vertex 23.4755 19.9899 -53
-      vertex 23.7898 17 -47.6073
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.25 36.5638 -44
-      vertex -12 35.7846 -44
-      vertex -10.25 35.5 -44
-    endloop
-  endfacet
   facet normal -0 0 1
     outer loop
-      vertex -10.25 35.5 -44
-      vertex -9.07974 30 -44
-      vertex -7.91068 35.5 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
+      vertex -16.0591 32.8355 -44
       vertex -12.608 30 -44
-      vertex -10.25 35.5 -44
       vertex -12 35.7846 -44
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -10.25 35.5 -44
       vertex -12.608 30 -44
-      vertex -9.07974 30 -44
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex -18 30.6799 -53
-      vertex -18.6122 30 -44
-      vertex -18 30.6799 -44
-    endloop
-  endfacet
-  facet normal -0.743145 0.669131 0
-    outer loop
-      vertex -19.4164 29.1068 -44.1575
-      vertex -18 30.6799 -53
-      vertex -19.4164 29.1068 -53
-    endloop
-  endfacet
-  facet normal -0.743144 0.669131 1.46116e-007
-    outer loop
-      vertex -18 30.6799 -53
-      vertex -19.4164 29.1068 -44.1575
-      vertex -18.6122 30 -44
+      vertex -16.0591 32.8355 -44
+      vertex -16.0591 30 -44
     endloop
   endfacet
   facet normal 0 0 1
@@ -748,18 +650,95 @@ solid OpenSCAD_Model
       vertex -23.6689 15.7525 -53
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.99452 0.104545 -0
     outer loop
-      vertex -7.91068 35.5 -44
-      vertex -5.39024 30 -44
-      vertex -3.60318 35.5 -44
+      vertex 23.7898 17 -47.6073
+      vertex 23.4755 19.9899 -45.7651
+      vertex 23.7898 17 -46.2923
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.99452 0.104545 0
     outer loop
-      vertex -5.39024 30 -44
-      vertex -7.91068 35.5 -44
-      vertex -9.07974 30 -44
+      vertex 23.4755 19.9899 -45.7651
+      vertex 23.7898 17 -47.6073
+      vertex 23.4755 19.9899 -53
+    endloop
+  endfacet
+  facet normal 0.99452 0.104545 -0
+    outer loop
+      vertex 23.7898 17 -53
+      vertex 23.4755 19.9899 -53
+      vertex 23.7898 17 -47.6073
+    endloop
+  endfacet
+  facet normal 0.743137 0.66914 0
+    outer loop
+      vertex 18.6122 30 -44
+      vertex 18 30.6799 -53
+      vertex 18 30.6799 -44
+    endloop
+  endfacet
+  facet normal 0.743161 0.669112 -3.78246e-06
+    outer loop
+      vertex 19.4164 29.1068 -44.1575
+      vertex 18 30.6799 -53
+      vertex 18.6122 30 -44
+    endloop
+  endfacet
+  facet normal 0.743151 0.669124 0
+    outer loop
+      vertex 18 30.6799 -53
+      vertex 19.4164 29.1068 -44.1575
+      vertex 19.4164 29.1068 -53
+    endloop
+  endfacet
+  facet normal -0.99452 0.104545 0
+    outer loop
+      vertex -23.7898 17 -46.2923
+      vertex -23.4755 19.9899 -53
+      vertex -23.7898 17 -53
+    endloop
+  endfacet
+  facet normal -0.99452 0.104545 0
+    outer loop
+      vertex -23.4755 19.9899 -53
+      vertex -23.7898 17 -46.2923
+      vertex -23.4755 19.9899 -45.7651
+    endloop
+  endfacet
+  facet normal -0.743137 0.66914 0
+    outer loop
+      vertex -18 30.6799 -53
+      vertex -18.6122 30 -44
+      vertex -18 30.6799 -44
+    endloop
+  endfacet
+  facet normal -0.743151 0.669124 0
+    outer loop
+      vertex -19.4164 29.1068 -44.1575
+      vertex -18 30.6799 -53
+      vertex -19.4164 29.1068 -53
+    endloop
+  endfacet
+  facet normal -0.743161 0.669112 -3.78246e-06
+    outer loop
+      vertex -18 30.6799 -53
+      vertex -19.4164 29.1068 -44.1575
+      vertex -18.6122 30 -44
+    endloop
+  endfacet
+  facet normal -0.866021 0.500008 0
+    outer loop
+      vertex -21.9251 24.7617 -44.9237
+      vertex -19.4164 29.1068 -53
+      vertex -21.9251 24.7617 -53
+    endloop
+  endfacet
+  facet normal -0.866021 0.500008 0
+    outer loop
+      vertex -19.4164 29.1068 -53
+      vertex -21.9251 24.7617 -44.9237
+      vertex -19.4164 29.1068 -44.1575
     endloop
   endfacet
   facet normal -0 0 1
@@ -776,14 +755,14 @@ solid OpenSCAD_Model
       vertex -5.39024 30 -44
     endloop
   endfacet
-  facet normal -0.951057 0.309017 0
+  facet normal -0.95106 0.309008 0
     outer loop
       vertex -23.4755 19.9899 -45.7651
       vertex -21.9251 24.7617 -53
       vertex -23.4755 19.9899 -53
     endloop
   endfacet
-  facet normal -0.951057 0.309017 0
+  facet normal -0.95106 0.309008 0
     outer loop
       vertex -21.9251 24.7617 -53
       vertex -23.4755 19.9899 -45.7651
@@ -811,46 +790,46 @@ solid OpenSCAD_Model
       vertex 12.0299 35.5 -44
     endloop
   endfacet
-  facet normal 0.866026 0.5 0
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0591 30 -44
+      vertex 18 30.6799 -44
+      vertex 16.0591 32.8355 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18 30.6799 -44
+      vertex 16.0591 30 -44
+      vertex 18.6122 30 -44
+    endloop
+  endfacet
+  facet normal 0.866021 0.500008 0
     outer loop
       vertex 21.9251 24.7617 -44.9237
       vertex 19.4164 29.1068 -53
       vertex 19.4164 29.1068 -44.1575
     endloop
   endfacet
-  facet normal 0.866026 0.5 0
+  facet normal 0.866021 0.500008 0
     outer loop
       vertex 19.4164 29.1068 -53
       vertex 21.9251 24.7617 -44.9237
       vertex 21.9251 24.7617 -53
     endloop
   endfacet
-  facet normal 0.951057 0.309017 0
+  facet normal 0.95106 0.309008 0
     outer loop
       vertex 23.4755 19.9899 -45.7651
       vertex 21.9251 24.7617 -53
       vertex 21.9251 24.7617 -44.9237
     endloop
   endfacet
-  facet normal 0.951057 0.309017 0
+  facet normal 0.95106 0.309008 0
     outer loop
       vertex 21.9251 24.7617 -53
       vertex 23.4755 19.9899 -45.7651
       vertex 23.4755 19.9899 -53
-    endloop
-  endfacet
-  facet normal -0.866026 0.5 0
-    outer loop
-      vertex -21.9251 24.7617 -44.9237
-      vertex -19.4164 29.1068 -53
-      vertex -21.9251 24.7617 -53
-    endloop
-  endfacet
-  facet normal -0.866026 0.5 0
-    outer loop
-      vertex -19.4164 29.1068 -53
-      vertex -21.9251 24.7617 -44.9237
-      vertex -19.4164 29.1068 -44.1575
     endloop
   endfacet
   facet normal -0 0 1
@@ -867,112 +846,133 @@ solid OpenSCAD_Model
       vertex -18.6122 30 -44
     endloop
   endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.91068 35.5 -44
+      vertex 5.39024 30 -44
+      vertex 9.07974 30 -44
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 5.39024 30 -44
+      vertex 7.91068 35.5 -44
+      vertex 3.60318 35.5 -44
+    endloop
+  endfacet
   facet normal -0 0 1
     outer loop
-      vertex -16.0591 32.8355 -44
-      vertex -12.608 30 -44
+      vertex -7.91068 35.5 -44
+      vertex -5.39024 30 -44
+      vertex -3.60318 35.5 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.39024 30 -44
+      vertex -7.91068 35.5 -44
+      vertex -9.07974 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.25 36.5638 -44
       vertex -12 35.7846 -44
+      vertex -10.25 35.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.25 35.5 -44
+      vertex -9.07974 30 -44
+      vertex -7.91068 35.5 -44
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex -12.608 30 -44
-      vertex -16.0591 32.8355 -44
-      vertex -16.0591 30 -44
+      vertex -10.25 35.5 -44
+      vertex -12 35.7846 -44
     endloop
   endfacet
-  facet normal 0.743145 0.66913 0
+  facet normal 0 0 1
     outer loop
-      vertex 18.6122 30 -44
-      vertex 18 30.6799 -53
-      vertex 18 30.6799 -44
+      vertex -10.25 35.5 -44
+      vertex -12.608 30 -44
+      vertex -9.07974 30 -44
     endloop
   endfacet
-  facet normal 0.743144 0.669131 1.46116e-007
-    outer loop
-      vertex 19.4164 29.1068 -44.1575
-      vertex 18 30.6799 -53
-      vertex 18.6122 30 -44
-    endloop
-  endfacet
-  facet normal 0.743145 0.669131 0
-    outer loop
-      vertex 18 30.6799 -53
-      vertex 19.4164 29.1068 -44.1575
-      vertex 19.4164 29.1068 -53
-    endloop
-  endfacet
-  facet normal -0.20791 -0.978148 0
+  facet normal -0.207831 -0.978165 0
     outer loop
       vertex 2.1049 28.787 -49
       vertex 1.4634 28.9233 -44.1898
       vertex 1.4634 28.9233 -49
     endloop
   endfacet
-  facet normal -0.207912 -0.978148 -1.86764e-007
+  facet normal -0.207907 -0.978149 -1.05409e-05
     outer loop
       vertex 1.4634 28.9233 -44.1898
       vertex 2.1049 28.787 -49
       vertex 4.32624 28.3148 -44.2971
     endloop
   endfacet
-  facet normal -0.207912 -0.978148 -0
+  facet normal -0.207928 -0.978144 -0
     outer loop
       vertex 4.32624 28.3148 -44.2971
       vertex 2.1049 28.787 -49
       vertex 4.32624 28.3148 -49
     endloop
   endfacet
-  facet normal -0.866025 -0.5 -9.88455e-008
+  facet normal -0.866007 -0.500033 -3.52396e-05
     outer loop
       vertex 12.7896 20.6943 -45.6408
       vertex 11.3262 23.229 -49
       vertex 12.5127 21.1741 -49
     endloop
   endfacet
-  facet normal -0.866026 -0.499999 -0
+  facet normal -0.866113 -0.499847 -0
     outer loop
       vertex 12.7896 20.6943 -45.6408
       vertex 12.5127 21.1741 -49
       vertex 12.7896 20.6943 -49
     endloop
   endfacet
-  facet normal -0.866026 -0.5 0
+  facet normal -0.866027 -0.499998 0
     outer loop
       vertex 11.3262 23.229 -49
       vertex 12.7896 20.6943 -45.6408
       vertex 11.3262 23.229 -45.1939
     endloop
   endfacet
-  facet normal -0.951056 -0.309017 -0
+  facet normal -0.951048 -0.309044 -0
     outer loop
       vertex 13.6941 17.9108 -46.1317
       vertex 12.7896 20.6943 -49
       vertex 13.6941 17.9108 -49
     endloop
   endfacet
-  facet normal -0.951056 -0.309017 0
+  facet normal -0.951048 -0.309044 0
     outer loop
       vertex 12.7896 20.6943 -49
       vertex 13.6941 17.9108 -46.1317
       vertex 12.7896 20.6943 -45.6408
     endloop
   endfacet
-  facet normal 0.406736 -0.913546 0
+  facet normal 0.406699 -0.913562 0
     outer loop
       vertex -5.25329 27.902 -49
       vertex -7 27.1244 -44.5071
       vertex -7 27.1244 -49
     endloop
   endfacet
-  facet normal 0.406737 -0.913545 1.62462e-007
+  facet normal 0.406726 -0.91355 1.23832e-05
     outer loop
       vertex -7 27.1244 -44.5071
       vertex -5.25329 27.902 -49
       vertex -4.32624 28.3148 -44.2971
     endloop
   endfacet
-  facet normal 0.406737 -0.913545 0
+  facet normal 0.406778 -0.913527 0
     outer loop
       vertex -4.32624 28.3148 -44.2971
       vertex -5.25329 27.902 -49
@@ -993,203 +993,203 @@ solid OpenSCAD_Model
       vertex 1.4634 28.9233 -49
     endloop
   endfacet
-  facet normal 0.951056 -0.309017 0
+  facet normal 0.951048 -0.309044 0
     outer loop
       vertex -13.6941 17.9108 -46.1317
       vertex -12.7896 20.6943 -49
       vertex -12.7896 20.6943 -45.6408
     endloop
   endfacet
-  facet normal 0.951056 -0.309017 0
+  facet normal 0.951048 -0.309044 0
     outer loop
       vertex -12.7896 20.6943 -49
       vertex -13.6941 17.9108 -46.1317
       vertex -13.6941 17.9108 -49
     endloop
   endfacet
-  facet normal 0.994521 -0.104534 0
+  facet normal 0.994572 -0.104048 0
     outer loop
       vertex -13.6941 17.9108 -46.1317
       vertex -13.7043 17.8133 -49
       vertex -13.6941 17.9108 -49
     endloop
   endfacet
-  facet normal 0.994522 -0.104528 -1.82158e-007
+  facet normal 0.994525 -0.1045 1.55453e-05
     outer loop
       vertex -13.7898 17 -46.2923
       vertex -13.7043 17.8133 -49
       vertex -13.6941 17.9108 -46.1317
     endloop
   endfacet
-  facet normal 0.994522 -0.104528 0
+  facet normal 0.99452 -0.104551 0
     outer loop
       vertex -13.7043 17.8133 -49
       vertex -13.7898 17 -46.2923
       vertex -13.7898 17 -49
     endloop
   endfacet
-  facet normal -0.406737 -0.913545 0
+  facet normal -0.406778 -0.913527 0
     outer loop
       vertex 5.25329 27.902 -49
       vertex 4.32624 28.3148 -44.2971
       vertex 4.32624 28.3148 -49
     endloop
   endfacet
-  facet normal -0.406737 -0.913545 1.62462e-007
+  facet normal -0.406726 -0.91355 1.23832e-05
     outer loop
       vertex 4.32624 28.3148 -44.2971
       vertex 5.25329 27.902 -49
       vertex 7 27.1244 -44.5071
     endloop
   endfacet
-  facet normal -0.406736 -0.913546 -0
+  facet normal -0.406699 -0.913562 -0
     outer loop
       vertex 7 27.1244 -44.5071
       vertex 5.25329 27.902 -49
       vertex 7 27.1244 -49
     endloop
   endfacet
-  facet normal -0.587786 -0.809017 0
+  facet normal -0.587795 -0.80901 0
     outer loop
       vertex 8.13989 26.2962 -49
       vertex 7 27.1244 -44.5071
       vertex 7 27.1244 -49
     endloop
   endfacet
-  facet normal -0.587786 -0.809017 5.56894e-008
+  facet normal -0.587801 -0.809005 -2.35407e-06
     outer loop
       vertex 7 27.1244 -44.5071
       vertex 8.13989 26.2962 -49
       vertex 9.36783 25.404 -44.8104
     endloop
   endfacet
-  facet normal -0.587785 -0.809017 -0
+  facet normal -0.587807 -0.809002 -0
     outer loop
       vertex 9.36783 25.404 -44.8104
       vertex 8.13989 26.2962 -49
       vertex 9.36783 25.404 -49
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 0
+  facet normal -0.74312 -0.669158 0
     outer loop
       vertex 10.6085 24.0262 -49
       vertex 9.36783 25.404 -44.8104
       vertex 9.36783 25.404 -49
     endloop
   endfacet
-  facet normal -0.743145 -0.66913 -0
+  facet normal -0.743192 -0.669078 -0
     outer loop
       vertex 11.3262 23.229 -45.1939
       vertex 10.6085 24.0262 -49
       vertex 11.3262 23.229 -49
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 -1.16314e-007
+  facet normal -0.743148 -0.669127 -1.86189e-05
     outer loop
       vertex 10.6085 24.0262 -49
       vertex 11.3262 23.229 -45.1939
       vertex 9.36783 25.404 -44.8104
     endloop
   endfacet
-  facet normal -0.994521 -0.104534 0
+  facet normal -0.994572 -0.104048 0
     outer loop
       vertex 13.7043 17.8133 -49
       vertex 13.6941 17.9108 -46.1317
       vertex 13.6941 17.9108 -49
     endloop
   endfacet
-  facet normal -0.994522 -0.104528 -0
+  facet normal -0.99452 -0.104551 -0
     outer loop
       vertex 13.7898 17 -46.2923
       vertex 13.7043 17.8133 -49
       vertex 13.7898 17 -49
     endloop
   endfacet
-  facet normal -0.994522 -0.104528 -1.82158e-007
+  facet normal -0.994525 -0.1045 1.55453e-05
     outer loop
       vertex 13.7043 17.8133 -49
       vertex 13.7898 17 -46.2923
       vertex 13.6941 17.9108 -46.1317
     endloop
   endfacet
-  facet normal 0.207912 -0.978148 0
+  facet normal 0.207928 -0.978144 0
     outer loop
       vertex -2.1049 28.787 -49
       vertex -4.32624 28.3148 -44.2971
       vertex -4.32624 28.3148 -49
     endloop
   endfacet
-  facet normal 0.207912 -0.978148 -1.86764e-007
+  facet normal 0.207907 -0.978149 -1.05409e-05
     outer loop
       vertex -4.32624 28.3148 -44.2971
       vertex -2.1049 28.787 -49
       vertex -1.4634 28.9233 -44.1898
     endloop
   endfacet
-  facet normal 0.20791 -0.978148 0
+  facet normal 0.207831 -0.978165 0
     outer loop
       vertex -1.4634 28.9233 -44.1898
       vertex -2.1049 28.787 -49
       vertex -1.4634 28.9233 -49
     endloop
   endfacet
-  facet normal 0.743145 -0.669131 0
+  facet normal 0.74312 -0.669158 0
     outer loop
       vertex -9.36783 25.404 -44.8104
       vertex -10.6085 24.0262 -49
       vertex -9.36783 25.404 -49
     endloop
   endfacet
-  facet normal 0.743145 -0.669131 -1.16314e-007
+  facet normal 0.743148 -0.669127 -1.86189e-05
     outer loop
       vertex -11.3262 23.229 -45.1939
       vertex -10.6085 24.0262 -49
       vertex -9.36783 25.404 -44.8104
     endloop
   endfacet
-  facet normal 0.743145 -0.66913 0
+  facet normal 0.743192 -0.669078 0
     outer loop
       vertex -10.6085 24.0262 -49
       vertex -11.3262 23.229 -45.1939
       vertex -11.3262 23.229 -49
     endloop
   endfacet
-  facet normal 0.587785 -0.809017 0
+  facet normal 0.587807 -0.809002 0
     outer loop
       vertex -8.13989 26.2962 -49
       vertex -9.36783 25.404 -44.8104
       vertex -9.36783 25.404 -49
     endloop
   endfacet
-  facet normal 0.587786 -0.809017 5.56894e-008
+  facet normal 0.587801 -0.809005 -2.35407e-06
     outer loop
       vertex -9.36783 25.404 -44.8104
       vertex -8.13989 26.2962 -49
       vertex -7 27.1244 -44.5071
     endloop
   endfacet
-  facet normal 0.587786 -0.809017 0
+  facet normal 0.587795 -0.80901 0
     outer loop
       vertex -7 27.1244 -44.5071
       vertex -8.13989 26.2962 -49
       vertex -7 27.1244 -49
     endloop
   endfacet
-  facet normal 0.866026 -0.5 0
+  facet normal 0.866027 -0.499998 0
     outer loop
       vertex -12.7896 20.6943 -45.6408
       vertex -11.3262 23.229 -49
       vertex -11.3262 23.229 -45.1939
     endloop
   endfacet
-  facet normal 0.866025 -0.5 -9.88455e-008
+  facet normal 0.866007 -0.500033 -3.52396e-05
     outer loop
       vertex -11.3262 23.229 -49
       vertex -12.7896 20.6943 -45.6408
       vertex -12.5127 21.1741 -49
     endloop
   endfacet
-  facet normal 0.866026 -0.499999 0
+  facet normal 0.866113 -0.499847 0
     outer loop
       vertex -12.5127 21.1741 -49
       vertex -12.7896 20.6943 -45.6408
@@ -1287,1131 +1287,1124 @@ solid OpenSCAD_Model
       vertex 18 30.6799 -53
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 1 0
     outer loop
-      vertex -11.1397 52 -44
-      vertex 10.25 51 -44
-      vertex 11.2 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.25 51 -44
-      vertex -11.1397 52 -44
-      vertex -10.25 51 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18 40.1177 -44
-      vertex -10.25 51 -44
-      vertex -11.1397 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.25 51 -44
-      vertex -18 40.1177 -44
-      vertex -10.25 36.5638 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10.25 36.5638 -44
-      vertex -18 40.1177 -44
-      vertex -12 35.7846 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12 35.7846 -44
-      vertex -18 40.1177 -44
-      vertex -16.0591 32.8355 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0591 32.8355 -44
-      vertex -18 40.1177 -44
-      vertex -18 30.6799 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.2 52 -44
-      vertex 12.25 44 -44
-      vertex 17.8395 40.5 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.25 51 -44
-      vertex 12.25 44 -44
-      vertex 11.2 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.25 44 -44
-      vertex 10.25 51 -44
-      vertex 10.25 44 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.25 41 -44
-      vertex 17.8395 40.5 -44
-      vertex 12.25 44 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.25 41 -44
-      vertex 10.5 40.5 -44
-      vertex 17.8395 40.5 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10.25 41 -44
-      vertex 10.5 40.5 -44
-      vertex 12.25 41 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.25 36.5638 -44
-      vertex 10.5 40.5 -44
-      vertex 10.25 41 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 40.5 -44
-      vertex 10.25 36.5638 -44
-      vertex 10.5 36.4525 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18 35.5 -44
-      vertex 16.0591 32.8355 -44
-      vertex 18 30.6799 -44
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 16.0591 32.8355 -44
-      vertex 18 35.5 -44
-      vertex 12.3917 35.5 -44
+      vertex 3.35452 52 -47.226
+      vertex 2.36353 52 -46.776
+      vertex 2.74963 52 -46.826
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.83774 52 -46.977
-      vertex -5.10487 52 -49.592
-      vertex -4.36874 52 -46.977
+      vertex 3.35452 52 -47.226
+      vertex 2.74963 52 -46.826
+      vertex 3.07997 52 -46.976
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -5.97687 52 -50.104
-      vertex -5.88887 52 -49.592
-      vertex -5.10487 52 -49.592
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex -7.0352 52 -50.0647
-      vertex -5.88887 52 -49.592
-      vertex -5.97687 52 -50.104
+      vertex 3.55952 52 -47.5676
+      vertex 2.36353 52 -46.776
+      vertex 3.35452 52 -47.226
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -5.97687 52 -50.104
-      vertex -5.10487 52 -49.592
-      vertex -4.99588 52 -50.104
+      vertex 2.36353 52 -46.776
+      vertex 1.37952 52 -47.227
+      vertex 1.97864 52 -46.8261
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.97864 52 -46.8261
+      vertex 1.37952 52 -47.227
+      vertex 1.65063 52 -46.9765
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.17674 52 -47.5693
+      vertex 2.36353 52 -46.776
+      vertex 3.55952 52 -47.5676
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.36353 52 -46.776
+      vertex 1.17674 52 -47.5693
+      vertex 1.37952 52 -47.227
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.68253 52 -47.9936
+      vertex 1.17674 52 -47.5693
+      vertex 3.55952 52 -47.5676
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.68253 52 -47.9936
+      vertex 1.05508 52 -47.995
+      vertex 1.17674 52 -47.5693
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.72353 52 -48.504
+      vertex 1.05508 52 -47.995
+      vertex 3.68253 52 -47.9936
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.72353 52 -48.504
+      vertex 1.01453 52 -48.504
+      vertex 1.05508 52 -47.995
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -2.83774 52 -51
-      vertex -5.10487 52 -49.592
-      vertex -2.83774 52 -46.977
+      vertex 3.68253 52 -49.0146
+      vertex 1.01453 52 -48.504
+      vertex 3.72353 52 -48.504
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -5.10487 52 -49.592
-      vertex -2.83774 52 -51
-      vertex -4.99588 52 -50.104
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -4.99588 52 -50.104
-      vertex -2.83774 52 -51
-      vertex -4.99588 52 -51
+      vertex 3.68253 52 -49.0146
+      vertex 1.05508 52 -49.0146
+      vertex 1.01453 52 -48.504
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -4.36874 52 -46.977
-      vertex -4.99588 52 -46.2
-      vertex -4.36874 52 -46.2
+      vertex 3.55952 52 -49.4409
+      vertex 1.05508 52 -49.0146
+      vertex 3.68253 52 -49.0146
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -4.99588 52 -46.2
-      vertex -4.36874 52 -46.977
-      vertex -5.10487 52 -49.592
+      vertex 3.55952 52 -49.4409
+      vertex 1.17674 52 -49.4409
+      vertex 1.05508 52 -49.0146
     endloop
   endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 8.52701 52 -48.12
-      vertex 6.42101 52 -46.2
-      vertex 8.52701 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 6.42101 52 -46.2
-      vertex 8.52701 52 -48.12
-      vertex 6.42101 52 -48.12
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -44
-      vertex -8.12955 52 -46.1746
-      vertex -8.57843 52 -46.136
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -44
-      vertex -0.296738 52 -46.2
-      vertex -4.36874 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.65808 52 -46.2086
-      vertex -0.296738 52 -46.2
-      vertex 2.36508 52 -46.136
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.06242 52 -46.4262
-      vertex -0.296738 52 -46.2
-      vertex 1.65808 52 -46.2086
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.578079 52 -46.789
-      vertex -0.296738 52 -46.2
-      vertex 1.06242 52 -46.4262
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.578079 52 -46.789
-      vertex -0.296738 52 -46.977
-      vertex -0.296738 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.220306 52 -47.2778
-      vertex -0.296738 52 -46.977
-      vertex 0.578079 52 -46.789
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.00564575 52 -47.8748
-      vertex -0.296738 52 -46.977
-      vertex 0.220306 52 -47.2778
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.296738 52 -46.977
-      vertex 0.00564575 52 -47.8748
-      vertex -1.83275 52 -46.977
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -0.065918 52 -48.58
-      vertex -1.83275 52 -46.977
-      vertex 0.00564575 52 -47.8748
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.0329132 52 -49.0581
-      vertex -1.83275 52 -46.977
-      vertex -0.065918 52 -48.58
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -1.83275 52 -51
-      vertex -0.0329132 52 -49.0581
-      vertex 0.0660858 52 -49.4964
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -1.83275 52 -51
-      vertex 0.0660858 52 -49.4964
-      vertex 0.231079 52 -49.895
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -1.83275 52 -51
-      vertex 0.231079 52 -49.895
-      vertex 0.457535 52 -50.2435
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.0329132 52 -49.0581
-      vertex -1.83275 52 -51
-      vertex -1.83275 52 -46.977
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.74086 52 -50.5328
-      vertex -1.83275 52 -51
-      vertex 0.457535 52 -50.2435
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.08109 52 -50.763
-      vertex -1.83275 52 -51
-      vertex 0.74086 52 -50.5328
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.47031 52 -50.9302
-      vertex -1.83275 52 -51
-      vertex 1.08109 52 -50.763
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -53
-      vertex -2.83774 52 -51
-      vertex -1.83275 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2.83774 52 -51
-      vertex -11.1397 52 -53
-      vertex -4.99588 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -4.99588 52 -51
-      vertex -11.1397 52 -53
-      vertex -5.97687 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.97687 52 -51
-      vertex -11.1397 52 -53
-      vertex -6.89143 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -53
-      vertex -1.83275 52 -51
-      vertex 1.90063 52 -51.0305
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.90063 52 -51.0305
-      vertex -1.83275 52 -51
-      vertex 1.47031 52 -50.9302
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.296738 52 -46.2
-      vertex 11.2 52 -44
-      vertex 2.36508 52 -46.136
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 8.52701 52 -46.2
-      vertex 11.2 52 -44
-      vertex 9.53201 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 11.2 52 -53
-      vertex 9.53201 52 -46.2
-      vertex 11.2 52 -44
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 11.2 52 -53
-      vertex 8.52701 52 -51
-      vertex 9.53201 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 8.52701 52 -51
-      vertex 11.2 52 -53
-      vertex 6.42101 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 6.42101 52 -51
-      vertex 11.2 52 -53
-      vertex 5.416 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -51
-      vertex 11.2 52 -53
-      vertex 2.37209 52 -51.064
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 9.53201 52 -46.2
-      vertex 11.2 52 -53
-      vertex 9.53201 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 11.2 52 -44
-      vertex -0.296738 52 -46.2
-      vertex -11.1397 52 -44
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.05876 52 -46.1753
-      vertex -11.1397 52 -44
-      vertex -8.57843 52 -46.136
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.45844 52 -46.2933
-      vertex -11.1397 52 -44
-      vertex -9.05876 52 -46.1753
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -9.77744 52 -46.49
-      vertex -11.1397 52 -44
-      vertex -9.45844 52 -46.2933
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.0102 52 -46.7572
-      vertex -11.1397 52 -44
-      vertex -9.77744 52 -46.49
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.1499 52 -47.0882
-      vertex -11.1397 52 -44
-      vertex -10.0102 52 -46.7572
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -10.1964 52 -47.483
-      vertex -11.1397 52 -44
-      vertex -10.1499 52 -47.0882
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.1815 52 -47.6999
-      vertex -11.1397 52 -44
-      vertex -10.1964 52 -47.483
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -10.1815 52 -47.6999
-      vertex -10.1369 52 -47.9026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -8.75443 52 -49.414
-      vertex -8.59909 52 -49.5411
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -8.59909 52 -49.5411
-      vertex -8.45309 52 -49.6691
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -8.45309 52 -49.6691
-      vertex -8.31644 52 -49.798
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.75443 52 -49.414
-      vertex -10.2714 52 -50.213
-      vertex -9.25143 52 -49.023
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -8.31644 52 -49.798
-      vertex -8.19577 52 -49.9303
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -8.19577 52 -49.9303
-      vertex -8.09776 52 -50.0687
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -8.09776 52 -50.0687
-      vertex -8.02243 52 -50.213
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.25143 52 -49.023
-      vertex -10.2714 52 -50.213
-      vertex -9.41754 52 -48.8859
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.41754 52 -48.8859
-      vertex -10.2714 52 -50.213
-      vertex -9.57321 52 -48.7426
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -9.71843 52 -48.593
-      vertex -9.57321 52 -48.7426
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -9.84999 52 -48.435
-      vertex -9.71843 52 -48.593
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -9.96465 52 -48.2677
-      vertex -9.84999 52 -48.435
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -10.0624 52 -48.091
-      vertex -9.96465 52 -48.2677
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.2714 52 -50.213
-      vertex -10.1369 52 -47.9026
-      vertex -10.0624 52 -48.091
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -53
-      vertex -10.1815 52 -47.6999
-      vertex -10.2714 52 -50.213
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -53
-      vertex -10.2714 52 -50.213
-      vertex -10.2714 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -53
-      vertex 1.90063 52 -51.0305
-      vertex 2.37209 52 -51.064
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -53
-      vertex 2.37209 52 -51.064
-      vertex 11.2 52 -53
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.1815 52 -47.6999
-      vertex -11.1397 52 -53
-      vertex -11.1397 52 -44
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -6.89143 52 -51
-      vertex -11.1397 52 -53
-      vertex -10.2714 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 6.42101 52 -46.2
-      vertex 11.2 52 -44
-      vertex 8.52701 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -46.2
-      vertex 11.2 52 -44
-      vertex 6.42101 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.07198 52 -46.2078
-      vertex 11.2 52 -44
-      vertex 5.416 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 11.2 52 -44
-      vertex 3.07198 52 -46.2078
-      vertex 2.36508 52 -46.136
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -46.2
-      vertex 3.66731 52 -46.4231
-      vertex 3.07198 52 -46.2078
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -46.2
-      vertex 4.15109 52 -46.782
-      vertex 3.66731 52 -46.4231
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -46.2
-      vertex 4.50775 52 -47.2684
-      vertex 4.15109 52 -46.782
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -46.2
-      vertex 4.72176 52 -47.8678
-      vertex 4.50775 52 -47.2684
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -46.2
-      vertex 4.79309 52 -48.58
-      vertex 4.72176 52 -47.8678
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 5.416 52 -51
-      vertex 4.79309 52 -48.58
-      vertex 5.416 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.79309 52 -48.58
-      vertex 5.416 52 -51
-      vertex 4.72163 52 -49.2956
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -51
-      vertex 4.50731 52 -49.9022
-      vertex 4.72163 52 -49.2956
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -51
-      vertex 4.15009 52 -50.4
-      vertex 4.50731 52 -49.9022
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -51
-      vertex 3.66631 52 -50.7689
-      vertex 4.15009 52 -50.4
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 5.416 52 -51
-      vertex 3.07364 52 -50.9902
-      vertex 3.66631 52 -50.7689
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.07364 52 -50.9902
-      vertex 5.416 52 -51
-      vertex 2.37209 52 -51.064
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -4.99588 52 -46.2
-      vertex -11.1397 52 -44
-      vertex -4.36874 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -5.99788 52 -46.2
-      vertex -11.1397 52 -44
-      vertex -4.99588 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -11.1397 52 -44
-      vertex -5.99788 52 -46.2
-      vertex -8.12955 52 -46.1746
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.99788 52 -46.2
-      vertex -7.74821 52 -46.2902
-      vertex -8.12955 52 -46.1746
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.99788 52 -46.2
-      vertex -7.43443 52 -46.483
-      vertex -7.74821 52 -46.2902
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.99788 52 -46.2
-      vertex -7.19199 52 -46.7491
-      vertex -7.43443 52 -46.483
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.99788 52 -46.2
-      vertex -7.02466 52 -47.0848
-      vertex -7.19199 52 -46.7491
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.99788 52 -46.2
-      vertex -6.93243 52 -47.49
-      vertex -7.02466 52 -47.0848
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.9752 52 -48.9976
-      vertex -7.89642 52 -47.544
-      vertex -6.93243 52 -47.49
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex -9.13531 52 -47.8689
-      vertex -7.89642 52 -47.544
-      vertex -9.02142 52 -48.045
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.89642 52 -47.544
-      vertex -9.13531 52 -47.8689
-      vertex -9.20366 52 -47.6952
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.89642 52 -47.544
-      vertex -8.85155 52 -48.2376
-      vertex -9.02142 52 -48.045
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.89642 52 -47.544
-      vertex -8.61388 52 -48.4619
-      vertex -8.85155 52 -48.2376
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.89642 52 -47.544
-      vertex -7.9752 52 -48.9976
-      vertex -8.61388 52 -48.4619
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.88887 52 -49.592
-      vertex -6.93243 52 -47.49
-      vertex -5.99788 52 -46.2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -6.93243 52 -47.49
-      vertex -7.68221 52 -49.2696
-      vertex -7.9752 52 -48.9976
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex -7.42943 52 -49.534
-      vertex -6.93243 52 -47.49
-      vertex -5.88887 52 -49.592
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -6.93243 52 -47.49
-      vertex -7.42943 52 -49.534
-      vertex -7.68221 52 -49.2696
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.42943 52 -49.534
-      vertex -5.88887 52 -49.592
-      vertex -7.21454 52 -49.797
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.94144 52 -47.3472
-      vertex -8.58543 52 -46.899
-      vertex -8.39432 52 -46.917
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.01244 52 -47.1862
-      vertex -8.39432 52 -46.917
-      vertex -8.23566 52 -46.971
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.01244 52 -47.1862
-      vertex -8.23566 52 -46.971
-      vertex -8.10944 52 -47.061
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.58543 52 -46.899
-      vertex -9.22643 52 -47.524
-      vertex -8.94154 52 -46.9684
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.39432 52 -46.917
-      vertex -8.01244 52 -47.1862
-      vertex -7.94144 52 -47.3472
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.58543 52 -46.899
-      vertex -7.94144 52 -47.3472
-      vertex -9.20366 52 -47.6952
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.94154 52 -46.9684
-      vertex -9.22643 52 -47.524
-      vertex -9.15521 52 -47.1768
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.20366 52 -47.6952
-      vertex -7.94144 52 -47.3472
-      vertex -7.89642 52 -47.544
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.58543 52 -46.899
-      vertex -9.20366 52 -47.6952
-      vertex -9.22643 52 -47.524
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.88887 52 -49.592
-      vertex -7.0352 52 -50.0647
-      vertex -7.21454 52 -49.797
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -5.97687 52 -50.104
-      vertex -6.89143 52 -50.337
-      vertex -7.0352 52 -50.0647
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -5.97687 52 -51
-      vertex -6.89143 52 -50.337
-      vertex -5.97687 52 -50.104
-    endloop
-  endfacet
   facet normal 0 1 0
-    outer loop
-      vertex -6.89143 52 -50.337
-      vertex -5.97687 52 -51
-      vertex -6.89143 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 8.52701 52 -51
-      vertex 6.42101 52 -48.951
-      vertex 8.52701 52 -48.951
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 6.42101 52 -48.951
-      vertex 8.52701 52 -51
-      vertex 6.42101 52 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.61708 52 -47.692
-      vertex 2.36508 52 -46.926
-      vertex 2.7823 52 -46.9746
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.41208 52 -47.363
-      vertex 2.7823 52 -46.9746
-      vertex 3.1313 52 -47.1202
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.74008 52 -48.0977
-      vertex 2.36508 52 -46.926
-      vertex 3.61708 52 -47.692
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.7823 52 -46.9746
-      vertex 3.41208 52 -47.363
-      vertex 3.61708 52 -47.692
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.36508 52 -46.926
-      vertex 1.12354 52 -47.696
-      vertex 1.95354 52 -46.9749
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex 1.32909 52 -47.366
-      vertex 1.95354 52 -46.9749
-      vertex 1.12354 52 -47.696
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.95354 52 -46.9749
-      vertex 1.32909 52 -47.366
-      vertex 1.6082 52 -47.1216
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.0002 52 -48.1007
-      vertex 2.36508 52 -46.926
-      vertex 3.74008 52 -48.0977
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.36508 52 -46.926
-      vertex 1.0002 52 -48.1007
-      vertex 1.12354 52 -47.696
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.78108 52 -48.58
-      vertex 1.0002 52 -48.1007
-      vertex 3.74008 52 -48.0977
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.78108 52 -48.58
-      vertex 0.959091 52 -48.58
-      vertex 1.0002 52 -48.1007
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 3.73909 52 -49.0677
-      vertex 0.959091 52 -48.58
-      vertex 3.78108 52 -48.58
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.73909 52 -49.0677
-      vertex 0.999969 52 -49.0797
-      vertex 0.959091 52 -48.58
-    endloop
-  endfacet
-  facet normal 0 1 -0
     outer loop
-      vertex 3.61308 52 -49.4813
-      vertex 0.999969 52 -49.0797
-      vertex 3.73909 52 -49.0677
+      vertex 2.36353 52 -50.232
+      vertex 3.55952 52 -49.4409
+      vertex 3.35452 52 -49.783
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 3.61308 52 -49.4813
-      vertex 1.12263 52 -49.4973
-      vertex 0.999969 52 -49.0797
+      vertex 3.55952 52 -49.4409
+      vertex 2.36353 52 -50.232
+      vertex 1.17674 52 -49.4409
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.37209 52 -50.274
-      vertex 3.61308 52 -49.4813
-      vertex 3.40309 52 -49.821
+      vertex 2.74963 52 -50.1821
+      vertex 3.35452 52 -49.783
+      vertex 3.07997 52 -50.0325
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 3.61308 52 -49.4813
-      vertex 2.37209 52 -50.274
-      vertex 1.12263 52 -49.4973
+      vertex 1.17674 52 -49.4409
+      vertex 2.36353 52 -50.232
+      vertex 1.37952 52 -49.783
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 2.77687 52 -50.2237
-      vertex 3.40309 52 -49.821
-      vertex 3.12053 52 -50.0727
+      vertex 3.35452 52 -49.783
+      vertex 2.74963 52 -50.1821
+      vertex 2.36353 52 -50.232
     endloop
   endfacet
   facet normal -0 1 -0
     outer loop
-      vertex 1.95464 52 -50.225
-      vertex 1.12263 52 -49.4973
-      vertex 2.37209 52 -50.274
+      vertex 1.97864 52 -50.1821
+      vertex 1.37952 52 -49.783
+      vertex 2.36353 52 -50.232
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 3.40309 52 -49.821
-      vertex 2.77687 52 -50.2237
-      vertex 2.37209 52 -50.274
+      vertex 1.37952 52 -49.783
+      vertex 1.97864 52 -50.1821
+      vertex 1.65063 52 -50.0325
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 1.12263 52 -49.4973
-      vertex 1.95464 52 -50.225
-      vertex 1.32709 52 -49.833
+      vertex -5.09949 52 -49.976
+      vertex -4.33089 52 -46.904
+      vertex -2.83589 52 -46.904
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 1.32709 52 -49.833
-      vertex 1.95464 52 -50.225
-      vertex 1.60631 52 -50.078
+      vertex -4.33089 52 -46.904
+      vertex -5.35649 52 -49.592
+      vertex -5.07549 52 -47.27
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.1095 52 -49.976
+      vertex -5.86249 52 -49.592
+      vertex -5.35649 52 -49.592
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.1095 52 -49.976
+      vertex -5.35649 52 -49.592
+      vertex -5.09949 52 -49.976
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -4.33089 52 -46.904
+      vertex -5.09949 52 -49.976
+      vertex -5.35649 52 -49.592
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.83589 52 -51
+      vertex -5.09949 52 -49.976
+      vertex -2.83589 52 -46.904
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.09949 52 -49.976
+      vertex -2.83589 52 -51
+      vertex -5.09949 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.13649 52 -46.008
+      vertex -7.47694 52 -46.1528
+      vertex -8.06828 52 -46.072
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.13649 52 -46.008
+      vertex -7.01895 52 -46.3951
+      vertex -7.47694 52 -46.1528
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.13649 52 -46.008
+      vertex -6.69427 52 -46.799
+      vertex -7.01895 52 -46.3951
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -6.13649 52 -47.27
+      vertex -6.69427 52 -46.799
+      vertex -6.13649 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.69427 52 -46.799
+      vertex -6.13649 52 -47.27
+      vertex -6.57884 52 -47.0796
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.13649 52 -47.27
+      vertex -6.50317 52 -47.4132
+      vertex -6.57884 52 -47.0796
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.13649 52 -47.27
+      vertex -6.46729 52 -47.8
+      vertex -6.50317 52 -47.4132
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.61728 52 -48.998
+      vertex -7.40628 52 -47.8
+      vertex -6.46729 52 -47.8
+    endloop
+  endfacet
+  facet normal -0 1 0
+    outer loop
+      vertex -8.64906 52 -48.093
+      vertex -7.40628 52 -47.8
+      vertex -8.48128 52 -48.311
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.40628 52 -47.8
+      vertex -8.64906 52 -48.093
+      vertex -8.74973 52 -47.8617
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.40628 52 -47.8
+      vertex -8.29817 52 -48.4776
+      vertex -8.48128 52 -48.311
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.40628 52 -47.8
+      vertex -8.01018 52 -48.7066
+      vertex -8.29817 52 -48.4776
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.40628 52 -47.8
+      vertex -7.61728 52 -48.998
+      vertex -8.01018 52 -48.7066
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.46729 52 -47.8
+      vertex -7.1665 52 -49.3611
+      vertex -7.61728 52 -48.998
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.86249 52 -49.592
+      vertex -6.46729 52 -47.8
+      vertex -6.13649 52 -47.27
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.46729 52 -47.8
+      vertex -5.86249 52 -49.592
+      vertex -7.1665 52 -49.3611
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.1665 52 -49.3611
+      vertex -5.86249 52 -49.592
+      vertex -6.84084 52 -49.7091
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -4.33089 52 -46.904
+      vertex -5.07549 52 -46.008
+      vertex -4.33089 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.07549 52 -46.008
+      vertex -4.33089 52 -46.904
+      vertex -5.07549 52 -47.27
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 1.16008 52 -46.1373
+      vertex -0.282898 52 -46.008
+      vertex 1.70609 52 -45.9443
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.726517 52 -46.459
+      vertex -0.282898 52 -46.008
+      vertex 1.16008 52 -46.1373
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.306519 52 -46.9898
+      vertex -0.282898 52 -46.008
+      vertex 0.726517 52 -46.459
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.282898 52 -46.008
+      vertex 0.306519 52 -46.9898
+      vertex -0.282898 52 -46.904
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 0.0545197 52 -47.6714
+      vertex -0.282898 52 -46.904
+      vertex 0.306519 52 -46.9898
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.282898 52 -46.904
+      vertex 0.0545197 52 -47.6714
+      vertex -1.7849 52 -46.904
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -0.02948 52 -48.504
+      vertex -1.7849 52 -46.904
+      vertex 0.0545197 52 -47.6714
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.7849 52 -51
+      vertex -0.02948 52 -48.504
+      vertex 0.0545197 52 -49.325
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1.7849 52 -51
+      vertex 0.0545197 52 -49.325
+      vertex 0.306519 52 -50.0067
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.02948 52 -48.504
+      vertex -1.7849 52 -51
+      vertex -1.7849 52 -46.904
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.726517 52 -50.549
+      vertex -1.7849 52 -51
+      vertex 0.306519 52 -50.0067
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.16008 52 -50.8707
+      vertex -1.7849 52 -51
+      vertex 0.726517 52 -50.549
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1397 52 -53
+      vertex -2.83589 52 -51
+      vertex -1.7849 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -2.83589 52 -51
+      vertex -11.1397 52 -53
+      vertex -5.09949 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.09949 52 -51
+      vertex -11.1397 52 -53
+      vertex -6.1095 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.1095 52 -51
+      vertex -11.1397 52 -53
+      vertex -6.41328 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1397 52 -53
+      vertex -1.7849 52 -51
+      vertex 1.70609 52 -51.0637
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.70609 52 -51.0637
+      vertex -1.7849 52 -51
+      vertex 1.16008 52 -50.8707
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 8.444 52 -47.928
+      vertex 6.49101 52 -46.008
+      vertex 8.444 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6.49101 52 -46.008
+      vertex 8.444 52 -47.928
+      vertex 6.49101 52 -47.928
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.2 52 -44
+      vertex 2.36452 52 -45.88
+      vertex -11.1397 52 -44
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.2 52 -44
+      vertex 3.02242 52 -45.9443
+      vertex 2.36452 52 -45.88
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 8.444 52 -46.008
+      vertex 11.2 52 -44
+      vertex 9.47801 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.2 52 -44
+      vertex 9.47801 52 -51
+      vertex 9.47801 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.2 52 -53
+      vertex 8.444 52 -51
+      vertex 9.47801 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 8.444 52 -51
+      vertex 11.2 52 -53
+      vertex 6.49101 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6.49101 52 -51
+      vertex 11.2 52 -53
+      vertex 5.453 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -51
+      vertex 11.2 52 -53
+      vertex 3.02242 52 -51.0637
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.02242 52 -51.0637
+      vertex 11.2 52 -53
+      vertex 2.36452 52 -51.128
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 11.2 52 -53
+      vertex 9.47801 52 -51
+      vertex 11.2 52 -44
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.282898 52 -46.008
+      vertex 2.36452 52 -45.88
+      vertex 1.70609 52 -45.9443
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.36452 52 -45.88
+      vertex -0.282898 52 -46.008
+      vertex -11.1397 52 -44
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -4.33089 52 -46.008
+      vertex -11.1397 52 -44
+      vertex -0.282898 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -5.07549 52 -46.008
+      vertex -11.1397 52 -44
+      vertex -4.33089 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -6.13649 52 -46.008
+      vertex -11.1397 52 -44
+      vertex -5.07549 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -8.06828 52 -46.072
+      vertex -11.1397 52 -44
+      vertex -6.13649 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -8.55284 52 -46.1199
+      vertex -11.1397 52 -44
+      vertex -8.06828 52 -46.072
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -8.96651 52 -46.2636
+      vertex -11.1397 52 -44
+      vertex -8.55284 52 -46.1199
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -9.30928 52 -46.503
+      vertex -11.1397 52 -44
+      vertex -8.96651 52 -46.2636
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -9.5654 52 -46.8213
+      vertex -11.1397 52 -44
+      vertex -9.30928 52 -46.503
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -9.71906 52 -47.2017
+      vertex -11.1397 52 -44
+      vertex -9.5654 52 -46.8213
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -9.77028 52 -47.644
+      vertex -11.1397 52 -44
+      vertex -9.71906 52 -47.2017
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1397 52 -53
+      vertex -9.77028 52 -47.644
+      vertex -9.73405 52 -47.9931
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.78029 52 -50.168
+      vertex -9.73405 52 -47.9931
+      vertex -9.6254 52 -48.3151
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.78029 52 -50.168
+      vertex -8.35628 52 -49.519
+      vertex -8.13972 52 -49.677
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.78029 52 -50.168
+      vertex -8.13972 52 -49.677
+      vertex -7.97406 52 -49.803
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.78029 52 -50.168
+      vertex -7.97406 52 -49.803
+      vertex -7.85928 52 -49.897
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.63428 52 -50.168
+      vertex -7.85928 52 -49.897
+      vertex -7.77472 52 -49.9787
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.63428 52 -50.168
+      vertex -7.77472 52 -49.9787
+      vertex -7.69972 52 -50.069
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -8.35628 52 -49.519
+      vertex -9.78029 52 -50.168
+      vertex -8.74228 52 -49.241
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.85928 52 -49.897
+      vertex -7.63428 52 -50.168
+      vertex -9.78029 52 -50.168
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -8.74228 52 -49.241
+      vertex -9.78029 52 -50.168
+      vertex -9.03761 52 -49.0153
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.78029 52 -50.168
+      vertex -9.27162 52 -48.805
+      vertex -9.03761 52 -49.0153
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.78029 52 -50.168
+      vertex -9.44427 52 -48.61
+      vertex -9.27162 52 -48.805
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.78029 52 -50.168
+      vertex -9.6254 52 -48.3151
+      vertex -9.44427 52 -48.61
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.73405 52 -47.9931
+      vertex -9.78029 52 -50.168
+      vertex -11.1397 52 -53
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1397 52 -53
+      vertex -9.78029 52 -50.168
+      vertex -9.78029 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1397 52 -53
+      vertex 1.70609 52 -51.0637
+      vertex 2.36452 52 -51.128
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.1397 52 -53
+      vertex 2.36452 52 -51.128
+      vertex 11.2 52 -53
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -9.77028 52 -47.644
+      vertex -11.1397 52 -53
+      vertex -11.1397 52 -44
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.41328 52 -51
+      vertex -11.1397 52 -53
+      vertex -9.78029 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6.49101 52 -46.008
+      vertex 11.2 52 -44
+      vertex 8.444 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -46.008
+      vertex 11.2 52 -44
+      vertex 6.49101 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.2 52 -44
+      vertex 5.453 52 -46.008
+      vertex 3.02242 52 -45.9443
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -46.008
+      vertex 3.56808 52 -46.1373
+      vertex 3.02242 52 -45.9443
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -46.008
+      vertex 4.00153 52 -46.459
+      vertex 3.56808 52 -46.1373
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -46.008
+      vertex 4.42375 52 -46.9898
+      vertex 4.00153 52 -46.459
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -46.008
+      vertex 4.67708 52 -47.6714
+      vertex 4.42375 52 -46.9898
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -46.008
+      vertex 4.76152 52 -48.504
+      vertex 4.67708 52 -47.6714
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.453 52 -51
+      vertex 4.76152 52 -48.504
+      vertex 5.453 52 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 4.76152 52 -48.504
+      vertex 5.453 52 -51
+      vertex 4.67708 52 -49.325
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -51
+      vertex 4.42375 52 -50.0067
+      vertex 4.67708 52 -49.325
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -51
+      vertex 4.00153 52 -50.549
+      vertex 4.42375 52 -50.0067
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.453 52 -51
+      vertex 3.56808 52 -50.8707
+      vertex 4.00153 52 -50.549
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.56808 52 -50.8707
+      vertex 5.453 52 -51
+      vertex 3.02242 52 -51.0637
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.46228 52 -47.3658
+      vertex -8.11528 52 -46.904
+      vertex -7.85262 52 -46.9391
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -8.76405 52 -47.4245
+      vertex -8.11528 52 -46.904
+      vertex -7.46228 52 -47.3658
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.51527 52 -47.22
+      vertex -7.85262 52 -46.9391
+      vertex -7.65262 52 -47.0444
+    endloop
+  endfacet
+  facet normal -0 1 0
+    outer loop
+      vertex -8.70639 52 -47.2548
+      vertex -8.11528 52 -46.904
+      vertex -8.76405 52 -47.4245
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.85262 52 -46.9391
+      vertex -7.51527 52 -47.22
+      vertex -7.46228 52 -47.3658
+    endloop
+  endfacet
+  facet normal -0 1 0
+    outer loop
+      vertex -8.61028 52 -47.108
+      vertex -8.31339 52 -46.9267
+      vertex -8.70639 52 -47.2548
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -8.31339 52 -46.9267
+      vertex -8.61028 52 -47.108
+      vertex -8.47839 52 -46.9947
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -8.11528 52 -46.904
+      vertex -8.70639 52 -47.2548
+      vertex -8.31339 52 -46.9267
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.42595 52 -47.5591
+      vertex -8.76405 52 -47.4245
+      vertex -7.46228 52 -47.3658
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.42595 52 -47.5591
+      vertex -8.78328 52 -47.617
+      vertex -8.76405 52 -47.4245
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -8.74973 52 -47.8617
+      vertex -7.42595 52 -47.5591
+      vertex -7.40628 52 -47.8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -7.42595 52 -47.5591
+      vertex -8.74973 52 -47.8617
+      vertex -8.78328 52 -47.617
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.86249 52 -49.592
+      vertex -6.1095 52 -49.976
+      vertex -6.84084 52 -49.7091
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.1095 52 -49.976
+      vertex -6.64027 52 -50.042
+      vertex -6.84084 52 -49.7091
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.1095 52 -49.976
+      vertex -6.52039 52 -50.3409
+      vertex -6.64027 52 -50.042
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.1095 52 -49.976
+      vertex -6.44473 52 -50.6602
+      vertex -6.52039 52 -50.3409
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -6.1095 52 -51
+      vertex -6.44473 52 -50.6602
+      vertex -6.1095 52 -49.976
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -6.44473 52 -50.6602
+      vertex -6.1095 52 -51
+      vertex -6.41328 52 -51
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 8.444 52 -51
+      vertex 6.49101 52 -48.824
+      vertex 8.444 52 -48.824
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 6.49101 52 -48.824
+      vertex 8.444 52 -51
+      vertex 6.49101 52 -51
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18 35.5 -44
+      vertex 16.0591 32.8355 -44
+      vertex 18 30.6799 -44
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 16.0591 32.8355 -44
+      vertex 18 35.5 -44
+      vertex 12.3917 35.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.1397 52 -44
+      vertex 10.25 51 -44
+      vertex 11.2 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.25 51 -44
+      vertex -11.1397 52 -44
+      vertex -10.25 51 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18 40.1177 -44
+      vertex -10.25 51 -44
+      vertex -11.1397 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.25 51 -44
+      vertex -18 40.1177 -44
+      vertex -10.25 36.5638 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10.25 36.5638 -44
+      vertex -18 40.1177 -44
+      vertex -12 35.7846 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 35.7846 -44
+      vertex -18 40.1177 -44
+      vertex -16.0591 32.8355 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0591 32.8355 -44
+      vertex -18 40.1177 -44
+      vertex -18 30.6799 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.2 52 -44
+      vertex 12.25 44 -44
+      vertex 17.8395 40.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.25 51 -44
+      vertex 12.25 44 -44
+      vertex 11.2 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.25 44 -44
+      vertex 10.25 51 -44
+      vertex 10.25 44 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 12.25 41 -44
+      vertex 17.8395 40.5 -44
+      vertex 12.25 44 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.25 41 -44
+      vertex 10.5 40.5 -44
+      vertex 17.8395 40.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10.25 41 -44
+      vertex 10.5 40.5 -44
+      vertex 12.25 41 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.25 36.5638 -44
+      vertex 10.5 40.5 -44
+      vertex 10.25 41 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 40.5 -44
+      vertex 10.25 36.5638 -44
+      vertex 10.5 36.4525 -44
     endloop
   endfacet
   facet normal 0 -1 0
@@ -2512,18 +2505,18 @@ solid OpenSCAD_Model
       vertex 17.8 11 -47.3502
     endloop
   endfacet
-  facet normal -0.406737 -0.913545 0
+  facet normal -0.994523 -0.104515 -0
     outer loop
-      vertex -20.8 11.8038 -53
-      vertex -19.6541 11.2937 -47.2984
-      vertex -20.8 11.8038 -47.2085
+      vertex -23.6689 15.7525 -46.5122
+      vertex -23.8 17 -53
+      vertex -23.6689 15.7525 -53
     endloop
   endfacet
-  facet normal -0.406737 -0.913545 -0
+  facet normal -0.994523 -0.104515 0
     outer loop
-      vertex -19.6541 11.2937 -47.2984
-      vertex -20.8 11.8038 -53
-      vertex -19.6541 11.2937 -53
+      vertex -23.8 17 -53
+      vertex -23.6689 15.7525 -46.5122
+      vertex -23.8 17 -46.2923
     endloop
   endfacet
   facet normal 0 -1 0
@@ -2540,84 +2533,84 @@ solid OpenSCAD_Model
       vertex -17.8 11.0329 -53
     endloop
   endfacet
-  facet normal -0.994522 -0.104529 -0
+  facet normal -0.406678 -0.913571 0
     outer loop
-      vertex -23.6689 15.7525 -46.5122
-      vertex -23.8 17 -53
-      vertex -23.6689 15.7525 -53
+      vertex -20.8 11.8038 -53
+      vertex -19.6541 11.2937 -47.2984
+      vertex -20.8 11.8038 -47.2085
     endloop
   endfacet
-  facet normal -0.994522 -0.104529 0
+  facet normal -0.406678 -0.913571 -0
     outer loop
-      vertex -23.8 17 -53
-      vertex -23.6689 15.7525 -46.5122
-      vertex -23.8 17 -46.2923
+      vertex -19.6541 11.2937 -47.2984
+      vertex -20.8 11.8038 -53
+      vertex -19.6541 11.2937 -53
     endloop
   endfacet
-  facet normal -0.866025 -0.500001 -0
+  facet normal -0.866017 -0.500015 -0
     outer loop
       vertex -22.6541 13.4733 -46.9141
       vertex -23.2813 14.5596 -53
       vertex -22.6541 13.4733 -53
     endloop
   endfacet
-  facet normal -0.866025 -0.500001 0
+  facet normal -0.866017 -0.500015 0
     outer loop
       vertex -23.2813 14.5596 -53
       vertex -22.6541 13.4733 -46.9141
       vertex -23.2813 14.5596 -46.7226
     endloop
   endfacet
-  facet normal -0.951057 -0.309016 -0
-    outer loop
-      vertex -23.2813 14.5596 -46.7226
-      vertex -23.6689 15.7525 -53
-      vertex -23.2813 14.5596 -53
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309016 0
-    outer loop
-      vertex -23.6689 15.7525 -53
-      vertex -23.2813 14.5596 -46.7226
-      vertex -23.6689 15.7525 -46.5122
-    endloop
-  endfacet
-  facet normal -0.207911 -0.978148 0
+  facet normal -0.207923 -0.978145 0
     outer loop
       vertex -19.6541 11.2937 -53
       vertex -18.4272 11.0329 -47.3444
       vertex -19.6541 11.2937 -47.2984
     endloop
   endfacet
-  facet normal -0.207911 -0.978148 -0
+  facet normal -0.207923 -0.978145 -0
     outer loop
       vertex -18.4272 11.0329 -47.3444
       vertex -19.6541 11.2937 -53
       vertex -18.4272 11.0329 -53
     endloop
   endfacet
-  facet normal -0.587785 -0.809017 0
+  facet normal -0.951056 -0.309019 -0
+    outer loop
+      vertex -23.2813 14.5596 -46.7226
+      vertex -23.6689 15.7525 -53
+      vertex -23.2813 14.5596 -53
+    endloop
+  endfacet
+  facet normal -0.951056 -0.309019 0
+    outer loop
+      vertex -23.6689 15.7525 -53
+      vertex -23.2813 14.5596 -46.7226
+      vertex -23.6689 15.7525 -46.5122
+    endloop
+  endfacet
+  facet normal -0.587788 -0.809015 0
     outer loop
       vertex -21.8148 12.5411 -53
       vertex -20.8 11.8038 -47.2085
       vertex -21.8148 12.5411 -47.0785
     endloop
   endfacet
-  facet normal -0.587785 -0.809017 -0
+  facet normal -0.587788 -0.809015 -0
     outer loop
       vertex -20.8 11.8038 -47.2085
       vertex -21.8148 12.5411 -53
       vertex -20.8 11.8038 -53
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 -0
+  facet normal -0.743167 -0.669106 -0
     outer loop
       vertex -21.8148 12.5411 -47.0785
       vertex -22.6541 13.4733 -53
       vertex -21.8148 12.5411 -53
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 0
+  facet normal -0.743167 -0.669106 0
     outer loop
       vertex -22.6541 13.4733 -53
       vertex -21.8148 12.5411 -47.0785
@@ -2638,60 +2631,46 @@ solid OpenSCAD_Model
       vertex -17.8 11.0329 -47.3444
     endloop
   endfacet
-  facet normal 0.994522 -0.104526 1.93806e-007
+  facet normal 0.994519 -0.104552 -1.40517e-05
     outer loop
       vertex 23.6689 15.7525 -46.5122
       vertex 23.7781 16.7921 -53
       vertex 23.7066 16.1111 -46.449
     endloop
   endfacet
-  facet normal 0.994522 -0.104527 0
+  facet normal 0.994528 -0.104466 0
     outer loop
       vertex 23.7781 16.7921 -53
       vertex 23.6689 15.7525 -46.5122
       vertex 23.6689 15.7525 -53
     endloop
   endfacet
-  facet normal 0.866026 -0.5 0
+  facet normal 0.951056 -0.309019 0
     outer loop
-      vertex 22.6541 13.4733 -46.9141
-      vertex 23.2813 14.5596 -53
       vertex 23.2813 14.5596 -46.7226
+      vertex 23.6689 15.7525 -53
+      vertex 23.6689 15.7525 -46.5122
     endloop
   endfacet
-  facet normal 0.866026 -0.5 0
+  facet normal 0.951056 -0.309019 0
     outer loop
+      vertex 23.6689 15.7525 -53
+      vertex 23.2813 14.5596 -46.7226
       vertex 23.2813 14.5596 -53
-      vertex 22.6541 13.4733 -46.9141
-      vertex 22.6541 13.4733 -53
     endloop
   endfacet
-  facet normal 0.587785 -0.809017 0
+  facet normal 0.994525 -0.104498 0
     outer loop
-      vertex 21.8148 12.5411 -53
-      vertex 20.8 11.8038 -47.2085
-      vertex 20.8 11.8038 -53
+      vertex 23.7066 16.1111 -46.449
+      vertex 23.8 17 -53
+      vertex 23.8 17 -46.2923
     endloop
   endfacet
-  facet normal 0.587785 -0.809017 0
+  facet normal 0.994498 -0.104759 -3.58163e-05
     outer loop
-      vertex 20.8 11.8038 -47.2085
-      vertex 21.8148 12.5411 -53
-      vertex 21.8148 12.5411 -47.0785
-    endloop
-  endfacet
-  facet normal 0.743144 -0.669131 0
-    outer loop
-      vertex 21.8148 12.5411 -47.0785
-      vertex 22.6541 13.4733 -53
-      vertex 22.6541 13.4733 -46.9141
-    endloop
-  endfacet
-  facet normal 0.743144 -0.669131 0
-    outer loop
-      vertex 22.6541 13.4733 -53
-      vertex 21.8148 12.5411 -47.0785
-      vertex 21.8148 12.5411 -53
+      vertex 23.8 17 -53
+      vertex 23.7066 16.1111 -46.449
+      vertex 23.7781 16.7921 -53
     endloop
   endfacet
   facet normal 0 -1 0
@@ -2708,56 +2687,70 @@ solid OpenSCAD_Model
       vertex 18.4272 11.0329 -53
     endloop
   endfacet
-  facet normal 0.406737 -0.913545 0
+  facet normal 0.866017 -0.500015 0
+    outer loop
+      vertex 22.6541 13.4733 -46.9141
+      vertex 23.2813 14.5596 -53
+      vertex 23.2813 14.5596 -46.7226
+    endloop
+  endfacet
+  facet normal 0.866017 -0.500015 0
+    outer loop
+      vertex 23.2813 14.5596 -53
+      vertex 22.6541 13.4733 -46.9141
+      vertex 22.6541 13.4733 -53
+    endloop
+  endfacet
+  facet normal 0.406678 -0.913571 0
     outer loop
       vertex 20.8 11.8038 -53
       vertex 19.6541 11.2937 -47.2984
       vertex 19.6541 11.2937 -53
     endloop
   endfacet
-  facet normal 0.406737 -0.913545 0
+  facet normal 0.406678 -0.913571 0
     outer loop
       vertex 19.6541 11.2937 -47.2984
       vertex 20.8 11.8038 -53
       vertex 20.8 11.8038 -47.2085
     endloop
   endfacet
-  facet normal 0.994522 -0.104529 0
+  facet normal 0.743167 -0.669106 0
     outer loop
-      vertex 23.7066 16.1111 -46.449
-      vertex 23.8 17 -53
-      vertex 23.8 17 -46.2923
+      vertex 21.8148 12.5411 -47.0785
+      vertex 22.6541 13.4733 -53
+      vertex 22.6541 13.4733 -46.9141
     endloop
   endfacet
-  facet normal 0.994521 -0.104532 -4.80504e-007
+  facet normal 0.743167 -0.669106 0
     outer loop
-      vertex 23.8 17 -53
-      vertex 23.7066 16.1111 -46.449
-      vertex 23.7781 16.7921 -53
+      vertex 22.6541 13.4733 -53
+      vertex 21.8148 12.5411 -47.0785
+      vertex 21.8148 12.5411 -53
     endloop
   endfacet
-  facet normal 0.951056 -0.309017 0
+  facet normal 0.587788 -0.809015 0
     outer loop
-      vertex 23.2813 14.5596 -46.7226
-      vertex 23.6689 15.7525 -53
-      vertex 23.6689 15.7525 -46.5122
+      vertex 21.8148 12.5411 -53
+      vertex 20.8 11.8038 -47.2085
+      vertex 20.8 11.8038 -53
     endloop
   endfacet
-  facet normal 0.951056 -0.309017 0
+  facet normal 0.587788 -0.809015 0
     outer loop
-      vertex 23.6689 15.7525 -53
-      vertex 23.2813 14.5596 -46.7226
-      vertex 23.2813 14.5596 -53
+      vertex 20.8 11.8038 -47.2085
+      vertex 21.8148 12.5411 -53
+      vertex 21.8148 12.5411 -47.0785
     endloop
   endfacet
-  facet normal 0.207911 -0.978148 0
+  facet normal 0.207923 -0.978145 0
     outer loop
       vertex 19.6541 11.2937 -53
       vertex 18.4272 11.0329 -47.3444
       vertex 18.4272 11.0329 -53
     endloop
   endfacet
-  facet normal 0.207911 -0.978148 0
+  facet normal 0.207923 -0.978145 0
     outer loop
       vertex 18.4272 11.0329 -47.3444
       vertex 19.6541 11.2937 -53
@@ -2780,523 +2773,523 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 0
     outer loop
+      vertex 5.39024 30 -44
+      vertex -5.39024 30 -44
+      vertex -9.07974 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 11.1204 30 -44
+      vertex 12.365 30 -44
+      vertex 18.6122 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 9.07974 30 -44
+      vertex 5.39024 30 -44
+      vertex -9.07974 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 12.608 30 -44
+      vertex 9.07974 30 -44
+      vertex -9.07974 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -18.6122 30 -44
       vertex -12.6355 30 -44
+      vertex -11.3909 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 18.6122 30 -44
+      vertex 16.0591 30 -44
+      vertex 12.608 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -9.07974 30 -44
+      vertex -12.608 30 -44
+      vertex -16.0591 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -9.07974 30 -44
+      vertex -16.0591 30 -44
+      vertex -18.6122 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -18.6122 30 -44
       vertex -11.3909 30 -44
       vertex 11.1204 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
-      vertex -18.6122 30 -44
-      vertex -12.6355 30 -44
-      vertex 11.1204 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex 16.0591 30 -44
+      vertex 18.6122 30 -44
       vertex 12.608 30 -44
-      vertex 9.07974 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex 16.0591 30 -44
-      vertex 9.07974 30 -44
-      vertex 5.39024 30 -44
+      vertex -9.07974 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
       vertex 18.6122 30 -44
-      vertex 16.0591 30 -44
-      vertex 5.39024 30 -44
+      vertex -9.07974 30 -44
+      vertex -18.6122 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
       vertex -18.6122 30 -44
       vertex 11.1204 30 -44
-      vertex 12.365 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex 18.6122 30 -44
-      vertex 5.39024 30 -44
-      vertex -5.39024 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex -18.6122 30 -44
-      vertex 12.365 30 -44
       vertex 18.6122 30 -44
     endloop
   endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex -18.6122 30 -44
-      vertex 18.6122 30 -44
-      vertex -5.39024 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex -18.6122 30 -44
-      vertex -5.39024 30 -44
-      vertex -9.07974 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex -18.6122 30 -44
-      vertex -9.07974 30 -44
-      vertex -12.608 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex -18.6122 30 -44
-      vertex -12.608 30 -44
-      vertex -16.0591 30 -44
-    endloop
-  endfacet
-  facet normal 7.5739e-007 -0.173648 0.984808
+  facet normal 5.89577e-06 -0.173638 0.98481
     outer loop
       vertex -11.3262 23.229 -45.1939
       vertex -19.4164 29.1068 -44.1575
       vertex -12.7896 20.6943 -45.6408
     endloop
   endfacet
-  facet normal -8.08563e-008 -0.173648 0.984808
+  facet normal -1.12629e-05 -0.173651 0.984807
     outer loop
       vertex -21.9251 24.7617 -44.9237
       vertex -12.7896 20.6943 -45.6408
       vertex -19.4164 29.1068 -44.1575
     endloop
   endfacet
-  facet normal 0 -0.173651 0.984807
+  facet normal 0 -0.17365 0.984807
     outer loop
       vertex -13.6941 17.9108 -46.1317
       vertex -13.8 17 -46.2923
       vertex -13.7898 17 -46.2923
     endloop
   endfacet
-  facet normal -2.57575e-007 -0.173647 0.984808
+  facet normal -3.60176e-06 -0.173637 0.98481
     outer loop
       vertex -21.8148 12.5411 -47.0785
       vertex -13.8 15.4505 -46.5655
       vertex -13.8 17 -46.2923
     endloop
   endfacet
-  facet normal -2.65171e-008 -0.173648 0.984808
+  facet normal -2.53809e-07 -0.173649 0.984808
     outer loop
       vertex -23.4755 19.9899 -45.7651
       vertex -13.6941 17.9108 -46.1317
       vertex -21.9251 24.7617 -44.9237
     endloop
   endfacet
-  facet normal -7.00806e-007 -0.173651 0.984807
+  facet normal -4.50921e-07 -0.17365 0.984808
     outer loop
       vertex -13.6941 17.9108 -46.1317
       vertex -23.4755 19.9899 -45.7651
       vertex -13.8 17 -46.2923
     endloop
   endfacet
-  facet normal 0 -0.173649 0.984808
+  facet normal 0 -0.173648 0.984808
     outer loop
       vertex -23.7898 17 -46.2923
       vertex -13.8 17 -46.2923
       vertex -23.4755 19.9899 -45.7651
     endloop
   endfacet
-  facet normal 0 -0.173636 0.98481
+  facet normal 0 -0.173168 0.984892
     outer loop
       vertex -18.6122 30 -44
       vertex -12.7114 29.9363 -44.0112
       vertex -12.6355 30 -44
     endloop
   endfacet
-  facet normal -1.24281e-007 -0.173647 0.984808
+  facet normal -5.34982e-06 -0.173649 0.984808
     outer loop
       vertex -19.4164 29.1068 -44.1575
       vertex -12.7114 29.9363 -44.0112
       vertex -18.6122 30 -44
     endloop
   endfacet
-  facet normal 1.69316e-009 -0.173648 0.984808
+  facet normal -2.1613e-05 -0.173674 0.984803
     outer loop
       vertex -12.7896 20.6943 -45.6408
       vertex -21.9251 24.7617 -44.9237
       vertex -13.6941 17.9108 -46.1317
     endloop
   endfacet
-  facet normal -4.35895e-007 -0.173648 0.984808
+  facet normal -3.45046e-07 -0.173639 0.984809
     outer loop
       vertex -13.8 15.4505 -46.5655
       vertex -17.8 11.0329 -47.3444
       vertex -15.4199 11 -47.3502
     endloop
   endfacet
-  facet normal 0 -0.173648 0.984808
+  facet normal 0 -0.173596 0.984817
     outer loop
       vertex -23.6689 15.7525 -46.5122
       vertex -13.8 17 -46.2923
       vertex -23.7898 17 -46.2923
     endloop
   endfacet
-  facet normal -8.03804e-007 -0.173647 0.984808
+  facet normal -1.9821e-05 -0.173608 0.984815
     outer loop
       vertex -13.8 15.4505 -46.5655
       vertex -20.8 11.8038 -47.2085
       vertex -19.6541 11.2937 -47.2984
     endloop
   endfacet
-  facet normal 0 -0.173654 0.984807
+  facet normal 0 -0.173699 0.984799
     outer loop
       vertex -17.8 11.0329 -47.3444
       vertex -19.6541 11.2937 -47.2984
       vertex -18.4272 11.0329 -47.3444
     endloop
   endfacet
-  facet normal 6.97195e-007 -0.173649 0.984808
+  facet normal 7.73012e-06 -0.173646 0.984808
     outer loop
       vertex -13.8 15.4505 -46.5655
       vertex -19.6541 11.2937 -47.2984
       vertex -17.8 11.0329 -47.3444
     endloop
   endfacet
-  facet normal 6.6182e-007 -0.17365 0.984807
+  facet normal -1.43358e-06 -0.173642 0.984809
     outer loop
       vertex -13.8 15.4505 -46.5655
       vertex -21.8148 12.5411 -47.0785
       vertex -20.8 11.8038 -47.2085
     endloop
   endfacet
-  facet normal -1.47907e-008 -0.173648 0.984808
+  facet normal 1.29554e-05 -0.173666 0.984805
     outer loop
       vertex -13.8 17 -46.2923
       vertex -22.6541 13.4733 -46.9141
       vertex -21.8148 12.5411 -47.0785
     endloop
   endfacet
-  facet normal 4.28717e-007 -0.173649 0.984808
+  facet normal -8.18225e-06 -0.173614 0.984814
     outer loop
       vertex -13.8 17 -46.2923
       vertex -23.2813 14.5596 -46.7226
       vertex -22.6541 13.4733 -46.9141
     endloop
   endfacet
-  facet normal -3.22383e-007 -0.173646 0.984808
+  facet normal 1.24778e-05 -0.173692 0.9848
     outer loop
       vertex -13.8 17 -46.2923
       vertex -23.6689 15.7525 -46.5122
       vertex -23.2813 14.5596 -46.7226
     endloop
   endfacet
-  facet normal 0.000129773 -0.173636 0.98481
+  facet normal 0 -0.173596 0.984817
     outer loop
       vertex -23.7898 17 -46.2923
       vertex -23.8 17 -46.2923
       vertex -23.6689 15.7525 -46.5122
     endloop
   endfacet
-  facet normal -0.000129773 -0.173637 0.98481
+  facet normal 0 -0.173608 0.984815
     outer loop
       vertex 23.7898 17 -46.2923
       vertex 23.7066 16.1111 -46.449
       vertex 23.8 17 -46.2923
     endloop
   endfacet
-  facet normal 0 -0.173648 0.984808
+  facet normal 0 -0.173608 0.984815
     outer loop
       vertex 13.8 17 -46.2923
       vertex 23.7066 16.1111 -46.449
       vertex 23.7898 17 -46.2923
     endloop
   endfacet
-  facet normal 0 -0.173649 0.984808
+  facet normal 0 -0.173648 0.984808
     outer loop
       vertex 13.8 17 -46.2923
       vertex 23.7898 17 -46.2923
       vertex 23.4755 19.9899 -45.7651
     endloop
   endfacet
-  facet normal 1.76371e-007 -0.173646 0.984808
+  facet normal -5.18975e-06 -0.173664 0.984805
     outer loop
       vertex 23.2813 14.5596 -46.7226
       vertex 23.7066 16.1111 -46.449
       vertex 13.8 17 -46.2923
     endloop
   endfacet
-  facet normal 1.22772e-005 -0.17365 0.984807
+  facet normal -0.000609203 -0.173504 0.984833
     outer loop
       vertex 23.7066 16.1111 -46.449
       vertex 23.2813 14.5596 -46.7226
       vertex 23.6689 15.7525 -46.5122
     endloop
   endfacet
-  facet normal 2.65171e-008 -0.173648 0.984808
+  facet normal 2.53809e-07 -0.173649 0.984808
     outer loop
       vertex 13.6941 17.9108 -46.1317
       vertex 23.4755 19.9899 -45.7651
       vertex 21.9251 24.7617 -44.9237
     endloop
   endfacet
-  facet normal 7.00806e-007 -0.173651 0.984807
+  facet normal 4.50921e-07 -0.17365 0.984808
     outer loop
       vertex 13.8 17 -46.2923
       vertex 23.4755 19.9899 -45.7651
       vertex 13.6941 17.9108 -46.1317
     endloop
   endfacet
-  facet normal -4.28718e-007 -0.173649 0.984808
+  facet normal 8.18225e-06 -0.173614 0.984814
     outer loop
       vertex 23.2813 14.5596 -46.7226
       vertex 13.8 17 -46.2923
       vertex 22.6541 13.4733 -46.9141
     endloop
   endfacet
-  facet normal -2.3802e-007 -0.173648 0.984808
+  facet normal 5.75336e-06 -0.17362 0.984813
     outer loop
       vertex 13.8 15.6069 -46.5379
       vertex 22.6541 13.4733 -46.9141
       vertex 13.8 17 -46.2923
     endloop
   endfacet
-  facet normal 8.08563e-008 -0.173648 0.984808
+  facet normal 1.12629e-05 -0.173651 0.984807
     outer loop
       vertex 12.7896 20.6943 -45.6408
       vertex 21.9251 24.7617 -44.9237
       vertex 19.4164 29.1068 -44.1575
     endloop
   endfacet
-  facet normal -8.37037e-008 -0.173647 0.984808
+  facet normal 4.28282e-06 -0.17365 0.984808
     outer loop
       vertex 11.9114 29.3363 -44.117
       vertex 19.4164 29.1068 -44.1575
       vertex 18.6122 30 -44
     endloop
   endfacet
-  facet normal -6.72691e-008 -0.173648 0.984808
+  facet normal -6.88268e-06 -0.173671 0.984804
     outer loop
       vertex 22.6541 13.4733 -46.9141
       vertex 13.8 15.6069 -46.5379
       vertex 21.8148 12.5411 -47.0785
     endloop
   endfacet
-  facet normal -8.16158e-007 -0.17365 0.984808
+  facet normal 3.31673e-06 -0.173645 0.984808
     outer loop
       vertex 21.8148 12.5411 -47.0785
       vertex 13.8 15.6069 -46.5379
       vertex 20.8 11.8038 -47.2085
     endloop
   endfacet
-  facet normal 0 -0.173617 0.984813
+  facet normal 0 -0.173615 0.984814
     outer loop
       vertex 17.8 11.0329 -47.3444
       vertex 15.4768 11 -47.3502
       vertex 17.8 11 -47.3502
     endloop
   endfacet
-  facet normal 7.10618e-007 -0.173647 0.984808
+  facet normal 2.16584e-05 -0.173612 0.984814
     outer loop
       vertex 20.8 11.8038 -47.2085
       vertex 13.8 15.6069 -46.5379
       vertex 19.6541 11.2937 -47.2984
     endloop
   endfacet
-  facet normal 0 -0.173648 0.984808
+  facet normal 0 -0.173644 0.984808
     outer loop
       vertex 18.4272 11.0329 -47.3444
       vertex 13.8 15.6069 -46.5379
       vertex 17.8 11.0329 -47.3444
     endloop
   endfacet
-  facet normal -1.04182e-006 -0.173649 0.984808
+  facet normal -9.93673e-06 -0.173654 0.984807
     outer loop
       vertex 19.6541 11.2937 -47.2984
       vertex 13.8 15.6069 -46.5379
       vertex 18.4272 11.0329 -47.3444
     endloop
   endfacet
-  facet normal 0 -0.173651 0.984807
+  facet normal 0 -0.17365 0.984807
     outer loop
       vertex 13.8 17 -46.2923
       vertex 13.6941 17.9108 -46.1317
       vertex 13.7898 17 -46.2923
     endloop
   endfacet
-  facet normal -1.69316e-009 -0.173648 0.984808
+  facet normal 2.1613e-05 -0.173674 0.984803
     outer loop
       vertex 21.9251 24.7617 -44.9237
       vertex 12.7896 20.6943 -45.6408
       vertex 13.6941 17.9108 -46.1317
     endloop
   endfacet
-  facet normal -8.35403e-008 -0.173647 0.984808
+  facet normal -4.70835e-06 -0.173561 0.984823
     outer loop
       vertex 11.9114 29.3363 -44.117
       vertex 18.6122 30 -44
       vertex 12.4256 29.9491 -44.009
     endloop
   endfacet
-  facet normal 0 -0.173657 0.984806
+  facet normal 0 -0.174116 0.984725
     outer loop
       vertex 12.4256 29.9491 -44.009
       vertex 18.6122 30 -44
       vertex 12.365 30 -44
     endloop
   endfacet
-  facet normal 4.41499e-007 -0.173648 0.984808
+  facet normal 4.25673e-07 -0.173644 0.984809
     outer loop
       vertex 17.8 11.0329 -47.3444
       vertex 13.8 15.6069 -46.5379
       vertex 15.4768 11 -47.3502
     endloop
   endfacet
-  facet normal -1.29118e-007 -0.173648 0.984808
+  facet normal 4.22248e-06 -0.173651 0.984807
     outer loop
       vertex 19.4164 29.1068 -44.1575
       vertex 11.9114 29.3363 -44.117
       vertex 11.3262 23.229 -45.1939
     endloop
   endfacet
-  facet normal -7.5739e-007 -0.173648 0.984808
+  facet normal -5.89577e-06 -0.173638 0.98481
     outer loop
       vertex 19.4164 29.1068 -44.1575
       vertex 11.3262 23.229 -45.1939
       vertex 12.7896 20.6943 -45.6408
     endloop
   endfacet
-  facet normal -2.74209e-007 -0.173648 0.984808
+  facet normal -2.67781e-05 -0.173639 0.984809
     outer loop
       vertex 9.36783 25.404 -44.8104
       vertex 11.9114 29.3363 -44.117
       vertex 11.1204 30 -44
     endloop
   endfacet
-  facet normal 2.69529e-007 -0.173648 0.984808
+  facet normal -8.0336e-06 -0.17365 0.984807
     outer loop
       vertex 11.9114 29.3363 -44.117
       vertex 9.36783 25.404 -44.8104
       vertex 11.3262 23.229 -45.1939
     endloop
   endfacet
-  facet normal 1.35366e-007 -0.173648 0.984808
+  facet normal -1.73866e-05 -0.173642 0.984809
     outer loop
       vertex 11.1204 30 -44
       vertex 7 27.1244 -44.5071
       vertex 9.36783 25.404 -44.8104
     endloop
   endfacet
-  facet normal -4.52324e-007 -0.173647 0.984808
+  facet normal 1.7529e-05 -0.173691 0.9848
     outer loop
       vertex 11.1204 30 -44
       vertex 4.32624 28.3148 -44.2971
       vertex 7 27.1244 -44.5071
     endloop
   endfacet
-  facet normal 2.92995e-007 -0.17365 0.984807
+  facet normal 4.02445e-06 -0.173638 0.98481
     outer loop
       vertex 11.1204 30 -44
       vertex 1.4634 28.9233 -44.1898
       vertex 4.32624 28.3148 -44.2971
     endloop
   endfacet
-  facet normal 0 -0.173648 0.984808
+  facet normal 0 -0.173603 0.984816
     outer loop
       vertex 11.1204 30 -44
       vertex -1.4634 28.9233 -44.1898
       vertex 1.4634 28.9233 -44.1898
     endloop
   endfacet
-  facet normal 0 -0.173648 0.984808
+  facet normal 0 -0.173603 0.984816
     outer loop
       vertex -11.3909 30 -44
       vertex -1.4634 28.9233 -44.1898
       vertex 11.1204 30 -44
     endloop
   endfacet
-  facet normal -2.87709e-007 -0.17365 0.984807
+  facet normal -3.95184e-06 -0.173638 0.98481
     outer loop
       vertex -11.3909 30 -44
       vertex -4.32624 28.3148 -44.2971
       vertex -1.4634 28.9233 -44.1898
     endloop
   endfacet
-  facet normal 4.41048e-007 -0.173647 0.984808
+  facet normal -1.7092e-05 -0.173691 0.9848
     outer loop
       vertex -11.3909 30 -44
       vertex -7 27.1244 -44.5071
       vertex -4.32624 28.3148 -44.2971
     endloop
   endfacet
-  facet normal -1.30981e-007 -0.173648 0.984808
+  facet normal 1.68232e-05 -0.173641 0.984809
     outer loop
       vertex -11.3909 30 -44
       vertex -9.36783 25.404 -44.8104
       vertex -7 27.1244 -44.5071
     endloop
   endfacet
-  facet normal 1.1174e-006 -0.173648 0.984808
+  facet normal -1.3043e-05 -0.173654 0.984807
     outer loop
       vertex -12.1971 29.3235 -44.1193
       vertex -9.36783 25.404 -44.8104
       vertex -11.3909 30 -44
     endloop
   endfacet
-  facet normal -1.0792e-007 -0.173649 0.984808
+  facet normal 1.01475e-06 -0.173644 0.984808
     outer loop
       vertex -9.36783 25.404 -44.8104
       vertex -12.1971 29.3235 -44.1193
       vertex -11.3262 23.229 -45.1939
     endloop
   endfacet
-  facet normal -2.29942e-008 -0.173648 0.984808
+  facet normal 3.54145e-06 -0.173718 0.984795
     outer loop
       vertex -19.4164 29.1068 -44.1575
       vertex -12.1971 29.3235 -44.1193
       vertex -12.7114 29.9363 -44.0112
     endloop
   endfacet
-  facet normal 7.64522e-009 -0.173649 0.984808
+  facet normal 1.24631e-06 -0.173644 0.984808
     outer loop
       vertex -12.1971 29.3235 -44.1193
       vertex -19.4164 29.1068 -44.1575
       vertex -11.3262 23.229 -45.1939
     endloop
   endfacet
-  facet normal 0 -0.173617 0.984813
+  facet normal 0 -0.173615 0.984814
     outer loop
       vertex -15.4199 11 -47.3502
       vertex -17.8 11.0329 -47.3444
       vertex -17.8 11 -47.3502
     endloop
   endfacet
-  facet normal -0.866025 0.5 0
+  facet normal -0.866024 0.500003 0
     outer loop
       vertex -18 40.1177 -53
       vertex -11.1397 52 -44
       vertex -11.1397 52 -53
     endloop
   endfacet
-  facet normal -0.866025 0.5 0
+  facet normal -0.866024 0.500003 0
     outer loop
       vertex -11.1397 52 -44
       vertex -18 40.1177 -53
       vertex -18 40.1177 -44
     endloop
   endfacet
-  facet normal 0.866025 0.5 0
+  facet normal 0.866026 0.499998 0
     outer loop
       vertex 17.8395 40.5 -44
       vertex 11.2 52 -53
       vertex 11.2 52 -44
     endloop
   endfacet
-  facet normal 0.866025 0.5 0
+  facet normal 0.866026 0.499998 0
     outer loop
       vertex 11.2 52 -53
       vertex 17.8395 40.5 -44
@@ -3870,18 +3863,32 @@ solid OpenSCAD_Model
       vertex 17.8395 40.5 -44
     endloop
   endfacet
-  facet normal -0.866023 0 -0.500004
+  facet normal -0.99451 0 -0.10464
     outer loop
-      vertex 16.0074 35.5 -39.8289
-      vertex 15.8349 38 -39.5302
-      vertex 16.0074 38 -39.8289
+      vertex 16.15 35.5 -40.5
+      vertex 16.1139 38 -40.1569
+      vertex 16.15 38 -40.5
     endloop
   endfacet
-  facet normal -0.866023 -0 -0.500004
+  facet normal -0.99451 -0 -0.10464
     outer loop
-      vertex 15.8349 38 -39.5302
-      vertex 16.0074 35.5 -39.8289
-      vertex 15.8349 35.5 -39.5302
+      vertex 16.1139 38 -40.1569
+      vertex 16.15 35.5 -40.5
+      vertex 16.1139 35.5 -40.1569
+    endloop
+  endfacet
+  facet normal 0.99451 0 -0.10464
+    outer loop
+      vertex 12.8861 35.5 -40.1569
+      vertex 12.85 38 -40.5
+      vertex 12.8861 38 -40.1569
+    endloop
+  endfacet
+  facet normal 0.99451 0 -0.10464
+    outer loop
+      vertex 12.85 38 -40.5
+      vertex 12.8861 35.5 -40.1569
+      vertex 12.85 35.5 -40.5
     endloop
   endfacet
   facet normal 0 0 -1
@@ -3898,342 +3905,6 @@ solid OpenSCAD_Model
       vertex 14.3275 38 -38.859
     endloop
   endfacet
-  facet normal 0.951057 0 -0.309017
-    outer loop
-      vertex 12.9926 35.5 -39.8289
-      vertex 12.8861 38 -40.1569
-      vertex 12.9926 38 -39.8289
-    endloop
-  endfacet
-  facet normal 0.951057 0 -0.309017
-    outer loop
-      vertex 12.8861 38 -40.1569
-      vertex 12.9926 35.5 -39.8289
-      vertex 12.8861 35.5 -40.1569
-    endloop
-  endfacet
-  facet normal -0.743145 0 -0.669131
-    outer loop
-      vertex 15.8349 35.5 -39.5302
-      vertex 15.6041 38 -39.2738
-      vertex 15.8349 38 -39.5302
-    endloop
-  endfacet
-  facet normal -0.743145 -0 -0.669131
-    outer loop
-      vertex 15.6041 38 -39.2738
-      vertex 15.8349 35.5 -39.5302
-      vertex 15.6041 35.5 -39.2738
-    endloop
-  endfacet
-  facet normal -0.207907 0 -0.978149
-    outer loop
-      vertex 14.6725 35.5 -38.859
-      vertex 15.0099 38 -38.9308
-      vertex 15.0099 35.5 -38.9308
-    endloop
-  endfacet
-  facet normal -0.207907 0 -0.978149
-    outer loop
-      vertex 15.0099 38 -38.9308
-      vertex 14.6725 35.5 -38.859
-      vertex 14.6725 38 -38.859
-    endloop
-  endfacet
-  facet normal 0.406735 0 -0.913546
-    outer loop
-      vertex 13.675 35.5 -39.0711
-      vertex 13.9901 38 -38.9308
-      vertex 13.9901 35.5 -38.9308
-    endloop
-  endfacet
-  facet normal 0.406735 0 -0.913546
-    outer loop
-      vertex 13.9901 38 -38.9308
-      vertex 13.675 35.5 -39.0711
-      vertex 13.675 38 -39.0711
-    endloop
-  endfacet
-  facet normal 0.866024 0 -0.500002
-    outer loop
-      vertex 13.1651 35.5 -39.5302
-      vertex 12.9926 38 -39.8289
-      vertex 13.1651 38 -39.5302
-    endloop
-  endfacet
-  facet normal 0.866024 0 -0.500002
-    outer loop
-      vertex 12.9926 38 -39.8289
-      vertex 13.1651 35.5 -39.5302
-      vertex 12.9926 35.5 -39.8289
-    endloop
-  endfacet
-  facet normal 0.58779 0 -0.809014
-    outer loop
-      vertex 13.3959 35.5 -39.2738
-      vertex 13.675 38 -39.0711
-      vertex 13.675 35.5 -39.0711
-    endloop
-  endfacet
-  facet normal 0.58779 0 -0.809014
-    outer loop
-      vertex 13.675 38 -39.0711
-      vertex 13.3959 35.5 -39.2738
-      vertex 13.3959 38 -39.2738
-    endloop
-  endfacet
-  facet normal -0.994522 0 0.104528
-    outer loop
-      vertex 16.1139 35.5 -40.8431
-      vertex 16.15 38 -40.5
-      vertex 16.1139 38 -40.8431
-    endloop
-  endfacet
-  facet normal -0.994522 0 0.104528
-    outer loop
-      vertex 16.15 38 -40.5
-      vertex 16.1139 35.5 -40.8431
-      vertex 16.15 35.5 -40.5
-    endloop
-  endfacet
-  facet normal -0.207907 0 0.978149
-    outer loop
-      vertex 14.6725 38 -42.141
-      vertex 15.0099 35.5 -42.0692
-      vertex 15.0099 38 -42.0692
-    endloop
-  endfacet
-  facet normal -0.207907 0 0.978149
-    outer loop
-      vertex 15.0099 35.5 -42.0692
-      vertex 14.6725 38 -42.141
-      vertex 14.6725 35.5 -42.141
-    endloop
-  endfacet
-  facet normal -0.951057 0 -0.309014
-    outer loop
-      vertex 16.1139 35.5 -40.1569
-      vertex 16.0074 38 -39.8289
-      vertex 16.1139 38 -40.1569
-    endloop
-  endfacet
-  facet normal -0.951057 -0 -0.309014
-    outer loop
-      vertex 16.0074 38 -39.8289
-      vertex 16.1139 35.5 -40.1569
-      vertex 16.0074 35.5 -39.8289
-    endloop
-  endfacet
-  facet normal -0.58779 0 -0.809014
-    outer loop
-      vertex 15.325 35.5 -39.0711
-      vertex 15.6041 38 -39.2738
-      vertex 15.6041 35.5 -39.2738
-    endloop
-  endfacet
-  facet normal -0.58779 0 -0.809014
-    outer loop
-      vertex 15.6041 38 -39.2738
-      vertex 15.325 35.5 -39.0711
-      vertex 15.325 38 -39.0711
-    endloop
-  endfacet
-  facet normal -0.406735 0 -0.913546
-    outer loop
-      vertex 15.0099 35.5 -38.9308
-      vertex 15.325 38 -39.0711
-      vertex 15.325 35.5 -39.0711
-    endloop
-  endfacet
-  facet normal -0.406735 0 -0.913546
-    outer loop
-      vertex 15.325 38 -39.0711
-      vertex 15.0099 35.5 -38.9308
-      vertex 15.0099 38 -38.9308
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104528
-    outer loop
-      vertex 12.8861 35.5 -40.1569
-      vertex 12.85 38 -40.5
-      vertex 12.8861 38 -40.1569
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104528
-    outer loop
-      vertex 12.85 38 -40.5
-      vertex 12.8861 35.5 -40.1569
-      vertex 12.85 35.5 -40.5
-    endloop
-  endfacet
-  facet normal 0.743145 0 -0.669131
-    outer loop
-      vertex 13.3959 35.5 -39.2738
-      vertex 13.1651 38 -39.5302
-      vertex 13.3959 38 -39.2738
-    endloop
-  endfacet
-  facet normal 0.743145 0 -0.669131
-    outer loop
-      vertex 13.1651 38 -39.5302
-      vertex 13.3959 35.5 -39.2738
-      vertex 13.1651 35.5 -39.5302
-    endloop
-  endfacet
-  facet normal 0.207907 0 -0.978149
-    outer loop
-      vertex 13.9901 35.5 -38.9308
-      vertex 14.3275 38 -38.859
-      vertex 14.3275 35.5 -38.859
-    endloop
-  endfacet
-  facet normal 0.207907 0 -0.978149
-    outer loop
-      vertex 14.3275 38 -38.859
-      vertex 13.9901 35.5 -38.9308
-      vertex 13.9901 38 -38.9308
-    endloop
-  endfacet
-  facet normal -0.994522 0 -0.104528
-    outer loop
-      vertex 16.15 35.5 -40.5
-      vertex 16.1139 38 -40.1569
-      vertex 16.15 38 -40.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0 -0.104528
-    outer loop
-      vertex 16.1139 38 -40.1569
-      vertex 16.15 35.5 -40.5
-      vertex 16.1139 35.5 -40.1569
-    endloop
-  endfacet
-  facet normal -0.951057 0 0.309014
-    outer loop
-      vertex 16.0074 35.5 -41.1711
-      vertex 16.1139 38 -40.8431
-      vertex 16.0074 38 -41.1711
-    endloop
-  endfacet
-  facet normal -0.951057 0 0.309014
-    outer loop
-      vertex 16.1139 38 -40.8431
-      vertex 16.0074 35.5 -41.1711
-      vertex 16.1139 35.5 -40.8431
-    endloop
-  endfacet
-  facet normal 0.58779 0 0.809014
-    outer loop
-      vertex 13.3959 38 -41.7262
-      vertex 13.675 35.5 -41.9289
-      vertex 13.675 38 -41.9289
-    endloop
-  endfacet
-  facet normal 0.58779 0 0.809014
-    outer loop
-      vertex 13.675 35.5 -41.9289
-      vertex 13.3959 38 -41.7262
-      vertex 13.3959 35.5 -41.7262
-    endloop
-  endfacet
-  facet normal 0.866024 -0 0.500002
-    outer loop
-      vertex 12.9926 35.5 -41.1711
-      vertex 13.1651 38 -41.4698
-      vertex 12.9926 38 -41.1711
-    endloop
-  endfacet
-  facet normal 0.866024 0 0.500002
-    outer loop
-      vertex 13.1651 38 -41.4698
-      vertex 12.9926 35.5 -41.1711
-      vertex 13.1651 35.5 -41.4698
-    endloop
-  endfacet
-  facet normal -0.58779 0 0.809014
-    outer loop
-      vertex 15.325 38 -41.9289
-      vertex 15.6041 35.5 -41.7262
-      vertex 15.6041 38 -41.7262
-    endloop
-  endfacet
-  facet normal -0.58779 0 0.809014
-    outer loop
-      vertex 15.6041 35.5 -41.7262
-      vertex 15.325 38 -41.9289
-      vertex 15.325 35.5 -41.9289
-    endloop
-  endfacet
-  facet normal -0.866023 0 0.500004
-    outer loop
-      vertex 15.8349 35.5 -41.4698
-      vertex 16.0074 38 -41.1711
-      vertex 15.8349 38 -41.4698
-    endloop
-  endfacet
-  facet normal -0.866023 0 0.500004
-    outer loop
-      vertex 16.0074 38 -41.1711
-      vertex 15.8349 35.5 -41.4698
-      vertex 16.0074 35.5 -41.1711
-    endloop
-  endfacet
-  facet normal 0.994522 -0 0.104528
-    outer loop
-      vertex 12.85 35.5 -40.5
-      vertex 12.8861 38 -40.8431
-      vertex 12.85 38 -40.5
-    endloop
-  endfacet
-  facet normal 0.994522 0 0.104528
-    outer loop
-      vertex 12.8861 38 -40.8431
-      vertex 12.85 35.5 -40.5
-      vertex 12.8861 35.5 -40.8431
-    endloop
-  endfacet
-  facet normal 0.743145 -0 0.669131
-    outer loop
-      vertex 13.1651 35.5 -41.4698
-      vertex 13.3959 38 -41.7262
-      vertex 13.1651 38 -41.4698
-    endloop
-  endfacet
-  facet normal 0.743145 0 0.669131
-    outer loop
-      vertex 13.3959 38 -41.7262
-      vertex 13.1651 35.5 -41.4698
-      vertex 13.3959 35.5 -41.7262
-    endloop
-  endfacet
-  facet normal -0.406735 0 0.913546
-    outer loop
-      vertex 15.0099 38 -42.0692
-      vertex 15.325 35.5 -41.9289
-      vertex 15.325 38 -41.9289
-    endloop
-  endfacet
-  facet normal -0.406735 0 0.913546
-    outer loop
-      vertex 15.325 35.5 -41.9289
-      vertex 15.0099 38 -42.0692
-      vertex 15.0099 35.5 -42.0692
-    endloop
-  endfacet
-  facet normal 0.406735 0 0.913546
-    outer loop
-      vertex 13.675 38 -41.9289
-      vertex 13.9901 35.5 -42.0692
-      vertex 13.9901 38 -42.0692
-    endloop
-  endfacet
-  facet normal 0.406735 0 0.913546
-    outer loop
-      vertex 13.9901 35.5 -42.0692
-      vertex 13.675 38 -41.9289
-      vertex 13.675 35.5 -41.9289
-    endloop
-  endfacet
   facet normal -0 0 1
     outer loop
       vertex 14.3275 38 -42.141
@@ -4248,158 +3919,396 @@ solid OpenSCAD_Model
       vertex 14.3275 35.5 -42.141
     endloop
   endfacet
-  facet normal 0.951057 -0 0.309017
+  facet normal -0.587637 0 -0.809125
+    outer loop
+      vertex 15.325 35.5 -39.0711
+      vertex 15.6041 38 -39.2738
+      vertex 15.6041 35.5 -39.2738
+    endloop
+  endfacet
+  facet normal -0.587637 0 -0.809125
+    outer loop
+      vertex 15.6041 38 -39.2738
+      vertex 15.325 35.5 -39.0711
+      vertex 15.325 38 -39.0711
+    endloop
+  endfacet
+  facet normal 0.587637 0 -0.809125
+    outer loop
+      vertex 13.3959 35.5 -39.2738
+      vertex 13.675 38 -39.0711
+      vertex 13.675 35.5 -39.0711
+    endloop
+  endfacet
+  facet normal 0.587637 0 -0.809125
+    outer loop
+      vertex 13.675 38 -39.0711
+      vertex 13.3959 35.5 -39.2738
+      vertex 13.3959 38 -39.2738
+    endloop
+  endfacet
+  facet normal 0.406757 0 -0.913536
+    outer loop
+      vertex 13.675 35.5 -39.0711
+      vertex 13.9901 38 -38.9308
+      vertex 13.9901 35.5 -38.9308
+    endloop
+  endfacet
+  facet normal 0.406757 0 -0.913536
+    outer loop
+      vertex 13.9901 38 -38.9308
+      vertex 13.675 35.5 -39.0711
+      vertex 13.675 38 -39.0711
+    endloop
+  endfacet
+  facet normal -0.865968 0 0.500099
+    outer loop
+      vertex 15.8349 35.5 -41.4698
+      vertex 16.0074 38 -41.1711
+      vertex 15.8349 38 -41.4698
+    endloop
+  endfacet
+  facet normal -0.865968 0 0.500099
+    outer loop
+      vertex 16.0074 38 -41.1711
+      vertex 15.8349 35.5 -41.4698
+      vertex 16.0074 35.5 -41.1711
+    endloop
+  endfacet
+  facet normal -0.865968 0 -0.500099
+    outer loop
+      vertex 16.0074 35.5 -39.8289
+      vertex 15.8349 38 -39.5302
+      vertex 16.0074 38 -39.8289
+    endloop
+  endfacet
+  facet normal -0.865968 -0 -0.500099
+    outer loop
+      vertex 15.8349 38 -39.5302
+      vertex 16.0074 35.5 -39.8289
+      vertex 15.8349 35.5 -39.5302
+    endloop
+  endfacet
+  facet normal -0.951119 0 -0.308824
+    outer loop
+      vertex 16.1139 35.5 -40.1569
+      vertex 16.0074 38 -39.8289
+      vertex 16.1139 38 -40.1569
+    endloop
+  endfacet
+  facet normal -0.951119 -0 -0.308824
+    outer loop
+      vertex 16.0074 38 -39.8289
+      vertex 16.1139 35.5 -40.1569
+      vertex 16.0074 35.5 -39.8289
+    endloop
+  endfacet
+  facet normal -0.743236 0 -0.669029
+    outer loop
+      vertex 15.8349 35.5 -39.5302
+      vertex 15.6041 38 -39.2738
+      vertex 15.8349 38 -39.5302
+    endloop
+  endfacet
+  facet normal -0.743236 -0 -0.669029
+    outer loop
+      vertex 15.6041 38 -39.2738
+      vertex 15.8349 35.5 -39.5302
+      vertex 15.6041 35.5 -39.2738
+    endloop
+  endfacet
+  facet normal -0.208143 0 -0.978098
+    outer loop
+      vertex 14.6725 35.5 -38.859
+      vertex 15.0099 38 -38.9308
+      vertex 15.0099 35.5 -38.9308
+    endloop
+  endfacet
+  facet normal -0.208143 0 -0.978098
+    outer loop
+      vertex 15.0099 38 -38.9308
+      vertex 14.6725 35.5 -38.859
+      vertex 14.6725 38 -38.859
+    endloop
+  endfacet
+  facet normal -0.406757 0 -0.913536
+    outer loop
+      vertex 15.0099 35.5 -38.9308
+      vertex 15.325 38 -39.0711
+      vertex 15.325 35.5 -39.0711
+    endloop
+  endfacet
+  facet normal -0.406757 0 -0.913536
+    outer loop
+      vertex 15.325 38 -39.0711
+      vertex 15.0099 35.5 -38.9308
+      vertex 15.0099 38 -38.9308
+    endloop
+  endfacet
+  facet normal 0.865968 0 -0.500099
+    outer loop
+      vertex 13.1651 35.5 -39.5302
+      vertex 12.9926 38 -39.8289
+      vertex 13.1651 38 -39.5302
+    endloop
+  endfacet
+  facet normal 0.865968 0 -0.500099
+    outer loop
+      vertex 12.9926 38 -39.8289
+      vertex 13.1651 35.5 -39.5302
+      vertex 12.9926 35.5 -39.8289
+    endloop
+  endfacet
+  facet normal 0.743236 0 -0.669029
+    outer loop
+      vertex 13.3959 35.5 -39.2738
+      vertex 13.1651 38 -39.5302
+      vertex 13.3959 38 -39.2738
+    endloop
+  endfacet
+  facet normal 0.743236 0 -0.669029
+    outer loop
+      vertex 13.1651 38 -39.5302
+      vertex 13.3959 35.5 -39.2738
+      vertex 13.1651 35.5 -39.5302
+    endloop
+  endfacet
+  facet normal 0.951119 0 -0.308824
+    outer loop
+      vertex 12.9926 35.5 -39.8289
+      vertex 12.8861 38 -40.1569
+      vertex 12.9926 38 -39.8289
+    endloop
+  endfacet
+  facet normal 0.951119 0 -0.308824
+    outer loop
+      vertex 12.8861 38 -40.1569
+      vertex 12.9926 35.5 -39.8289
+      vertex 12.8861 35.5 -40.1569
+    endloop
+  endfacet
+  facet normal 0.208143 0 -0.978098
+    outer loop
+      vertex 13.9901 35.5 -38.9308
+      vertex 14.3275 38 -38.859
+      vertex 14.3275 35.5 -38.859
+    endloop
+  endfacet
+  facet normal 0.208143 0 -0.978098
+    outer loop
+      vertex 14.3275 38 -38.859
+      vertex 13.9901 35.5 -38.9308
+      vertex 13.9901 38 -38.9308
+    endloop
+  endfacet
+  facet normal -0.99451 0 0.10464
+    outer loop
+      vertex 16.1139 35.5 -40.8431
+      vertex 16.15 38 -40.5
+      vertex 16.1139 38 -40.8431
+    endloop
+  endfacet
+  facet normal -0.99451 0 0.10464
+    outer loop
+      vertex 16.15 38 -40.5
+      vertex 16.1139 35.5 -40.8431
+      vertex 16.15 35.5 -40.5
+    endloop
+  endfacet
+  facet normal -0.951119 0 0.308824
+    outer loop
+      vertex 16.0074 35.5 -41.1711
+      vertex 16.1139 38 -40.8431
+      vertex 16.0074 38 -41.1711
+    endloop
+  endfacet
+  facet normal -0.951119 0 0.308824
+    outer loop
+      vertex 16.1139 38 -40.8431
+      vertex 16.0074 35.5 -41.1711
+      vertex 16.1139 35.5 -40.8431
+    endloop
+  endfacet
+  facet normal 0.865968 -0 0.500099
+    outer loop
+      vertex 12.9926 35.5 -41.1711
+      vertex 13.1651 38 -41.4698
+      vertex 12.9926 38 -41.1711
+    endloop
+  endfacet
+  facet normal 0.865968 0 0.500099
+    outer loop
+      vertex 13.1651 38 -41.4698
+      vertex 12.9926 35.5 -41.1711
+      vertex 13.1651 35.5 -41.4698
+    endloop
+  endfacet
+  facet normal 0.743236 -0 0.669029
+    outer loop
+      vertex 13.1651 35.5 -41.4698
+      vertex 13.3959 38 -41.7262
+      vertex 13.1651 38 -41.4698
+    endloop
+  endfacet
+  facet normal 0.743236 0 0.669029
+    outer loop
+      vertex 13.3959 38 -41.7262
+      vertex 13.1651 35.5 -41.4698
+      vertex 13.3959 35.5 -41.7262
+    endloop
+  endfacet
+  facet normal 0.99451 -0 0.10464
+    outer loop
+      vertex 12.85 35.5 -40.5
+      vertex 12.8861 38 -40.8431
+      vertex 12.85 38 -40.5
+    endloop
+  endfacet
+  facet normal 0.99451 0 0.10464
+    outer loop
+      vertex 12.8861 38 -40.8431
+      vertex 12.85 35.5 -40.5
+      vertex 12.8861 35.5 -40.8431
+    endloop
+  endfacet
+  facet normal -0.208143 0 0.978098
+    outer loop
+      vertex 14.6725 38 -42.141
+      vertex 15.0099 35.5 -42.0692
+      vertex 15.0099 38 -42.0692
+    endloop
+  endfacet
+  facet normal -0.208143 0 0.978098
+    outer loop
+      vertex 15.0099 35.5 -42.0692
+      vertex 14.6725 38 -42.141
+      vertex 14.6725 35.5 -42.141
+    endloop
+  endfacet
+  facet normal -0.587637 0 0.809125
+    outer loop
+      vertex 15.325 38 -41.9289
+      vertex 15.6041 35.5 -41.7262
+      vertex 15.6041 38 -41.7262
+    endloop
+  endfacet
+  facet normal -0.587637 0 0.809125
+    outer loop
+      vertex 15.6041 35.5 -41.7262
+      vertex 15.325 38 -41.9289
+      vertex 15.325 35.5 -41.9289
+    endloop
+  endfacet
+  facet normal 0.951119 -0 0.308824
     outer loop
       vertex 12.8861 35.5 -40.8431
       vertex 12.9926 38 -41.1711
       vertex 12.8861 38 -40.8431
     endloop
   endfacet
-  facet normal 0.951057 0 0.309017
+  facet normal 0.951119 0 0.308824
     outer loop
       vertex 12.9926 38 -41.1711
       vertex 12.8861 35.5 -40.8431
       vertex 12.9926 35.5 -41.1711
     endloop
   endfacet
-  facet normal -0.743145 0 0.669131
+  facet normal -0.406757 0 0.913536
+    outer loop
+      vertex 15.0099 38 -42.0692
+      vertex 15.325 35.5 -41.9289
+      vertex 15.325 38 -41.9289
+    endloop
+  endfacet
+  facet normal -0.406757 0 0.913536
+    outer loop
+      vertex 15.325 35.5 -41.9289
+      vertex 15.0099 38 -42.0692
+      vertex 15.0099 35.5 -42.0692
+    endloop
+  endfacet
+  facet normal -0.743236 0 0.669029
     outer loop
       vertex 15.6041 35.5 -41.7262
       vertex 15.8349 38 -41.4698
       vertex 15.6041 38 -41.7262
     endloop
   endfacet
-  facet normal -0.743145 0 0.669131
+  facet normal -0.743236 0 0.669029
     outer loop
       vertex 15.8349 38 -41.4698
       vertex 15.6041 35.5 -41.7262
       vertex 15.8349 35.5 -41.4698
     endloop
   endfacet
-  facet normal 0.207907 0 0.978149
+  facet normal 0.406757 0 0.913536
+    outer loop
+      vertex 13.675 38 -41.9289
+      vertex 13.9901 35.5 -42.0692
+      vertex 13.9901 38 -42.0692
+    endloop
+  endfacet
+  facet normal 0.406757 0 0.913536
+    outer loop
+      vertex 13.9901 35.5 -42.0692
+      vertex 13.675 38 -41.9289
+      vertex 13.675 35.5 -41.9289
+    endloop
+  endfacet
+  facet normal 0.587637 0 0.809125
+    outer loop
+      vertex 13.3959 38 -41.7262
+      vertex 13.675 35.5 -41.9289
+      vertex 13.675 38 -41.9289
+    endloop
+  endfacet
+  facet normal 0.587637 0 0.809125
+    outer loop
+      vertex 13.675 35.5 -41.9289
+      vertex 13.3959 38 -41.7262
+      vertex 13.3959 35.5 -41.7262
+    endloop
+  endfacet
+  facet normal 0.208143 0 0.978098
     outer loop
       vertex 13.9901 38 -42.0692
       vertex 14.3275 35.5 -42.141
       vertex 14.3275 38 -42.141
     endloop
   endfacet
-  facet normal 0.207907 0 0.978149
+  facet normal 0.208143 0 0.978098
     outer loop
       vertex 14.3275 35.5 -42.141
       vertex 13.9901 38 -42.0692
       vertex 13.9901 35.5 -42.0692
     endloop
   endfacet
-  facet normal 0.951056 0 -0.309018
+  facet normal -0.994528 0 -0.104468
     outer loop
-      vertex 11.668 38 -39.2391
-      vertex 11.4677 40.5 -39.8555
-      vertex 11.668 40.5 -39.2391
-    endloop
-  endfacet
-  facet normal 0.951056 0 -0.309018
-    outer loop
-      vertex 11.4677 40.5 -39.8555
-      vertex 11.668 38 -39.2391
-      vertex 11.4677 38 -39.8555
-    endloop
-  endfacet
-  facet normal -0.866027 0 -0.499998
-    outer loop
-      vertex 17.332 38 -39.2391
-      vertex 17.008 40.5 -38.6779
-      vertex 17.332 40.5 -39.2391
-    endloop
-  endfacet
-  facet normal -0.866027 -0 -0.499998
-    outer loop
-      vertex 17.008 40.5 -38.6779
-      vertex 17.332 38 -39.2391
-      vertex 17.008 38 -38.6779
-    endloop
-  endfacet
-  facet normal -0.951056 0 -0.309019
-    outer loop
-      vertex 17.5323 38 -39.8555
-      vertex 17.332 40.5 -39.2391
-      vertex 17.5323 40.5 -39.8555
-    endloop
-  endfacet
-  facet normal -0.951056 -0 -0.309019
-    outer loop
-      vertex 17.332 40.5 -39.2391
-      vertex 17.5323 38 -39.8555
-      vertex 17.332 38 -39.2391
-    endloop
-  endfacet
-  facet normal -0.406741 0 -0.913544
-    outer loop
-      vertex 15.458 38 -37.5517
-      vertex 16.05 40.5 -37.8153
-      vertex 16.05 38 -37.8153
-    endloop
-  endfacet
-  facet normal -0.406741 0 -0.913544
-    outer loop
-      vertex 16.05 40.5 -37.8153
-      vertex 15.458 38 -37.5517
-      vertex 15.458 40.5 -37.5517
-    endloop
-  endfacet
-  facet normal 0.207912 0 -0.978148
-    outer loop
-      vertex 13.542 38 -37.5517
-      vertex 14.176 40.5 -37.417
-      vertex 14.176 38 -37.417
-    endloop
-  endfacet
-  facet normal 0.207912 0 -0.978148
-    outer loop
-      vertex 14.176 40.5 -37.417
-      vertex 13.542 38 -37.5517
-      vertex 13.542 40.5 -37.5517
-    endloop
-  endfacet
-  facet normal 0.866026 0 -0.499999
-    outer loop
-      vertex 11.992 38 -38.6779
-      vertex 11.668 40.5 -39.2391
-      vertex 11.992 40.5 -38.6779
-    endloop
-  endfacet
-  facet normal 0.866026 0 -0.499999
-    outer loop
-      vertex 11.668 40.5 -39.2391
-      vertex 11.992 38 -38.6779
-      vertex 11.668 38 -39.2391
-    endloop
-  endfacet
-  facet normal -0.994522 0 0.104527
-    outer loop
-      vertex 17.5323 38 -41.1445
-      vertex 17.6 40.5 -40.5
-      vertex 17.5323 40.5 -41.1445
-    endloop
-  endfacet
-  facet normal -0.994522 0 0.104527
-    outer loop
-      vertex 17.6 40.5 -40.5
-      vertex 17.5323 38 -41.1445
       vertex 17.6 38 -40.5
+      vertex 17.5323 40.5 -39.8555
+      vertex 17.6 40.5 -40.5
     endloop
   endfacet
-  facet normal -0.743144 0 -0.669131
+  facet normal -0.994528 -0 -0.104468
     outer loop
-      vertex 17.008 38 -38.6779
-      vertex 16.5743 40.5 -38.1963
-      vertex 17.008 40.5 -38.6779
+      vertex 17.5323 40.5 -39.8555
+      vertex 17.6 38 -40.5
+      vertex 17.5323 38 -39.8555
     endloop
   endfacet
-  facet normal -0.743144 -0 -0.669131
+  facet normal 0.994528 0 -0.104468
     outer loop
-      vertex 16.5743 40.5 -38.1963
-      vertex 17.008 38 -38.6779
-      vertex 16.5743 38 -38.1963
+      vertex 11.4677 38 -39.8555
+      vertex 11.4 40.5 -40.5
+      vertex 11.4677 40.5 -39.8555
+    endloop
+  endfacet
+  facet normal 0.994528 0 -0.104468
+    outer loop
+      vertex 11.4 40.5 -40.5
+      vertex 11.4677 38 -39.8555
+      vertex 11.4 38 -40.5
     endloop
   endfacet
   facet normal 0 0 -1
@@ -4416,580 +4325,6 @@ solid OpenSCAD_Model
       vertex 14.176 40.5 -37.417
     endloop
   endfacet
-  facet normal -0.587783 0 -0.809019
-    outer loop
-      vertex 16.05 38 -37.8153
-      vertex 16.5743 40.5 -38.1963
-      vertex 16.5743 38 -38.1963
-    endloop
-  endfacet
-  facet normal -0.587783 0 -0.809019
-    outer loop
-      vertex 16.5743 40.5 -38.1963
-      vertex 16.05 38 -37.8153
-      vertex 16.05 40.5 -37.8153
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104528
-    outer loop
-      vertex 11.4677 38 -39.8555
-      vertex 11.4 40.5 -40.5
-      vertex 11.4677 40.5 -39.8555
-    endloop
-  endfacet
-  facet normal 0.994522 0 -0.104528
-    outer loop
-      vertex 11.4 40.5 -40.5
-      vertex 11.4677 38 -39.8555
-      vertex 11.4 38 -40.5
-    endloop
-  endfacet
-  facet normal 0.743144 0 -0.669131
-    outer loop
-      vertex 12.4257 38 -38.1963
-      vertex 11.992 40.5 -38.6779
-      vertex 12.4257 40.5 -38.1963
-    endloop
-  endfacet
-  facet normal 0.743144 0 -0.669131
-    outer loop
-      vertex 11.992 40.5 -38.6779
-      vertex 12.4257 38 -38.1963
-      vertex 11.992 38 -38.6779
-    endloop
-  endfacet
-  facet normal 0.406741 0 -0.913544
-    outer loop
-      vertex 12.95 38 -37.8153
-      vertex 13.542 40.5 -37.5517
-      vertex 13.542 38 -37.5517
-    endloop
-  endfacet
-  facet normal 0.406741 0 -0.913544
-    outer loop
-      vertex 13.542 40.5 -37.5517
-      vertex 12.95 38 -37.8153
-      vertex 12.95 40.5 -37.8153
-    endloop
-  endfacet
-  facet normal 0.587783 0 -0.809019
-    outer loop
-      vertex 12.4257 38 -38.1963
-      vertex 12.95 40.5 -37.8153
-      vertex 12.95 38 -37.8153
-    endloop
-  endfacet
-  facet normal 0.587783 0 -0.809019
-    outer loop
-      vertex 12.95 40.5 -37.8153
-      vertex 12.4257 38 -38.1963
-      vertex 12.4257 40.5 -38.1963
-    endloop
-  endfacet
-  facet normal -0.994522 0 -0.104527
-    outer loop
-      vertex 17.6 38 -40.5
-      vertex 17.5323 40.5 -39.8555
-      vertex 17.6 40.5 -40.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0 -0.104527
-    outer loop
-      vertex 17.5323 40.5 -39.8555
-      vertex 17.6 38 -40.5
-      vertex 17.5323 38 -39.8555
-    endloop
-  endfacet
-  facet normal -0.951056 0 0.309019
-    outer loop
-      vertex 17.332 38 -41.7609
-      vertex 17.5323 40.5 -41.1445
-      vertex 17.332 40.5 -41.7609
-    endloop
-  endfacet
-  facet normal -0.951056 0 0.309019
-    outer loop
-      vertex 17.5323 40.5 -41.1445
-      vertex 17.332 38 -41.7609
-      vertex 17.5323 38 -41.1445
-    endloop
-  endfacet
-  facet normal 0.587783 0 0.809019
-    outer loop
-      vertex 12.4257 40.5 -42.8037
-      vertex 12.95 38 -43.1847
-      vertex 12.95 40.5 -43.1847
-    endloop
-  endfacet
-  facet normal 0.587783 0 0.809019
-    outer loop
-      vertex 12.95 38 -43.1847
-      vertex 12.4257 40.5 -42.8037
-      vertex 12.4257 38 -42.8037
-    endloop
-  endfacet
-  facet normal 0.866026 -0 0.499999
-    outer loop
-      vertex 11.668 38 -41.7609
-      vertex 11.992 40.5 -42.3221
-      vertex 11.668 40.5 -41.7609
-    endloop
-  endfacet
-  facet normal 0.866026 0 0.499999
-    outer loop
-      vertex 11.992 40.5 -42.3221
-      vertex 11.668 38 -41.7609
-      vertex 11.992 38 -42.3221
-    endloop
-  endfacet
-  facet normal -0.207912 0 -0.978148
-    outer loop
-      vertex 14.824 38 -37.417
-      vertex 15.458 40.5 -37.5517
-      vertex 15.458 38 -37.5517
-    endloop
-  endfacet
-  facet normal -0.207912 0 -0.978148
-    outer loop
-      vertex 15.458 40.5 -37.5517
-      vertex 14.824 38 -37.417
-      vertex 14.824 40.5 -37.417
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 14.6725 38 -38.859
-      vertex 14.824 38 -37.417
-      vertex 15.458 38 -37.5517
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 14.824 38 -37.417
-      vertex 14.6725 38 -38.859
-      vertex 14.176 38 -37.417
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.0099 38 -38.9308
-      vertex 15.458 38 -37.5517
-      vertex 16.05 38 -37.8153
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 14.3275 38 -38.859
-      vertex 14.176 38 -37.417
-      vertex 14.6725 38 -38.859
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.325 38 -39.0711
-      vertex 16.05 38 -37.8153
-      vertex 16.5743 38 -38.1963
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 14.176 38 -37.417
-      vertex 14.3275 38 -38.859
-      vertex 13.542 38 -37.5517
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.6041 38 -39.2738
-      vertex 16.5743 38 -38.1963
-      vertex 17.008 38 -38.6779
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 13.9901 38 -38.9308
-      vertex 13.542 38 -37.5517
-      vertex 14.3275 38 -38.859
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 13.542 38 -37.5517
-      vertex 13.9901 38 -38.9308
-      vertex 12.95 38 -37.8153
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.458 38 -37.5517
-      vertex 15.0099 38 -38.9308
-      vertex 14.6725 38 -38.859
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.05 38 -37.8153
-      vertex 15.325 38 -39.0711
-      vertex 15.0099 38 -38.9308
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.8349 38 -39.5302
-      vertex 17.008 38 -38.6779
-      vertex 17.332 38 -39.2391
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.5743 38 -38.1963
-      vertex 15.6041 38 -39.2738
-      vertex 15.325 38 -39.0711
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.008 38 -38.6779
-      vertex 15.8349 38 -39.5302
-      vertex 15.6041 38 -39.2738
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.332 38 -39.2391
-      vertex 16.0074 38 -39.8289
-      vertex 15.8349 38 -39.5302
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.5323 38 -39.8555
-      vertex 16.0074 38 -39.8289
-      vertex 17.332 38 -39.2391
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.5323 38 -39.8555
-      vertex 16.1139 38 -40.1569
-      vertex 16.0074 38 -39.8289
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.6 38 -40.5
-      vertex 16.1139 38 -40.1569
-      vertex 17.5323 38 -39.8555
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.6 38 -40.5
-      vertex 16.15 38 -40.5
-      vertex 16.1139 38 -40.1569
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.6 38 -40.5
-      vertex 16.1139 38 -40.8431
-      vertex 16.15 38 -40.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 17.5323 38 -41.1445
-      vertex 16.1139 38 -40.8431
-      vertex 17.6 38 -40.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 17.5323 38 -41.1445
-      vertex 16.0074 38 -41.1711
-      vertex 16.1139 38 -40.8431
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 17.332 38 -41.7609
-      vertex 16.0074 38 -41.1711
-      vertex 17.5323 38 -41.1445
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 16.0074 38 -41.1711
-      vertex 17.332 38 -41.7609
-      vertex 15.8349 38 -41.4698
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 17.008 38 -42.3221
-      vertex 15.8349 38 -41.4698
-      vertex 17.332 38 -41.7609
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.8349 38 -41.4698
-      vertex 17.008 38 -42.3221
-      vertex 15.6041 38 -41.7262
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 16.5743 38 -42.8037
-      vertex 15.6041 38 -41.7262
-      vertex 17.008 38 -42.3221
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.6041 38 -41.7262
-      vertex 16.5743 38 -42.8037
-      vertex 15.325 38 -41.9289
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.325 38 -41.9289
-      vertex 16.05 38 -43.1847
-      vertex 15.0099 38 -42.0692
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 16.05 38 -43.1847
-      vertex 15.325 38 -41.9289
-      vertex 16.5743 38 -42.8037
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 13.675 38 -39.0711
-      vertex 12.95 38 -37.8153
-      vertex 13.9901 38 -38.9308
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.95 38 -37.8153
-      vertex 13.675 38 -39.0711
-      vertex 12.4257 38 -38.1963
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 13.3959 38 -39.2738
-      vertex 12.4257 38 -38.1963
-      vertex 13.675 38 -39.0711
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.4257 38 -38.1963
-      vertex 13.3959 38 -39.2738
-      vertex 11.992 38 -38.6779
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 13.1651 38 -39.5302
-      vertex 11.992 38 -38.6779
-      vertex 13.3959 38 -39.2738
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 11.992 38 -38.6779
-      vertex 13.1651 38 -39.5302
-      vertex 11.668 38 -39.2391
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 12.9926 38 -39.8289
-      vertex 11.668 38 -39.2391
-      vertex 13.1651 38 -39.5302
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.9926 38 -39.8289
-      vertex 11.4677 38 -39.8555
-      vertex 11.668 38 -39.2391
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 12.8861 38 -40.1569
-      vertex 11.4677 38 -39.8555
-      vertex 12.9926 38 -39.8289
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 12.85 38 -40.5
-      vertex 11.4677 38 -39.8555
-      vertex 12.8861 38 -40.1569
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.85 38 -40.5
-      vertex 11.4 38 -40.5
-      vertex 11.4677 38 -39.8555
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.8861 38 -40.8431
-      vertex 11.4 38 -40.5
-      vertex 12.85 38 -40.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.8861 38 -40.8431
-      vertex 11.4677 38 -41.1445
-      vertex 11.4 38 -40.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.9926 38 -41.1711
-      vertex 11.4677 38 -41.1445
-      vertex 12.8861 38 -40.8431
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 11.668 38 -41.7609
-      vertex 12.9926 38 -41.1711
-      vertex 13.1651 38 -41.4698
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 11.992 38 -42.3221
-      vertex 13.1651 38 -41.4698
-      vertex 13.3959 38 -41.7262
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.9926 38 -41.1711
-      vertex 11.668 38 -41.7609
-      vertex 11.4677 38 -41.1445
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.4257 38 -42.8037
-      vertex 13.3959 38 -41.7262
-      vertex 13.675 38 -41.9289
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.95 38 -43.1847
-      vertex 13.675 38 -41.9289
-      vertex 13.9901 38 -42.0692
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 13.542 38 -43.4483
-      vertex 13.9901 38 -42.0692
-      vertex 14.3275 38 -42.141
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 13.1651 38 -41.4698
-      vertex 11.992 38 -42.3221
-      vertex 11.668 38 -41.7609
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 15.458 38 -43.4483
-      vertex 15.0099 38 -42.0692
-      vertex 16.05 38 -43.1847
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 15.0099 38 -42.0692
-      vertex 15.458 38 -43.4483
-      vertex 14.6725 38 -42.141
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 13.3959 38 -41.7262
-      vertex 12.4257 38 -42.8037
-      vertex 11.992 38 -42.3221
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 14.824 38 -43.583
-      vertex 14.6725 38 -42.141
-      vertex 15.458 38 -43.4483
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 13.675 38 -41.9289
-      vertex 12.95 38 -43.1847
-      vertex 12.4257 38 -42.8037
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 14.6725 38 -42.141
-      vertex 14.824 38 -43.583
-      vertex 14.3275 38 -42.141
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 13.9901 38 -42.0692
-      vertex 13.542 38 -43.4483
-      vertex 12.95 38 -43.1847
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 14.176 38 -43.583
-      vertex 14.3275 38 -42.141
-      vertex 14.824 38 -43.583
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 14.3275 38 -42.141
-      vertex 14.176 38 -43.583
-      vertex 13.542 38 -43.4483
-    endloop
-  endfacet
-  facet normal -0.866027 0 0.499998
-    outer loop
-      vertex 17.008 38 -42.3221
-      vertex 17.332 40.5 -41.7609
-      vertex 17.008 40.5 -42.3221
-    endloop
-  endfacet
-  facet normal -0.866027 0 0.499998
-    outer loop
-      vertex 17.332 40.5 -41.7609
-      vertex 17.008 38 -42.3221
-      vertex 17.332 38 -41.7609
-    endloop
-  endfacet
   facet normal -0 0 1
     outer loop
       vertex 14.176 40.5 -43.583
@@ -5004,130 +4339,907 @@ solid OpenSCAD_Model
       vertex 14.176 38 -43.583
     endloop
   endfacet
-  facet normal 0.994522 -0 0.104528
+  facet normal -0.743095 0 -0.669186
     outer loop
-      vertex 11.4 38 -40.5
-      vertex 11.4677 40.5 -41.1445
-      vertex 11.4 40.5 -40.5
+      vertex 17.008 38 -38.6779
+      vertex 16.5743 40.5 -38.1963
+      vertex 17.008 40.5 -38.6779
     endloop
   endfacet
-  facet normal 0.994522 0 0.104528
+  facet normal -0.743095 -0 -0.669186
     outer loop
-      vertex 11.4677 40.5 -41.1445
+      vertex 16.5743 40.5 -38.1963
+      vertex 17.008 38 -38.6779
+      vertex 16.5743 38 -38.1963
+    endloop
+  endfacet
+  facet normal -0.951048 0 -0.309044
+    outer loop
+      vertex 17.5323 38 -39.8555
+      vertex 17.332 40.5 -39.2391
+      vertex 17.5323 40.5 -39.8555
+    endloop
+  endfacet
+  facet normal -0.951048 -0 -0.309044
+    outer loop
+      vertex 17.332 40.5 -39.2391
+      vertex 17.5323 38 -39.8555
+      vertex 17.332 38 -39.2391
+    endloop
+  endfacet
+  facet normal 0.58786 0 -0.808963
+    outer loop
+      vertex 12.4257 38 -38.1963
+      vertex 12.95 40.5 -37.8153
+      vertex 12.95 38 -37.8153
+    endloop
+  endfacet
+  facet normal 0.58786 0 -0.808963
+    outer loop
+      vertex 12.95 40.5 -37.8153
+      vertex 12.4257 38 -38.1963
+      vertex 12.4257 40.5 -38.1963
+    endloop
+  endfacet
+  facet normal 0.207822 0 -0.978167
+    outer loop
+      vertex 13.542 38 -37.5517
+      vertex 14.176 40.5 -37.417
+      vertex 14.176 38 -37.417
+    endloop
+  endfacet
+  facet normal 0.207822 0 -0.978167
+    outer loop
+      vertex 14.176 40.5 -37.417
+      vertex 13.542 38 -37.5517
+      vertex 13.542 40.5 -37.5517
+    endloop
+  endfacet
+  facet normal -0.866031 0 0.49999
+    outer loop
+      vertex 17.008 38 -42.3221
+      vertex 17.332 40.5 -41.7609
+      vertex 17.008 40.5 -42.3221
+    endloop
+  endfacet
+  facet normal -0.866031 0 0.49999
+    outer loop
+      vertex 17.332 40.5 -41.7609
+      vertex 17.008 38 -42.3221
+      vertex 17.332 38 -41.7609
+    endloop
+  endfacet
+  facet normal -0.866031 0 -0.49999
+    outer loop
+      vertex 17.332 38 -39.2391
+      vertex 17.008 40.5 -38.6779
+      vertex 17.332 40.5 -39.2391
+    endloop
+  endfacet
+  facet normal -0.866031 -0 -0.49999
+    outer loop
+      vertex 17.008 40.5 -38.6779
+      vertex 17.332 38 -39.2391
+      vertex 17.008 38 -38.6779
+    endloop
+  endfacet
+  facet normal -0.406768 0 -0.913531
+    outer loop
+      vertex 15.458 38 -37.5517
+      vertex 16.05 40.5 -37.8153
+      vertex 16.05 38 -37.8153
+    endloop
+  endfacet
+  facet normal -0.406768 0 -0.913531
+    outer loop
+      vertex 16.05 40.5 -37.8153
+      vertex 15.458 38 -37.5517
+      vertex 15.458 40.5 -37.5517
+    endloop
+  endfacet
+  facet normal -0.207822 0 -0.978167
+    outer loop
+      vertex 14.824 38 -37.417
+      vertex 15.458 40.5 -37.5517
+      vertex 15.458 38 -37.5517
+    endloop
+  endfacet
+  facet normal -0.207822 0 -0.978167
+    outer loop
+      vertex 15.458 40.5 -37.5517
+      vertex 14.824 38 -37.417
+      vertex 14.824 40.5 -37.417
+    endloop
+  endfacet
+  facet normal -0.58786 0 -0.808963
+    outer loop
+      vertex 16.05 38 -37.8153
+      vertex 16.5743 40.5 -38.1963
+      vertex 16.5743 38 -38.1963
+    endloop
+  endfacet
+  facet normal -0.58786 0 -0.808963
+    outer loop
+      vertex 16.5743 40.5 -38.1963
+      vertex 16.05 38 -37.8153
+      vertex 16.05 40.5 -37.8153
+    endloop
+  endfacet
+  facet normal 0.866031 0 -0.49999
+    outer loop
+      vertex 11.992 38 -38.6779
+      vertex 11.668 40.5 -39.2391
+      vertex 11.992 40.5 -38.6779
+    endloop
+  endfacet
+  facet normal 0.866031 0 -0.49999
+    outer loop
+      vertex 11.668 40.5 -39.2391
+      vertex 11.992 38 -38.6779
+      vertex 11.668 38 -39.2391
+    endloop
+  endfacet
+  facet normal 0.743095 0 -0.669186
+    outer loop
+      vertex 12.4257 38 -38.1963
+      vertex 11.992 40.5 -38.6779
+      vertex 12.4257 40.5 -38.1963
+    endloop
+  endfacet
+  facet normal 0.743095 0 -0.669186
+    outer loop
+      vertex 11.992 40.5 -38.6779
+      vertex 12.4257 38 -38.1963
+      vertex 11.992 38 -38.6779
+    endloop
+  endfacet
+  facet normal 0.951048 0 -0.309044
+    outer loop
+      vertex 11.668 38 -39.2391
+      vertex 11.4677 40.5 -39.8555
+      vertex 11.668 40.5 -39.2391
+    endloop
+  endfacet
+  facet normal 0.951048 0 -0.309044
+    outer loop
+      vertex 11.4677 40.5 -39.8555
+      vertex 11.668 38 -39.2391
+      vertex 11.4677 38 -39.8555
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 14.6725 38 -38.859
+      vertex 14.824 38 -37.417
+      vertex 15.458 38 -37.5517
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 14.824 38 -37.417
+      vertex 14.6725 38 -38.859
+      vertex 14.176 38 -37.417
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.0099 38 -38.9308
+      vertex 15.458 38 -37.5517
+      vertex 16.05 38 -37.8153
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 14.3275 38 -38.859
+      vertex 14.176 38 -37.417
+      vertex 14.6725 38 -38.859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.325 38 -39.0711
+      vertex 16.05 38 -37.8153
+      vertex 16.5743 38 -38.1963
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 14.176 38 -37.417
+      vertex 14.3275 38 -38.859
+      vertex 13.542 38 -37.5517
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.6041 38 -39.2738
+      vertex 16.5743 38 -38.1963
+      vertex 17.008 38 -38.6779
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 13.9901 38 -38.9308
+      vertex 13.542 38 -37.5517
+      vertex 14.3275 38 -38.859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 13.542 38 -37.5517
+      vertex 13.9901 38 -38.9308
+      vertex 12.95 38 -37.8153
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.458 38 -37.5517
+      vertex 15.0099 38 -38.9308
+      vertex 14.6725 38 -38.859
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 16.05 38 -37.8153
+      vertex 15.325 38 -39.0711
+      vertex 15.0099 38 -38.9308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.8349 38 -39.5302
+      vertex 17.008 38 -38.6779
+      vertex 17.332 38 -39.2391
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 16.5743 38 -38.1963
+      vertex 15.6041 38 -39.2738
+      vertex 15.325 38 -39.0711
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.008 38 -38.6779
+      vertex 15.8349 38 -39.5302
+      vertex 15.6041 38 -39.2738
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.332 38 -39.2391
+      vertex 16.0074 38 -39.8289
+      vertex 15.8349 38 -39.5302
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.5323 38 -39.8555
+      vertex 16.0074 38 -39.8289
+      vertex 17.332 38 -39.2391
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.5323 38 -39.8555
+      vertex 16.1139 38 -40.1569
+      vertex 16.0074 38 -39.8289
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.6 38 -40.5
+      vertex 16.1139 38 -40.1569
+      vertex 17.5323 38 -39.8555
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.6 38 -40.5
+      vertex 16.15 38 -40.5
+      vertex 16.1139 38 -40.1569
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.6 38 -40.5
+      vertex 16.1139 38 -40.8431
+      vertex 16.15 38 -40.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 17.5323 38 -41.1445
+      vertex 16.1139 38 -40.8431
+      vertex 17.6 38 -40.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 17.5323 38 -41.1445
+      vertex 16.0074 38 -41.1711
+      vertex 16.1139 38 -40.8431
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 17.332 38 -41.7609
+      vertex 16.0074 38 -41.1711
+      vertex 17.5323 38 -41.1445
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 16.0074 38 -41.1711
+      vertex 17.332 38 -41.7609
+      vertex 15.8349 38 -41.4698
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 17.008 38 -42.3221
+      vertex 15.8349 38 -41.4698
+      vertex 17.332 38 -41.7609
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.8349 38 -41.4698
+      vertex 17.008 38 -42.3221
+      vertex 15.6041 38 -41.7262
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 16.5743 38 -42.8037
+      vertex 15.6041 38 -41.7262
+      vertex 17.008 38 -42.3221
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.6041 38 -41.7262
+      vertex 16.5743 38 -42.8037
+      vertex 15.325 38 -41.9289
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.325 38 -41.9289
+      vertex 16.05 38 -43.1847
+      vertex 15.0099 38 -42.0692
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 16.05 38 -43.1847
+      vertex 15.325 38 -41.9289
+      vertex 16.5743 38 -42.8037
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 13.675 38 -39.0711
+      vertex 12.95 38 -37.8153
+      vertex 13.9901 38 -38.9308
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.95 38 -37.8153
+      vertex 13.675 38 -39.0711
+      vertex 12.4257 38 -38.1963
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 13.3959 38 -39.2738
+      vertex 12.4257 38 -38.1963
+      vertex 13.675 38 -39.0711
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.4257 38 -38.1963
+      vertex 13.3959 38 -39.2738
+      vertex 11.992 38 -38.6779
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 13.1651 38 -39.5302
+      vertex 11.992 38 -38.6779
+      vertex 13.3959 38 -39.2738
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.992 38 -38.6779
+      vertex 13.1651 38 -39.5302
+      vertex 11.668 38 -39.2391
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 12.9926 38 -39.8289
+      vertex 11.668 38 -39.2391
+      vertex 13.1651 38 -39.5302
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.9926 38 -39.8289
+      vertex 11.4677 38 -39.8555
+      vertex 11.668 38 -39.2391
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 12.8861 38 -40.1569
+      vertex 11.4677 38 -39.8555
+      vertex 12.9926 38 -39.8289
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 12.85 38 -40.5
+      vertex 11.4677 38 -39.8555
+      vertex 12.8861 38 -40.1569
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.85 38 -40.5
       vertex 11.4 38 -40.5
+      vertex 11.4677 38 -39.8555
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.8861 38 -40.8431
+      vertex 11.4 38 -40.5
+      vertex 12.85 38 -40.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.8861 38 -40.8431
+      vertex 11.4677 38 -41.1445
+      vertex 11.4 38 -40.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.9926 38 -41.1711
+      vertex 11.4677 38 -41.1445
+      vertex 12.8861 38 -40.8431
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.668 38 -41.7609
+      vertex 12.9926 38 -41.1711
+      vertex 13.1651 38 -41.4698
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 11.992 38 -42.3221
+      vertex 13.1651 38 -41.4698
+      vertex 13.3959 38 -41.7262
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 12.9926 38 -41.1711
+      vertex 11.668 38 -41.7609
       vertex 11.4677 38 -41.1445
     endloop
   endfacet
-  facet normal 0.743144 -0 0.669131
+  facet normal 0 1 0
     outer loop
-      vertex 11.992 38 -42.3221
-      vertex 12.4257 40.5 -42.8037
-      vertex 11.992 40.5 -42.3221
+      vertex 12.4257 38 -42.8037
+      vertex 13.3959 38 -41.7262
+      vertex 13.675 38 -41.9289
     endloop
   endfacet
-  facet normal 0.743144 0 0.669131
+  facet normal 0 1 0
     outer loop
-      vertex 12.4257 40.5 -42.8037
+      vertex 12.95 38 -43.1847
+      vertex 13.675 38 -41.9289
+      vertex 13.9901 38 -42.0692
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 13.542 38 -43.4483
+      vertex 13.9901 38 -42.0692
+      vertex 14.3275 38 -42.141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 13.1651 38 -41.4698
       vertex 11.992 38 -42.3221
+      vertex 11.668 38 -41.7609
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 15.458 38 -43.4483
+      vertex 15.0099 38 -42.0692
+      vertex 16.05 38 -43.1847
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 15.0099 38 -42.0692
+      vertex 15.458 38 -43.4483
+      vertex 14.6725 38 -42.141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 13.3959 38 -41.7262
+      vertex 12.4257 38 -42.8037
+      vertex 11.992 38 -42.3221
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 14.824 38 -43.583
+      vertex 14.6725 38 -42.141
+      vertex 15.458 38 -43.4483
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 13.675 38 -41.9289
+      vertex 12.95 38 -43.1847
       vertex 12.4257 38 -42.8037
     endloop
   endfacet
-  facet normal -0.207912 0 0.978148
+  facet normal 0 1 0
+    outer loop
+      vertex 14.6725 38 -42.141
+      vertex 14.824 38 -43.583
+      vertex 14.3275 38 -42.141
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 13.9901 38 -42.0692
+      vertex 13.542 38 -43.4483
+      vertex 12.95 38 -43.1847
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 14.176 38 -43.583
+      vertex 14.3275 38 -42.141
+      vertex 14.824 38 -43.583
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 14.3275 38 -42.141
+      vertex 14.176 38 -43.583
+      vertex 13.542 38 -43.4483
+    endloop
+  endfacet
+  facet normal 0.406768 0 -0.913531
+    outer loop
+      vertex 12.95 38 -37.8153
+      vertex 13.542 40.5 -37.5517
+      vertex 13.542 38 -37.5517
+    endloop
+  endfacet
+  facet normal 0.406768 0 -0.913531
+    outer loop
+      vertex 13.542 40.5 -37.5517
+      vertex 12.95 38 -37.8153
+      vertex 12.95 40.5 -37.8153
+    endloop
+  endfacet
+  facet normal -0.207822 0 0.978167
     outer loop
       vertex 14.824 40.5 -43.583
       vertex 15.458 38 -43.4483
       vertex 15.458 40.5 -43.4483
     endloop
   endfacet
-  facet normal -0.207912 0 0.978148
+  facet normal -0.207822 0 0.978167
     outer loop
       vertex 15.458 38 -43.4483
       vertex 14.824 40.5 -43.583
       vertex 14.824 38 -43.583
     endloop
   endfacet
-  facet normal -0.406741 0 0.913544
+  facet normal -0.58786 0 0.808963
     outer loop
-      vertex 15.458 40.5 -43.4483
-      vertex 16.05 38 -43.1847
       vertex 16.05 40.5 -43.1847
+      vertex 16.5743 38 -42.8037
+      vertex 16.5743 40.5 -42.8037
     endloop
   endfacet
-  facet normal -0.406741 0 0.913544
+  facet normal -0.58786 0 0.808963
     outer loop
+      vertex 16.5743 38 -42.8037
+      vertex 16.05 40.5 -43.1847
       vertex 16.05 38 -43.1847
-      vertex 15.458 40.5 -43.4483
-      vertex 15.458 38 -43.4483
     endloop
   endfacet
-  facet normal -0.743144 0 0.669131
+  facet normal -0.743095 0 0.669186
     outer loop
       vertex 16.5743 38 -42.8037
       vertex 17.008 40.5 -42.3221
       vertex 16.5743 40.5 -42.8037
     endloop
   endfacet
-  facet normal -0.743144 0 0.669131
+  facet normal -0.743095 0 0.669186
     outer loop
       vertex 17.008 40.5 -42.3221
       vertex 16.5743 38 -42.8037
       vertex 17.008 38 -42.3221
     endloop
   endfacet
-  facet normal -0.587783 0 0.809019
+  facet normal -0.951048 0 0.309044
     outer loop
-      vertex 16.05 40.5 -43.1847
-      vertex 16.5743 38 -42.8037
-      vertex 16.5743 40.5 -42.8037
+      vertex 17.332 38 -41.7609
+      vertex 17.5323 40.5 -41.1445
+      vertex 17.332 40.5 -41.7609
     endloop
   endfacet
-  facet normal -0.587783 0 0.809019
+  facet normal -0.951048 0 0.309044
     outer loop
-      vertex 16.5743 38 -42.8037
-      vertex 16.05 40.5 -43.1847
+      vertex 17.5323 40.5 -41.1445
+      vertex 17.332 38 -41.7609
+      vertex 17.5323 38 -41.1445
+    endloop
+  endfacet
+  facet normal -0.994528 0 0.104468
+    outer loop
+      vertex 17.5323 38 -41.1445
+      vertex 17.6 40.5 -40.5
+      vertex 17.5323 40.5 -41.1445
+    endloop
+  endfacet
+  facet normal -0.994528 0 0.104468
+    outer loop
+      vertex 17.6 40.5 -40.5
+      vertex 17.5323 38 -41.1445
+      vertex 17.6 38 -40.5
+    endloop
+  endfacet
+  facet normal 0.866031 -0 0.49999
+    outer loop
+      vertex 11.668 38 -41.7609
+      vertex 11.992 40.5 -42.3221
+      vertex 11.668 40.5 -41.7609
+    endloop
+  endfacet
+  facet normal 0.866031 0 0.49999
+    outer loop
+      vertex 11.992 40.5 -42.3221
+      vertex 11.668 38 -41.7609
+      vertex 11.992 38 -42.3221
+    endloop
+  endfacet
+  facet normal 0.994528 -0 0.104468
+    outer loop
+      vertex 11.4 38 -40.5
+      vertex 11.4677 40.5 -41.1445
+      vertex 11.4 40.5 -40.5
+    endloop
+  endfacet
+  facet normal 0.994528 0 0.104468
+    outer loop
+      vertex 11.4677 40.5 -41.1445
+      vertex 11.4 38 -40.5
+      vertex 11.4677 38 -41.1445
+    endloop
+  endfacet
+  facet normal -0.406768 0 0.913531
+    outer loop
+      vertex 15.458 40.5 -43.4483
       vertex 16.05 38 -43.1847
+      vertex 16.05 40.5 -43.1847
     endloop
   endfacet
-  facet normal 0.207912 0 0.978148
+  facet normal -0.406768 0 0.913531
+    outer loop
+      vertex 16.05 38 -43.1847
+      vertex 15.458 40.5 -43.4483
+      vertex 15.458 38 -43.4483
+    endloop
+  endfacet
+  facet normal 0.207822 0 0.978167
     outer loop
       vertex 13.542 40.5 -43.4483
       vertex 14.176 38 -43.583
       vertex 14.176 40.5 -43.583
     endloop
   endfacet
-  facet normal 0.207912 0 0.978148
+  facet normal 0.207822 0 0.978167
     outer loop
       vertex 14.176 38 -43.583
       vertex 13.542 40.5 -43.4483
       vertex 13.542 38 -43.4483
     endloop
   endfacet
-  facet normal 0.951056 -0 0.309018
+  facet normal 0.58786 0 0.808963
+    outer loop
+      vertex 12.4257 40.5 -42.8037
+      vertex 12.95 38 -43.1847
+      vertex 12.95 40.5 -43.1847
+    endloop
+  endfacet
+  facet normal 0.58786 0 0.808963
+    outer loop
+      vertex 12.95 38 -43.1847
+      vertex 12.4257 40.5 -42.8037
+      vertex 12.4257 38 -42.8037
+    endloop
+  endfacet
+  facet normal 0.743095 -0 0.669186
+    outer loop
+      vertex 11.992 38 -42.3221
+      vertex 12.4257 40.5 -42.8037
+      vertex 11.992 40.5 -42.3221
+    endloop
+  endfacet
+  facet normal 0.743095 0 0.669186
+    outer loop
+      vertex 12.4257 40.5 -42.8037
+      vertex 11.992 38 -42.3221
+      vertex 12.4257 38 -42.8037
+    endloop
+  endfacet
+  facet normal 0.951048 -0 0.309044
     outer loop
       vertex 11.4677 38 -41.1445
       vertex 11.668 40.5 -41.7609
       vertex 11.4677 40.5 -41.1445
     endloop
   endfacet
-  facet normal 0.951056 0 0.309018
+  facet normal 0.951048 0 0.309044
     outer loop
       vertex 11.668 40.5 -41.7609
       vertex 11.4677 38 -41.1445
       vertex 11.668 38 -41.7609
     endloop
   endfacet
-  facet normal 0.406741 0 0.913544
+  facet normal 0.406768 0 0.913531
     outer loop
       vertex 12.95 40.5 -43.1847
       vertex 13.542 38 -43.4483
       vertex 13.542 40.5 -43.4483
     endloop
   endfacet
-  facet normal 0.406741 0 0.913544
+  facet normal 0.406768 0 0.913531
     outer loop
       vertex 13.542 38 -43.4483
       vertex 12.95 40.5 -43.1847
       vertex 12.95 38 -43.1847
+    endloop
+  endfacet
+  facet normal 0.951052 -0.309031 0
+    outer loop
+      vertex -22.4974 19.782 -46.6833
+      vertex -21.0115 24.3549 -52
+      vertex -21.0115 24.3549 -45.877
+    endloop
+  endfacet
+  facet normal 0.951052 -0.309031 0
+    outer loop
+      vertex -21.0115 24.3549 -52
+      vertex -22.4974 19.782 -46.6833
+      vertex -22.4974 19.782 -52
+    endloop
+  endfacet
+  facet normal -0.951052 -0.309031 -0
+    outer loop
+      vertex 22.4974 19.782 -46.6833
+      vertex 21.0115 24.3549 -52
+      vertex 22.4974 19.782 -52
+    endloop
+  endfacet
+  facet normal -0.951052 -0.309031 0
+    outer loop
+      vertex 21.0115 24.3549 -52
+      vertex 22.4974 19.782 -46.6833
+      vertex 21.0115 24.3549 -45.877
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.93917 29.3287 -45
+      vertex 8.01463 32.6061 -45
+      vertex 8.71125 29.3287 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.94427 30.2169 -45
+      vertex 8.01463 32.6061 -45
+      vertex 6.93917 29.3287 -45
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.01463 32.6061 -45
+      vertex 4.94427 30.2169 -45
+      vertex 5.4 34.8 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.91423 35.4128 -45
+      vertex 7.39951 35.5 -45
+      vertex 7.74447 33.8771 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.88823 30.2288 -45
+      vertex 5.4 34.8 -45
+      vertex 4.94427 30.2169 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.91423 35.4128 -45
+      vertex 3.17551 35.5 -45
+      vertex 7.39951 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.4 34.8 -45
+      vertex 3.17551 35.5 -45
+      vertex 5.91423 35.4128 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.17551 35.5 -45
+      vertex 5.4 34.8 -45
+      vertex 4.88823 30.2288 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.2016 29.3287 -45
+      vertex -15.39 29.3287 -45
+      vertex -12.7114 29.9363 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.39 32.0923 -45
+      vertex -11.9571 30.5692 -45
+      vertex -12.7114 29.9363 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.39 32.0923 -45
+      vertex -12.7114 29.9363 -45
+      vertex -15.39 29.3287 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.9571 30.5692 -45
+      vertex -15.39 32.0923 -45
+      vertex -11.5 34.9186 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.0775 29.4238 -45
+      vertex -12.0875 29.3287 -45
+      vertex -12.1909 29.3287 -45
     endloop
   endfacet
   facet normal 0 0 -1
@@ -5188,48 +5300,6 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 15.39 29.3287 -45
-      vertex 17 30.3042 -45
-      vertex 17.8784 29.3287 -45
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 17 30.3042 -45
-      vertex 15.39 29.3287 -45
-      vertex 15.39 32.0923 -45
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 22.7898 17 -47.9277
-      vertex 22.4974 19.782 -46.6833
-      vertex 22.4974 19.782 -52
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 22.4974 19.782 -46.6833
-      vertex 22.7898 17 -47.9277
-      vertex 22.7898 17 -47.1739
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104528 0
-    outer loop
-      vertex -22.7898 17 -47.1739
-      vertex -22.4974 19.782 -52
-      vertex -22.4974 19.782 -46.6833
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104528 0
-    outer loop
-      vertex -22.4974 19.782 -52
-      vertex -22.7898 17 -47.1739
-      vertex -22.7898 17 -52
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
       vertex 7.74447 33.8771 -45
       vertex 11.5 34.9186 -45
       vertex 11.9833 30.3203 -45
@@ -5270,179 +5340,18 @@ solid OpenSCAD_Model
       vertex 8.01463 32.6061 -45
     endloop
   endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.39 29.3287 -45
-      vertex -17 30.3042 -45
-      vertex -15.39 32.0923 -45
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -17 30.3042 -45
-      vertex -15.39 29.3287 -45
-      vertex -17.8784 29.3287 -45
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 22.7898 17 -52
-      vertex 22.7898 17 -47.9277
-      vertex 22.4974 19.782 -52
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.39 29.3287 -45
-      vertex 12.4256 29.9491 -45
-      vertex 15.39 32.0923 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.0875 29.3287 -45
-      vertex 12.4256 29.9491 -45
-      vertex 15.39 29.3287 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.4256 29.9491 -45
-      vertex 12.0875 29.3287 -45
-      vertex 12.0672 29.522 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.9833 30.3203 -45
-      vertex 15.39 32.0923 -45
-      vertex 12.4256 29.9491 -45
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 15.39 32.0923 -45
-      vertex 11.9833 30.3203 -45
-      vertex 11.5 34.9186 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.93917 29.3287 -45
-      vertex 8.01463 32.6061 -45
-      vertex 8.71125 29.3287 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 4.94427 30.2169 -45
-      vertex 8.01463 32.6061 -45
-      vertex 6.93917 29.3287 -45
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 8.01463 32.6061 -45
-      vertex 4.94427 30.2169 -45
-      vertex 5.4 34.8 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.91423 35.4128 -45
-      vertex 7.39951 35.5 -45
-      vertex 7.74447 33.8771 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 4.88823 30.2288 -45
-      vertex 5.4 34.8 -45
-      vertex 4.94427 30.2169 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.91423 35.4128 -45
-      vertex 3.17551 35.5 -45
-      vertex 7.39951 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.4 34.8 -45
-      vertex 3.17551 35.5 -45
-      vertex 5.91423 35.4128 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3.17551 35.5 -45
-      vertex 5.4 34.8 -45
-      vertex 4.88823 30.2288 -45
-    endloop
-  endfacet
-  facet normal -0.866025 -0.5 -0
+  facet normal -0.866035 -0.499984 -0
     outer loop
       vertex 21.0115 24.3549 -45.877
       vertex 18.6074 28.5191 -52
       vertex 21.0115 24.3549 -52
     endloop
   endfacet
-  facet normal -0.866025 -0.5 0
+  facet normal -0.866035 -0.499984 0
     outer loop
       vertex 18.6074 28.5191 -52
       vertex 21.0115 24.3549 -45.877
       vertex 18.6074 28.5191 -45.1428
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -7.68576 34.1533 -45
-      vertex -10.1941 35.5 -45
-      vertex -7.39951 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -7.68576 34.1533 -45
-      vertex -11.5 34.9186 -45
-      vertex -10.1941 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -11.5 34.9186 -45
-      vertex -7.68576 34.1533 -45
-      vertex -11.9571 30.5692 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.71125 29.3287 -45
-      vertex -12.0775 29.4238 -45
-      vertex -7.95592 32.8823 -45
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -12.0775 29.4238 -45
-      vertex -8.71125 29.3287 -45
-      vertex -12.0875 29.3287 -45
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309017 0
-    outer loop
-      vertex -22.4974 19.782 -46.6833
-      vertex -21.0115 24.3549 -52
-      vertex -21.0115 24.3549 -45.877
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309017 0
-    outer loop
-      vertex -21.0115 24.3549 -52
-      vertex -22.4974 19.782 -46.6833
-      vertex -22.4974 19.782 -52
     endloop
   endfacet
   facet normal 0 0 1
@@ -5837,7 +5746,7 @@ solid OpenSCAD_Model
       vertex -22.6907 15.9604 -52
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 1
     outer loop
       vertex 22.7898 17 -52
       vertex 22.7727 16.7401 -52
@@ -6152,39 +6061,158 @@ solid OpenSCAD_Model
       vertex -12.7114 29.9363 -52
     endloop
   endfacet
-  facet normal -0.951057 -0.309017 -0
+  facet normal 0 0 -1
     outer loop
-      vertex 22.4974 19.782 -46.6833
-      vertex 21.0115 24.3549 -52
-      vertex 22.4974 19.782 -52
+      vertex 15.39 29.3287 -45
+      vertex 12.4256 29.9491 -45
+      vertex 15.39 32.0923 -45
     endloop
   endfacet
-  facet normal -0.951057 -0.309017 0
+  facet normal 0 0 -1
     outer loop
-      vertex 21.0115 24.3549 -52
-      vertex 22.4974 19.782 -46.6833
-      vertex 21.0115 24.3549 -45.877
+      vertex 12.0875 29.3287 -45
+      vertex 12.4256 29.9491 -45
+      vertex 15.39 29.3287 -45
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 0
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.4256 29.9491 -45
+      vertex 12.0875 29.3287 -45
+      vertex 12.0672 29.522 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.9833 30.3203 -45
+      vertex 15.39 32.0923 -45
+      vertex 12.4256 29.9491 -45
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.39 32.0923 -45
+      vertex 11.9833 30.3203 -45
+      vertex 11.5 34.9186 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.39 29.3287 -45
+      vertex 17 30.3042 -45
+      vertex 17.8784 29.3287 -45
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 17 30.3042 -45
+      vertex 15.39 29.3287 -45
+      vertex 15.39 32.0923 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.68576 34.1533 -45
+      vertex -10.1941 35.5 -45
+      vertex -7.39951 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.68576 34.1533 -45
+      vertex -11.5 34.9186 -45
+      vertex -10.1941 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -11.5 34.9186 -45
+      vertex -7.68576 34.1533 -45
+      vertex -11.9571 30.5692 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.71125 29.3287 -45
+      vertex -12.0775 29.4238 -45
+      vertex -7.95592 32.8823 -45
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -12.0775 29.4238 -45
+      vertex -8.71125 29.3287 -45
+      vertex -12.0875 29.3287 -45
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104528 0
+    outer loop
+      vertex -22.7898 17 -47.1739
+      vertex -22.4974 19.782 -52
+      vertex -22.4974 19.782 -46.6833
+    endloop
+  endfacet
+  facet normal 0.994522 -0.104528 0
+    outer loop
+      vertex -22.4974 19.782 -52
+      vertex -22.7898 17 -47.1739
+      vertex -22.7898 17 -52
+    endloop
+  endfacet
+  facet normal -0.743124 -0.669154 0
     outer loop
       vertex 17 30.3042 -52
       vertex 17.8784 29.3287 -45
       vertex 17 30.3042 -45
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 -0
+  facet normal -0.743126 -0.669151 -0
     outer loop
       vertex 18.6074 28.5191 -45.1428
       vertex 17 30.3042 -52
       vertex 18.6074 28.5191 -52
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 7.62316e-008
+  facet normal -0.74313 -0.669147 1.68169e-06
     outer loop
       vertex 17 30.3042 -52
       vertex 18.6074 28.5191 -45.1428
       vertex 17.8784 29.3287 -45
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104528 0
+    outer loop
+      vertex 22.7898 17 -47.9277
+      vertex 22.4974 19.782 -46.6833
+      vertex 22.4974 19.782 -52
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104528 0
+    outer loop
+      vertex 22.4974 19.782 -46.6833
+      vertex 22.7898 17 -47.9277
+      vertex 22.7898 17 -47.1739
+    endloop
+  endfacet
+  facet normal -0.994522 -0.104528 0
+    outer loop
+      vertex 22.7898 17 -52
+      vertex 22.7898 17 -47.9277
+      vertex 22.4974 19.782 -52
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.39 29.3287 -45
+      vertex -17 30.3042 -45
+      vertex -15.39 32.0923 -45
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -17 30.3042 -45
+      vertex -15.39 29.3287 -45
+      vertex -17.8784 29.3287 -45
     endloop
   endfacet
   facet normal 0 0 -1
@@ -6243,252 +6271,217 @@ solid OpenSCAD_Model
       vertex -7.68576 34.1533 -45
     endloop
   endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.2016 29.3287 -45
-      vertex -15.39 29.3287 -45
-      vertex -12.7114 29.9363 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.39 32.0923 -45
-      vertex -11.9571 30.5692 -45
-      vertex -12.7114 29.9363 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.39 32.0923 -45
-      vertex -12.7114 29.9363 -45
-      vertex -15.39 29.3287 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.9571 30.5692 -45
-      vertex -15.39 32.0923 -45
-      vertex -11.5 34.9186 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.0775 29.4238 -45
-      vertex -12.0875 29.3287 -45
-      vertex -12.1909 29.3287 -45
-    endloop
-  endfacet
-  facet normal 0.866025 -0.5 0
+  facet normal 0.866035 -0.499984 0
     outer loop
       vertex -21.0115 24.3549 -45.877
       vertex -18.6074 28.5191 -52
       vertex -18.6074 28.5191 -45.1428
     endloop
   endfacet
-  facet normal 0.866025 -0.5 0
+  facet normal 0.866035 -0.499984 0
     outer loop
       vertex -18.6074 28.5191 -52
       vertex -21.0115 24.3549 -45.877
       vertex -21.0115 24.3549 -52
     endloop
   endfacet
-  facet normal 0.743145 -0.669131 0
+  facet normal 0.743124 -0.669154 0
     outer loop
       vertex -17.8784 29.3287 -45
       vertex -17 30.3042 -52
       vertex -17 30.3042 -45
     endloop
   endfacet
-  facet normal 0.743145 -0.669131 7.62316e-008
+  facet normal 0.74313 -0.669147 1.68169e-06
     outer loop
       vertex -18.6074 28.5191 -45.1428
       vertex -17 30.3042 -52
       vertex -17.8784 29.3287 -45
     endloop
   endfacet
-  facet normal 0.743145 -0.669131 0
+  facet normal 0.743126 -0.669151 0
     outer loop
       vertex -17 30.3042 -52
       vertex -18.6074 28.5191 -45.1428
       vertex -18.6074 28.5191 -52
     endloop
   endfacet
-  facet normal -0.994522 0.104529 3.22159e-007
+  facet normal -0.994527 0.104483 -1.6329e-05
     outer loop
       vertex -15.7898 17 -47.1739
       vertex -15.6504 18.3266 -49
       vertex -15.7825 17.0692 -49
     endloop
   endfacet
-  facet normal -0.994523 0.104521 0
+  facet normal -0.994482 0.104909 0
     outer loop
       vertex -15.7898 17 -47.1739
       vertex -15.7825 17.0692 -49
       vertex -15.7898 17 -49
     endloop
   endfacet
-  facet normal -0.994522 0.104529 0
+  facet normal -0.994524 0.104505 0
     outer loop
       vertex -15.6504 18.3266 -49
       vertex -15.7898 17 -47.1739
       vertex -15.6504 18.3266 -46.94
     endloop
   endfacet
-  facet normal -0.743144 0.669132 0
+  facet normal -0.74319 0.669081 0
     outer loop
       vertex -11.1196 26.431 -49
       vertex -10.7061 26.8903 -45.43
       vertex -10.7061 26.8903 -49
     endloop
   endfacet
-  facet normal -0.743145 0.669131 0
+  facet normal -0.74313 0.669148 0
     outer loop
       vertex -12.5351 24.859 -48
       vertex -11.1196 26.431 -49
       vertex -12.5351 24.859 -49
     endloop
   endfacet
-  facet normal -0.743145 0.669131 2.24677e-007
+  facet normal -0.743134 0.669142 -1.43392e-05
     outer loop
       vertex -11.1196 26.431 -49
       vertex -12.5351 24.859 -48
       vertex -10.7061 26.8903 -45.43
     endloop
   endfacet
-  facet normal -0.743145 0.66913 0
+  facet normal -0.743099 0.669182 0
     outer loop
       vertex -12.9443 24.4046 -45.8683
       vertex -12.5351 24.859 -48
       vertex -12.9443 24.4046 -48
     endloop
   endfacet
-  facet normal -0.743145 0.669131 1.51473e-007
+  facet normal -0.743134 0.669143 -1.49169e-05
     outer loop
       vertex -12.5351 24.859 -48
       vertex -12.9443 24.4046 -45.8683
       vertex -10.7061 26.8903 -45.43
     endloop
   endfacet
-  facet normal -0.406737 0.913545 9.57782e-008
+  facet normal -0.406747 0.913541 -3.84813e-06
     outer loop
       vertex -6.14856 29.6807 -48
       vertex -6.93917 29.3287 -45
       vertex -5.43145 30 -45
     endloop
   endfacet
-  facet normal -0.406736 0.913546 0
+  facet normal -0.40676 0.913535 0
     outer loop
       vertex -6.14856 29.6807 -48
       vertex -5.43145 30 -45
       vertex -5.43145 30 -48
     endloop
   endfacet
-  facet normal -0.406737 0.913545 1.30828e-007
+  facet normal -0.406728 0.913549 1.98468e-06
     outer loop
       vertex -6.93917 29.3287 -45
       vertex -6.14856 29.6807 -48
       vertex -8 28.8564 -45.0833
     endloop
   endfacet
-  facet normal -0.406737 0.913545 0
+  facet normal -0.406731 0.913548 0
     outer loop
       vertex -8 28.8564 -49
       vertex -6.14856 29.6807 -48
       vertex -6.14856 29.6807 -49
     endloop
   endfacet
-  facet normal -0.406737 0.913545 0
+  facet normal -0.406731 0.913548 0
     outer loop
       vertex -6.14856 29.6807 -48
       vertex -8 28.8564 -49
       vertex -8 28.8564 -45.0833
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 1
     outer loop
+      vertex -4.94427 30.2169 -45
       vertex -5.43145 30 -45
       vertex -6.93917 29.3287 -45
-      vertex -4.94427 30.2169 -45
     endloop
   endfacet
-  facet normal -0.951057 0.309017 0
+  facet normal -0.951066 0.308989 0
     outer loop
       vertex -14.9257 20.5567 -49
       vertex -14.6167 21.5078 -46.379
       vertex -14.6167 21.5078 -49
     endloop
   endfacet
-  facet normal -0.951057 0.309017 0
+  facet normal -0.951044 0.309054 0
     outer loop
       vertex -15.6504 18.3266 -46.94
       vertex -14.9257 20.5567 -49
       vertex -15.6504 18.3266 -49
     endloop
   endfacet
-  facet normal -0.951057 0.309017 -1.28833e-009
+  facet normal -0.95105 0.309038 -1.96526e-05
     outer loop
       vertex -14.9257 20.5567 -49
       vertex -15.6504 18.3266 -46.94
       vertex -14.6167 21.5078 -46.379
     endloop
   endfacet
-  facet normal -0.587785 0.809017 0
+  facet normal -0.587845 0.808974 0
     outer loop
       vertex -8.37996 28.5803 -49
       vertex -8 28.8564 -45.0833
       vertex -8 28.8564 -49
     endloop
   endfacet
-  facet normal -0.587785 0.809017 8.3733e-008
+  facet normal -0.587785 0.809017 -8.8771e-06
     outer loop
       vertex -8 28.8564 -45.0833
       vertex -8.37996 28.5803 -49
       vertex -10.7061 26.8903 -45.43
     endloop
   endfacet
-  facet normal -0.587785 0.809017 0
+  facet normal -0.587776 0.809024 0
     outer loop
       vertex -10.7061 26.8903 -45.43
       vertex -8.37996 28.5803 -49
       vertex -10.7061 26.8903 -49
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0 0 1
     outer loop
       vertex 4.94427 30.2169 -45
       vertex 1.67245 30.9123 -45
       vertex 4.88823 30.2288 -45
     endloop
   endfacet
-  facet normal 0.406737 0.913545 -0
+  facet normal 0.406731 0.913548 -0
     outer loop
       vertex 8 28.8564 -49
       vertex 6.14856 29.6807 -48
       vertex 8 28.8564 -45.0833
     endloop
   endfacet
-  facet normal 0.406737 0.913545 0
+  facet normal 0.406731 0.913548 0
     outer loop
       vertex 6.14856 29.6807 -48
       vertex 8 28.8564 -49
       vertex 6.14856 29.6807 -49
     endloop
   endfacet
-  facet normal 0.406737 0.913545 1.30828e-007
+  facet normal 0.406728 0.913549 1.98468e-06
     outer loop
       vertex 6.14856 29.6807 -48
       vertex 6.93917 29.3287 -45
       vertex 8 28.8564 -45.0833
     endloop
   endfacet
-  facet normal 0.406737 0.913545 9.57782e-008
+  facet normal 0.406747 0.913541 -3.84813e-06
     outer loop
       vertex 6.93917 29.3287 -45
       vertex 6.14856 29.6807 -48
       vertex 5.43145 30 -45
     endloop
   endfacet
-  facet normal 0.406736 0.913546 0
+  facet normal 0.40676 0.913535 0
     outer loop
       vertex 5.43145 30 -45
       vertex 6.14856 29.6807 -48
@@ -6502,175 +6495,175 @@ solid OpenSCAD_Model
       vertex 4.94427 30.2169 -45
     endloop
   endfacet
-  facet normal 0.587785 0.809017 0
+  facet normal 0.587776 0.809024 0
     outer loop
       vertex 8.37996 28.5803 -49
       vertex 10.7061 26.8903 -45.43
       vertex 10.7061 26.8903 -49
     endloop
   endfacet
-  facet normal 0.587785 0.809017 8.3733e-008
+  facet normal 0.587785 0.809017 -8.8771e-06
     outer loop
       vertex 10.7061 26.8903 -45.43
       vertex 8.37996 28.5803 -49
       vertex 8 28.8564 -45.0833
     endloop
   endfacet
-  facet normal 0.587785 0.809017 0
+  facet normal 0.587845 0.808974 0
     outer loop
       vertex 8 28.8564 -45.0833
       vertex 8.37996 28.5803 -49
       vertex 8 28.8564 -49
     endloop
   endfacet
-  facet normal 0.743144 0.669132 0
+  facet normal 0.74319 0.669081 0
     outer loop
       vertex 10.7061 26.8903 -45.43
       vertex 11.1196 26.431 -49
       vertex 10.7061 26.8903 -49
     endloop
   endfacet
-  facet normal 0.743145 0.669131 2.24677e-007
+  facet normal 0.743134 0.669142 -1.43392e-05
     outer loop
       vertex 10.7061 26.8903 -45.43
       vertex 12.5351 24.859 -48
       vertex 11.1196 26.431 -49
     endloop
   endfacet
-  facet normal 0.743145 0.669131 1.51473e-007
+  facet normal 0.743134 0.669143 -1.49169e-05
     outer loop
       vertex 12.9443 24.4046 -45.8683
       vertex 12.5351 24.859 -48
       vertex 10.7061 26.8903 -45.43
     endloop
   endfacet
-  facet normal 0.743145 0.66913 0
+  facet normal 0.743099 0.669182 0
     outer loop
       vertex 12.5351 24.859 -48
       vertex 12.9443 24.4046 -45.8683
       vertex 12.9443 24.4046 -48
     endloop
   endfacet
-  facet normal 0.743145 0.669131 0
+  facet normal 0.74313 0.669148 0
     outer loop
       vertex 11.1196 26.431 -49
       vertex 12.5351 24.859 -48
       vertex 12.5351 24.859 -49
     endloop
   endfacet
-  facet normal 0.951057 0.309017 0
+  facet normal 0.951066 0.308989 0
     outer loop
       vertex 14.6167 21.5078 -46.379
       vertex 14.9257 20.5567 -49
       vertex 14.6167 21.5078 -49
     endloop
   endfacet
-  facet normal 0.951057 0.309017 -1.28833e-009
+  facet normal 0.95105 0.309038 -1.96526e-05
     outer loop
       vertex 15.6504 18.3266 -46.94
       vertex 14.9257 20.5567 -49
       vertex 14.6167 21.5078 -46.379
     endloop
   endfacet
-  facet normal 0.951057 0.309017 0
+  facet normal 0.951044 0.309054 0
     outer loop
       vertex 14.9257 20.5567 -49
       vertex 15.6504 18.3266 -46.94
       vertex 15.6504 18.3266 -49
     endloop
   endfacet
-  facet normal 0.994522 0.104529 0
+  facet normal 0.994524 0.104505 0
     outer loop
       vertex 15.7898 17 -47.1739
       vertex 15.6504 18.3266 -49
       vertex 15.6504 18.3266 -46.94
     endloop
   endfacet
-  facet normal 0.994522 0.104529 3.22159e-007
+  facet normal 0.994527 0.104483 -1.6329e-05
     outer loop
       vertex 15.6504 18.3266 -49
       vertex 15.7898 17 -47.1739
       vertex 15.7825 17.0692 -49
     endloop
   endfacet
-  facet normal 0.994523 0.104521 0
+  facet normal 0.994482 0.104909 0
     outer loop
       vertex 15.7825 17.0692 -49
       vertex 15.7898 17 -47.1739
       vertex 15.7898 17 -49
     endloop
   endfacet
-  facet normal -0.866025 0.500002 0
+  facet normal -0.866076 0.499912 0
     outer loop
       vertex -13.1416 24.0628 -49
       vertex -13.3397 23.7196 -49
       vertex -13.1416 24.0628 -48
     endloop
   endfacet
-  facet normal -0.866026 0.499999 0
+  facet normal -0.866067 0.499927 0
     outer loop
       vertex -13.1416 24.0628 -48
       vertex -12.9443 24.4046 -45.8683
       vertex -12.9443 24.4046 -48
     endloop
   endfacet
-  facet normal -0.866025 0.5 7.13197e-007
+  facet normal -0.866023 0.500005 -4.26081e-05
     outer loop
       vertex -14.6167 21.5078 -49
       vertex -13.1416 24.0628 -48
       vertex -13.3397 23.7196 -49
     endloop
   endfacet
-  facet normal -0.866025 0.5 0
+  facet normal -0.86603 0.499992 0
     outer loop
       vertex -13.1416 24.0628 -48
       vertex -14.6167 21.5078 -49
       vertex -14.6167 21.5078 -46.379
     endloop
   endfacet
-  facet normal -0.866025 0.5 -2.85567e-007
+  facet normal -0.866033 0.499986 -1.26545e-05
     outer loop
       vertex -13.1416 24.0628 -48
       vertex -14.6167 21.5078 -46.379
       vertex -12.9443 24.4046 -45.8683
     endloop
   endfacet
-  facet normal 0.866026 0.499999 0
+  facet normal 0.866067 0.499927 0
     outer loop
       vertex 12.9443 24.4046 -45.8683
       vertex 13.1416 24.0628 -48
       vertex 12.9443 24.4046 -48
     endloop
   endfacet
-  facet normal 0.866025 0.500002 0
+  facet normal 0.866076 0.499912 0
     outer loop
       vertex 13.1416 24.0628 -48
       vertex 13.3397 23.7196 -49
       vertex 13.1416 24.0628 -49
     endloop
   endfacet
-  facet normal 0.866025 0.5 -2.85567e-007
+  facet normal 0.866033 0.499986 -1.26545e-05
     outer loop
       vertex 14.6167 21.5078 -46.379
       vertex 13.1416 24.0628 -48
       vertex 12.9443 24.4046 -45.8683
     endloop
   endfacet
-  facet normal 0.866025 0.5 -0
+  facet normal 0.86603 0.499992 -0
     outer loop
       vertex 14.6167 21.5078 -49
       vertex 13.1416 24.0628 -48
       vertex 14.6167 21.5078 -46.379
     endloop
   endfacet
-  facet normal 0.866025 0.5 7.13197e-007
+  facet normal 0.866023 0.500005 -4.26081e-05
     outer loop
       vertex 13.1416 24.0628 -48
       vertex 14.6167 21.5078 -49
       vertex 13.3397 23.7196 -49
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal 0 0 1
     outer loop
       vertex -1.67245 30.9123 -45
       vertex -4.94427 30.2169 -45
@@ -6882,6 +6875,90 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
+      vertex -10.5072 40.6 -45
+      vertex -10.25 51 -45
+      vertex -10.25 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.2 41 -45
+      vertex -10.25 51 -45
+      vertex -10.5072 40.6 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5 34.9186 -45
+      vertex -10.25 35.5 -45
+      vertex -10.1941 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.7572 36.7029 -45
+      vertex -10.25 35.5 -45
+      vertex -11.5 34.9186 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.25 35.5 -45
+      vertex -12.7572 36.7029 -45
+      vertex -10.5072 40.6 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.39 32.0923 -45
+      vertex -12.7572 36.7029 -45
+      vertex -11.5 34.9186 -45
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.7572 36.7029 -45
+      vertex -15.39 32.0923 -45
+      vertex -13.45 37.1029 -45
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -10.25 51 -45
+      vertex -11.2 41 -45
+      vertex -10.4798 51 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17 36.3553 -45
+      vertex -11.2 41 -45
+      vertex -13.45 37.1029 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17 36.3553 -45
+      vertex -13.45 37.1029 -45
+      vertex -15.39 32.0923 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17 36.3553 -45
+      vertex -15.39 32.0923 -45
+      vertex -17 30.3042 -45
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.2 41 -45
+      vertex -17 36.3553 -45
+      vertex -10.4798 51 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
       vertex 11.0928 40.8 -45
       vertex 12.25 41 -45
       vertex 13.3428 36.9029 -45
@@ -6990,90 +7067,6 @@ solid OpenSCAD_Model
       vertex 10.5 51 -45
       vertex 10.25 44 -45
       vertex 10.25 51 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.5072 40.6 -45
-      vertex -10.25 51 -45
-      vertex -10.25 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.2 41 -45
-      vertex -10.25 51 -45
-      vertex -10.5072 40.6 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.5 34.9186 -45
-      vertex -10.25 35.5 -45
-      vertex -10.1941 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.7572 36.7029 -45
-      vertex -10.25 35.5 -45
-      vertex -11.5 34.9186 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.25 35.5 -45
-      vertex -12.7572 36.7029 -45
-      vertex -10.5072 40.6 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.39 32.0923 -45
-      vertex -12.7572 36.7029 -45
-      vertex -11.5 34.9186 -45
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -12.7572 36.7029 -45
-      vertex -15.39 32.0923 -45
-      vertex -13.45 37.1029 -45
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -10.25 51 -45
-      vertex -11.2 41 -45
-      vertex -10.4798 51 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17 36.3553 -45
-      vertex -11.2 41 -45
-      vertex -13.45 37.1029 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17 36.3553 -45
-      vertex -13.45 37.1029 -45
-      vertex -15.39 32.0923 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -17 36.3553 -45
-      vertex -15.39 32.0923 -45
-      vertex -17 30.3042 -45
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -11.2 41 -45
-      vertex -17 36.3553 -45
-      vertex -10.4798 51 -45
     endloop
   endfacet
   facet normal 0 0 -1
@@ -7279,18 +7272,144 @@ solid OpenSCAD_Model
       vertex 15.8 12 -49
     endloop
   endfacet
-  facet normal 0 -0.743146 0.669129
+  facet normal 0 -0.743167 0.669106
     outer loop
       vertex -11.3637 49.0148 -50.4589
       vertex 11.0102 49.8541 -49.5267
       vertex -10.99 49.8541 -49.5267
     endloop
   endfacet
-  facet normal 0 -0.743146 0.669129
+  facet normal 0 -0.743167 0.669106
     outer loop
       vertex 11.0102 49.8541 -49.5267
       vertex -11.3637 49.0148 -50.4589
       vertex 11.3839 49.0148 -50.4589
+    endloop
+  endfacet
+  facet normal 2.71289e-08 -0.406688 0.913567
+    outer loop
+      vertex -12.3257 46.8541 -51.7063
+      vertex 12.1945 47.1942 -51.5549
+      vertex -11.9688 47.6556 -51.3495
+    endloop
+  endfacet
+  facet normal 0 -0.406687 0.913568
+    outer loop
+      vertex 12.1945 47.1942 -51.5549
+      vertex -12.3257 46.8541 -51.7063
+      vertex 12.3459 46.8541 -51.7063
+    endloop
+  endfacet
+  facet normal 0 -0.58771 0.809072
+    outer loop
+      vertex -11.3637 49.0148 -50.4589
+      vertex 11.523 48.7023 -50.6859
+      vertex 11.3839 49.0148 -50.4589
+    endloop
+  endfacet
+  facet normal -9.44574e-07 -0.587755 0.809039
+    outer loop
+      vertex 11.523 48.7023 -50.6859
+      vertex -11.3637 49.0148 -50.4589
+      vertex -11.6775 48.3099 -50.971
+    endloop
+  endfacet
+  facet normal 0 -0.951056 0.309019
+    outer loop
+      vertex -10.7107 50.4813 -48.4404
+      vertex 10.5584 50.8689 -47.2475
+      vertex -10.5382 50.8689 -47.2475
+    endloop
+  endfacet
+  facet normal 0 -0.951056 0.309019
+    outer loop
+      vertex 10.5584 50.8689 -47.2475
+      vertex -10.7107 50.4813 -48.4404
+      vertex 10.731 50.4813 -48.4404
+    endloop
+  endfacet
+  facet normal -1.23955e-06 -0.994522 0.104531
+    outer loop
+      vertex -10.5382 50.8689 -47.2475
+      vertex 10.5394 50.9114 -46.8429
+      vertex -10.4988 50.9574 -46.4055
+    endloop
+  endfacet
+  facet normal 0 -0.994528 0.104467
+    outer loop
+      vertex 10.5394 50.9114 -46.8429
+      vertex -10.5382 50.8689 -47.2475
+      vertex 10.5584 50.8689 -47.2475
+    endloop
+  endfacet
+  facet normal 0 -0.994527 0.104481
+    outer loop
+      vertex -10.4988 50.9574 -46.4055
+      vertex 10.5 51 -46
+      vertex -10.4798 51 -46
+    endloop
+  endfacet
+  facet normal -1.10927e-06 -0.994521 0.104537
+    outer loop
+      vertex 10.5 51 -46
+      vertex -10.4988 50.9574 -46.4055
+      vertex 10.5394 50.9114 -46.8429
+    endloop
+  endfacet
+  facet normal 0 -0.406655 0.913582
+    outer loop
+      vertex -11.9688 47.6556 -51.3495
+      vertex 11.8357 48 -51.1962
+      vertex -11.8155 48 -51.1962
+    endloop
+  endfacet
+  facet normal 3.37883e-07 -0.406675 0.913573
+    outer loop
+      vertex 11.8357 48 -51.1962
+      vertex -11.9688 47.6556 -51.3495
+      vertex 12.1945 47.1942 -51.5549
+    endloop
+  endfacet
+  facet normal 7.87977e-07 -0.587822 0.80899
+    outer loop
+      vertex -11.6775 48.3099 -50.971
+      vertex 11.8357 48 -51.1962
+      vertex 11.523 48.7023 -50.6859
+    endloop
+  endfacet
+  facet normal 0 -0.587861 0.808962
+    outer loop
+      vertex 11.8357 48 -51.1962
+      vertex -11.6775 48.3099 -50.971
+      vertex -11.8155 48 -51.1962
+    endloop
+  endfacet
+  facet normal 0 -0.866017 0.500015
+    outer loop
+      vertex -10.99 49.8541 -49.5267
+      vertex 10.731 50.4813 -48.4404
+      vertex -10.7107 50.4813 -48.4404
+    endloop
+  endfacet
+  facet normal 0 -0.866017 0.500015
+    outer loop
+      vertex 10.731 50.4813 -48.4404
+      vertex -10.99 49.8541 -49.5267
+      vertex 11.0102 49.8541 -49.5267
+    endloop
+  endfacet
+  facet normal 0 -0.207923 0.978145
+    outer loop
+      vertex -12.3257 46.8541 -51.7063
+      vertex 12.8921 45.6272 -51.9671
+      vertex 12.3459 46.8541 -51.7063
+    endloop
+  endfacet
+  facet normal 0 -0.207923 0.978145
+    outer loop
+      vertex 12.8921 45.6272 -51.9671
+      vertex -12.3257 46.8541 -51.7063
+      vertex -12.8719 45.6272 -51.9671
     endloop
   endfacet
   facet normal -0 0 1
@@ -7307,853 +7426,6 @@ solid OpenSCAD_Model
       vertex -13.1512 45 -51.9671
     endloop
   endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex -10.5382 50.8689 -47.2475
-      vertex -10.1937 50.8 -47.4595
-      vertex -10.1687 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex -10.7107 50.4813 -48.4404
-      vertex -9.21319 50.8 -47.4595
-      vertex -10.1937 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex -9.21319 50.8 -47.4595
-      vertex -10.7107 50.4813 -48.4404
-      vertex -7.91576 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex -7.91576 50.8 -47.4595
-      vertex -10.7107 50.4813 -48.4404
-      vertex -6.93938 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex -6.93938 50.8 -47.4595
-      vertex -10.7107 50.4813 -48.4404
-      vertex -5.9574 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex -5.9574 50.8 -47.4595
-      vertex -10.7107 50.4813 -48.4404
-      vertex -5.03635 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex -5.03635 50.8 -47.4595
-      vertex -10.7107 50.4813 -48.4404
-      vertex -2.83774 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex -2.83774 50.8 -47.4595
-      vertex -10.7107 50.4813 -48.4404
-      vertex -1.83275 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex -1.83275 50.8 -47.4595
-      vertex -10.7107 50.4813 -48.4404
-      vertex 0.154976 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex 10.731 50.4813 -48.4404
-      vertex 0.154976 50.8 -47.4595
-      vertex -10.7107 50.4813 -48.4404
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex 0.154976 50.8 -47.4595
-      vertex 10.731 50.4813 -48.4404
-      vertex 1.27087 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex 1.27087 50.8 -47.4595
-      vertex 10.731 50.4813 -48.4404
-      vertex 3.47219 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex 3.47219 50.8 -47.4595
-      vertex 10.731 50.4813 -48.4404
-      vertex 4.57596 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex 4.57596 50.8 -47.4595
-      vertex 10.731 50.4813 -48.4404
-      vertex 5.416 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex 5.416 50.8 -47.4595
-      vertex 10.731 50.4813 -48.4404
-      vertex 6.42101 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex 6.42101 50.8 -47.4595
-      vertex 10.731 50.4813 -48.4404
-      vertex 8.52701 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 2.77621e-007 -0.951057 0.309016
-    outer loop
-      vertex -10.7107 50.4813 -48.4404
-      vertex -10.1937 50.8 -47.4595
-      vertex -10.5382 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex -9.21319 50.8 -47.4595
-      vertex -7.98543 50.8689 -47.2475
-      vertex -9.16971 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex -7.91576 50.8 -47.4595
-      vertex -7.98543 50.8689 -47.2475
-      vertex -9.21319 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal -1.75324e-005 -0.951059 0.309011
-    outer loop
-      vertex -7.98543 50.8689 -47.2475
-      vertex -7.91576 50.8 -47.4595
-      vertex -7.94144 50.8365 -47.3472
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex -6.93938 50.8 -47.4595
-      vertex -5.96422 50.8689 -47.2475
-      vertex -6.98763 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex -5.96422 50.8689 -47.2475
-      vertex -6.93938 50.8 -47.4595
-      vertex -5.9574 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex -2.83774 50.8 -47.4595
-      vertex -5.02954 50.8689 -47.2475
-      vertex -5.03635 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex -5.02954 50.8689 -47.2475
-      vertex -2.83774 50.8 -47.4595
-      vertex -2.83774 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.951061 0.309002
-    outer loop
-      vertex -1.83275 50.8689 -47.2475
-      vertex 0.220306 50.859 -47.2778
-      vertex 0.242497 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex 0.154976 50.8 -47.4595
-      vertex -1.83275 50.8689 -47.2475
-      vertex -1.83275 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 2.62468e-007 -0.951056 0.309018
-    outer loop
-      vertex -1.83275 50.8689 -47.2475
-      vertex 0.154976 50.8 -47.4595
-      vertex 0.220306 50.859 -47.2778
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex 3.47219 50.8 -47.4595
-      vertex 3.27846 50.8689 -47.2475
-      vertex 1.46444 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 2.07451e-005 -0.951062 0.308999
-    outer loop
-      vertex 1.27087 50.8 -47.4595
-      vertex 1.46444 50.8689 -47.2475
-      vertex 1.32909 50.8304 -47.366
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex 3.47219 50.8 -47.4595
-      vertex 1.46444 50.8689 -47.2475
-      vertex 1.27087 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal -2.47007e-005 -0.951063 0.308996
-    outer loop
-      vertex 3.27846 50.8689 -47.2475
-      vertex 3.47219 50.8 -47.4595
-      vertex 3.41208 50.8313 -47.363
-    endloop
-  endfacet
-  facet normal 0 -0.951043 0.309059
-    outer loop
-      vertex 4.50775 50.8621 -47.2684
-      vertex 5.416 50.8689 -47.2475
-      vertex 4.49237 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 1.19912e-006 -0.951058 0.309012
-    outer loop
-      vertex 4.57596 50.8 -47.4595
-      vertex 5.416 50.8689 -47.2475
-      vertex 4.50775 50.8621 -47.2684
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex 5.416 50.8689 -47.2475
-      vertex 4.57596 50.8 -47.4595
-      vertex 5.416 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex 6.42101 50.8 -47.4595
-      vertex 8.52701 50.8689 -47.2475
-      vertex 6.42101 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex 8.52701 50.8689 -47.2475
-      vertex 6.42101 50.8 -47.4595
-      vertex 8.52701 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309016
-    outer loop
-      vertex 9.53201 50.8 -47.4595
-      vertex 10.5584 50.8689 -47.2475
-      vertex 9.53201 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal -9.85363e-008 -0.951057 0.309016
-    outer loop
-      vertex 9.53201 50.8 -47.4595
-      vertex 10.731 50.4813 -48.4404
-      vertex 10.5584 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.951057 0.309017
-    outer loop
-      vertex 8.52701 50.8 -47.4595
-      vertex 10.731 50.4813 -48.4404
-      vertex 9.53201 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -0.207912 0.978148
-    outer loop
-      vertex -12.3257 46.8541 -51.7063
-      vertex 12.8921 45.6272 -51.9671
-      vertex 12.3459 46.8541 -51.7063
-    endloop
-  endfacet
-  facet normal 0 -0.207912 0.978148
-    outer loop
-      vertex 12.8921 45.6272 -51.9671
-      vertex -12.3257 46.8541 -51.7063
-      vertex -12.8719 45.6272 -51.9671
-    endloop
-  endfacet
-  facet normal 0 -0.587783 0.809019
-    outer loop
-      vertex -11.3637 49.0148 -50.4589
-      vertex 11.523 48.7023 -50.6859
-      vertex 11.3839 49.0148 -50.4589
-    endloop
-  endfacet
-  facet normal -6.61262e-008 -0.587786 0.809016
-    outer loop
-      vertex 11.523 48.7023 -50.6859
-      vertex -11.3637 49.0148 -50.4589
-      vertex -11.6775 48.3099 -50.971
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104529
-    outer loop
-      vertex 6.42101 50.9204 -46.7572
-      vertex 8.52701 50.979 -46.2
-      vertex 6.42101 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 6.5969e-007 -0.994522 0.104527
-    outer loop
-      vertex 8.52701 50.979 -46.2
-      vertex 6.42101 50.9204 -46.7572
-      vertex 8.52701 50.9158 -46.801
-    endloop
-  endfacet
-  facet normal -4.86465e-008 -0.99452 0.104547
-    outer loop
-      vertex 3.07198 50.9782 -46.2078
-      vertex 5.416 50.979 -46.2
-      vertex 2.36508 50.9857 -46.136
-    endloop
-  endfacet
-  facet normal 3.23875e-008 -0.994523 0.104523
-    outer loop
-      vertex 3.66731 50.9555 -46.4231
-      vertex 5.416 50.979 -46.2
-      vertex 3.07198 50.9782 -46.2078
-    endloop
-  endfacet
-  facet normal -5.82122e-007 -0.994522 0.104527
-    outer loop
-      vertex 4.05128 50.9256 -46.708
-      vertex 5.416 50.979 -46.2
-      vertex 3.66731 50.9555 -46.4231
-    endloop
-  endfacet
-  facet normal -6.71551e-007 -0.994522 0.104528
-    outer loop
-      vertex 5.416 50.979 -46.2
-      vertex 4.05128 50.9256 -46.708
-      vertex 5.416 50.9226 -46.7363
-    endloop
-  endfacet
-  facet normal 1.46301e-006 -0.994522 0.104531
-    outer loop
-      vertex -4.36874 50.944 -46.5329
-      vertex -4.99588 50.979 -46.2
-      vertex -5.00615 50.9454 -46.5196
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104528
-    outer loop
-      vertex -4.99588 50.979 -46.2
-      vertex -4.36874 50.944 -46.5329
-      vertex -4.36874 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 3.99563e-007 -0.994522 0.104524
-    outer loop
-      vertex -7.74821 50.9695 -46.2902
-      vertex -5.99788 50.979 -46.2
-      vertex -8.12955 50.9817 -46.1746
-    endloop
-  endfacet
-  facet normal 7.21421e-007 -0.994523 0.104518
-    outer loop
-      vertex -7.45775 50.9507 -46.4687
-      vertex -5.99788 50.979 -46.2
-      vertex -7.74821 50.9695 -46.2902
-    endloop
-  endfacet
-  facet normal -6.40338e-007 -0.994522 0.104525
-    outer loop
-      vertex -5.99788 50.979 -46.2
-      vertex -7.45775 50.9507 -46.4687
-      vertex -5.98826 50.9475 -46.4992
-    endloop
-  endfacet
-  facet normal 1.35539e-006 -0.994514 0.104603
-    outer loop
-      vertex -5.99788 50.979 -46.2
-      vertex -8.57843 50.9857 -46.136
-      vertex -8.12955 50.9817 -46.1746
-    endloop
-  endfacet
-  facet normal 0 -0.99452 0.104549
-    outer loop
-      vertex -4.99588 50.979 -46.2
-      vertex -8.57843 50.9857 -46.136
-      vertex -5.99788 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 0 -0.99452 0.104549
-    outer loop
-      vertex -8.57843 50.9857 -46.136
-      vertex -4.99588 50.979 -46.2
-      vertex 2.36508 50.9857 -46.136
-    endloop
-  endfacet
-  facet normal 0 -0.99452 0.104549
-    outer loop
-      vertex -4.36874 50.979 -46.2
-      vertex 2.36508 50.9857 -46.136
-      vertex -4.99588 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 0 -0.99452 0.104549
-    outer loop
-      vertex -0.296738 50.979 -46.2
-      vertex 2.36508 50.9857 -46.136
-      vertex -4.36874 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 7.8882e-007 -0.994523 0.104517
-    outer loop
-      vertex -0.296738 50.979 -46.2
-      vertex 1.65808 50.9781 -46.2086
-      vertex 2.36508 50.9857 -46.136
-    endloop
-  endfacet
-  facet normal 8.87982e-007 -0.994521 0.104539
-    outer loop
-      vertex -0.296738 50.979 -46.2
-      vertex 1.06242 50.9552 -46.4262
-      vertex 1.65808 50.9781 -46.2086
-    endloop
-  endfacet
-  facet normal 6.93261e-007 -0.994522 0.104532
-    outer loop
-      vertex 0.777154 50.9327 -46.6399
-      vertex -0.296738 50.979 -46.2
-      vertex -0.296738 50.9351 -46.6176
-    endloop
-  endfacet
-  facet normal -9.66168e-007 -0.994522 0.104528
-    outer loop
-      vertex -0.296738 50.979 -46.2
-      vertex 0.777154 50.9327 -46.6399
-      vertex 1.06242 50.9552 -46.4262
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104524
-    outer loop
-      vertex 2.36508 50.9857 -46.136
-      vertex -10.4798 51 -46
-      vertex -8.57843 50.9857 -46.136
-    endloop
-  endfacet
-  facet normal 7.95704e-007 -0.994521 0.104535
-    outer loop
-      vertex -10.4798 51 -46
-      vertex -9.05876 50.9816 -46.1753
-      vertex -8.57843 50.9857 -46.136
-    endloop
-  endfacet
-  facet normal -2.14752e-007 -0.994522 0.104527
-    outer loop
-      vertex -10.4798 51 -46
-      vertex -9.45844 50.9692 -46.2933
-      vertex -9.05876 50.9816 -46.1753
-    endloop
-  endfacet
-  facet normal -1.40266e-006 -0.994522 0.104527
-    outer loop
-      vertex -9.6683 50.9556 -46.4227
-      vertex -10.4798 51 -46
-      vertex -10.4988 50.9574 -46.4055
-    endloop
-  endfacet
-  facet normal 1.27355e-006 -0.994522 0.104532
-    outer loop
-      vertex -10.4798 51 -46
-      vertex -9.6683 50.9556 -46.4227
-      vertex -9.45844 50.9692 -46.2933
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104524
-    outer loop
-      vertex -10.4798 51 -46
-      vertex 2.36508 50.9857 -46.136
-      vertex 10.5 51 -46
-    endloop
-  endfacet
-  facet normal -2.39251e-007 -0.994521 0.104538
-    outer loop
-      vertex 5.416 50.979 -46.2
-      vertex 10.5 51 -46
-      vertex 2.36508 50.9857 -46.136
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104532
-    outer loop
-      vertex 6.42101 50.979 -46.2
-      vertex 10.5 51 -46
-      vertex 5.416 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104532
-    outer loop
-      vertex 8.52701 50.979 -46.2
-      vertex 10.5 51 -46
-      vertex 6.42101 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104532
-    outer loop
-      vertex 9.53201 50.979 -46.2
-      vertex 10.5 51 -46
-      vertex 8.52701 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 7.89296e-008 -0.994522 0.104528
-    outer loop
-      vertex 10.5394 50.9114 -46.8429
-      vertex 9.53201 50.979 -46.2
-      vertex 9.53201 50.9136 -46.8219
-    endloop
-  endfacet
-  facet normal 5.73166e-007 -0.994522 0.104529
-    outer loop
-      vertex 9.53201 50.979 -46.2
-      vertex 10.5394 50.9114 -46.8429
-      vertex 10.5 51 -46
-    endloop
-  endfacet
-  facet normal 0 -0.406736 0.913546
-    outer loop
-      vertex -11.9688 47.6556 -51.3495
-      vertex 11.8357 48 -51.1962
-      vertex -11.8155 48 -51.1962
-    endloop
-  endfacet
-  facet normal 4.85103e-009 -0.406736 0.913546
-    outer loop
-      vertex 11.8357 48 -51.1962
-      vertex -11.9688 47.6556 -51.3495
-      vertex 12.1945 47.1942 -51.5549
-    endloop
-  endfacet
-  facet normal -6.8371e-008 -0.587786 0.809016
-    outer loop
-      vertex -11.6775 48.3099 -50.971
-      vertex 11.8357 48 -51.1962
-      vertex 11.523 48.7023 -50.6859
-    endloop
-  endfacet
-  facet normal 0 -0.587783 0.809019
-    outer loop
-      vertex 11.8357 48 -51.1962
-      vertex -11.6775 48.3099 -50.971
-      vertex -11.8155 48 -51.1962
-    endloop
-  endfacet
-  facet normal 0 -0.866024 0.500002
-    outer loop
-      vertex -10.99 49.8541 -49.5267
-      vertex 10.731 50.4813 -48.4404
-      vertex -10.7107 50.4813 -48.4404
-    endloop
-  endfacet
-  facet normal 0 -0.866024 0.500002
-    outer loop
-      vertex 10.731 50.4813 -48.4404
-      vertex -10.99 49.8541 -49.5267
-      vertex 11.0102 49.8541 -49.5267
-    endloop
-  endfacet
-  facet normal -1.24269e-006 -0.994521 0.104534
-    outer loop
-      vertex -10.4988 50.9574 -46.4055
-      vertex -9.77744 50.9485 -46.49
-      vertex -9.6683 50.9556 -46.4227
-    endloop
-  endfacet
-  facet normal -1.38054e-006 -0.994521 0.104533
-    outer loop
-      vertex -10.4988 50.9574 -46.4055
-      vertex -10.0102 50.9204 -46.7572
-      vertex -9.77744 50.9485 -46.49
-    endloop
-  endfacet
-  facet normal -7.92134e-006 -0.994522 0.104524
-    outer loop
-      vertex -10.4988 50.9574 -46.4055
-      vertex -10.1499 50.8856 -47.0882
-      vertex -10.0102 50.9204 -46.7572
-    endloop
-  endfacet
-  facet normal 3.57622e-006 -0.994522 0.10453
-    outer loop
-      vertex -10.5382 50.8689 -47.2475
-      vertex -10.1499 50.8856 -47.0882
-      vertex -10.4988 50.9574 -46.4055
-    endloop
-  endfacet
-  facet normal 0 -0.994521 0.104538
-    outer loop
-      vertex -10.1499 50.8856 -47.0882
-      vertex -10.5382 50.8689 -47.2475
-      vertex -10.1687 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 8.23002e-008 -0.994522 0.104528
-    outer loop
-      vertex 9.53201 50.8689 -47.2475
-      vertex 10.5394 50.9114 -46.8429
-      vertex 9.53201 50.9136 -46.8219
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104529
-    outer loop
-      vertex 10.5394 50.9114 -46.8429
-      vertex 9.53201 50.8689 -47.2475
-      vertex 10.5584 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal -4.49955e-006 -0.994521 0.104534
-    outer loop
-      vertex -9.16971 50.8689 -47.2475
-      vertex -8.58543 50.9055 -46.899
-      vertex -8.94154 50.8982 -46.9684
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104527
-    outer loop
-      vertex -7.98543 50.8689 -47.2475
-      vertex -8.58543 50.9055 -46.899
-      vertex -9.16971 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 1.97546e-006 -0.994522 0.10453
-    outer loop
-      vertex -8.58543 50.9055 -46.899
-      vertex -7.98543 50.8689 -47.2475
-      vertex -8.39432 50.9036 -46.917
-    endloop
-  endfacet
-  facet normal 4.50817e-005 -0.994526 0.104494
-    outer loop
-      vertex -9.16971 50.8689 -47.2475
-      vertex -8.94154 50.8982 -46.9684
-      vertex -9.15521 50.8763 -47.1768
-    endloop
-  endfacet
-  facet normal -6.47143e-006 -0.994523 0.10452
-    outer loop
-      vertex -8.39432 50.9036 -46.917
-      vertex -7.98543 50.8689 -47.2475
-      vertex -8.23566 50.8979 -46.971
-    endloop
-  endfacet
-  facet normal 4.6421e-005 -0.994518 0.104567
-    outer loop
-      vertex -8.23566 50.8979 -46.971
-      vertex -7.98543 50.8689 -47.2475
-      vertex -8.10944 50.8885 -47.061
-    endloop
-  endfacet
-  facet normal -0.000102209 -0.994528 0.104469
-    outer loop
-      vertex -8.10944 50.8885 -47.061
-      vertex -7.98543 50.8689 -47.2475
-      vertex -8.01244 50.8753 -47.1862
-    endloop
-  endfacet
-  facet normal 1.91263e-006 -0.994509 0.104646
-    outer loop
-      vertex -7.43443 50.9492 -46.483
-      vertex -5.98826 50.9475 -46.4992
-      vertex -7.45775 50.9507 -46.4687
-    endloop
-  endfacet
-  facet normal 5.67627e-007 -0.994522 0.104528
-    outer loop
-      vertex -7.19199 50.9213 -46.7491
-      vertex -5.98826 50.9475 -46.4992
-      vertex -7.43443 50.9492 -46.483
-    endloop
-  endfacet
-  facet normal 1.12569e-006 -0.994522 0.104525
-    outer loop
-      vertex -7.02466 50.886 -47.0848
-      vertex -5.98826 50.9475 -46.4992
-      vertex -7.19199 50.9213 -46.7491
-    endloop
-  endfacet
-  facet normal 0 -0.994521 0.104538
-    outer loop
-      vertex -5.96422 50.8689 -47.2475
-      vertex -7.02466 50.886 -47.0848
-      vertex -6.98763 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal -1.29653e-006 -0.994522 0.10453
-    outer loop
-      vertex -7.02466 50.886 -47.0848
-      vertex -5.96422 50.8689 -47.2475
-      vertex -5.98826 50.9475 -46.4992
-    endloop
-  endfacet
-  facet normal 1.40749e-006 -0.994522 0.104528
-    outer loop
-      vertex -5.00615 50.9454 -46.5196
-      vertex -4.36874 50.8973 -46.977
-      vertex -4.36874 50.944 -46.5329
-    endloop
-  endfacet
-  facet normal 5.83475e-007 -0.994522 0.104527
-    outer loop
-      vertex -5.02954 50.8689 -47.2475
-      vertex -4.36874 50.8973 -46.977
-      vertex -5.00615 50.9454 -46.5196
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104529
-    outer loop
-      vertex -2.83774 50.8689 -47.2475
-      vertex -4.36874 50.8973 -46.977
-      vertex -5.02954 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104529
-    outer loop
-      vertex -4.36874 50.8973 -46.977
-      vertex -2.83774 50.8689 -47.2475
-      vertex -2.83774 50.8973 -46.977
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104529
-    outer loop
-      vertex -1.83275 50.8973 -46.977
-      vertex -1.83275 50.8689 -47.2475
-      vertex -0.296738 50.8973 -46.977
-    endloop
-  endfacet
-  facet normal 4.40045e-007 -0.994523 0.10452
-    outer loop
-      vertex -0.296738 50.9351 -46.6176
-      vertex 0.578079 50.9171 -46.789
-      vertex 0.777154 50.9327 -46.6399
-    endloop
-  endfacet
-  facet normal 1.19885e-006 -0.994522 0.104524
-    outer loop
-      vertex -0.296738 50.8973 -46.977
-      vertex 0.578079 50.9171 -46.789
-      vertex -0.296738 50.9351 -46.6176
-    endloop
-  endfacet
-  facet normal 1.20407e-007 -0.994522 0.104529
-    outer loop
-      vertex -0.296738 50.8973 -46.977
-      vertex 0.242497 50.8689 -47.2475
-      vertex 0.578079 50.9171 -46.789
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104529
-    outer loop
-      vertex 0.242497 50.8689 -47.2475
-      vertex -0.296738 50.8973 -46.977
-      vertex -1.83275 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal -1.58882e-007 -0.994522 0.104529
-    outer loop
-      vertex 1.46444 50.8689 -47.2475
-      vertex 2.36508 50.9027 -46.926
-      vertex 1.95354 50.8975 -46.9749
-    endloop
-  endfacet
-  facet normal -3.22839e-006 -0.994523 0.104519
-    outer loop
-      vertex 2.36508 50.9027 -46.926
-      vertex 3.27846 50.8689 -47.2475
-      vertex 2.7823 50.8976 -46.9746
-    endloop
-  endfacet
-  facet normal -1.87861e-006 -0.994522 0.104532
-    outer loop
-      vertex 1.46444 50.8689 -47.2475
-      vertex 1.95354 50.8975 -46.9749
-      vertex 1.6082 50.8821 -47.1216
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104528
-    outer loop
-      vertex 2.36508 50.9027 -46.926
-      vertex 1.46444 50.8689 -47.2475
-      vertex 3.27846 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 7.22106e-006 -0.994521 0.104538
-    outer loop
-      vertex 2.7823 50.8976 -46.9746
-      vertex 3.27846 50.8689 -47.2475
-      vertex 3.1313 50.8823 -47.1202
-    endloop
-  endfacet
-  facet normal -8.66668e-007 -0.994523 0.104518
-    outer loop
-      vertex 4.15109 50.9178 -46.782
-      vertex 5.416 50.9226 -46.7363
-      vertex 4.05128 50.9256 -46.708
-    endloop
-  endfacet
-  facet normal -1.34914e-006 -0.994522 0.104531
-    outer loop
-      vertex 4.49237 50.8689 -47.2475
-      vertex 5.416 50.9226 -46.7363
-      vertex 4.15109 50.9178 -46.782
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.104529
-    outer loop
-      vertex 5.416 50.9226 -46.7363
-      vertex 4.49237 50.8689 -47.2475
-      vertex 5.416 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 6.71076e-007 -0.994522 0.104527
-    outer loop
-      vertex 6.42101 50.8689 -47.2475
-      vertex 8.52701 50.9158 -46.801
-      vertex 6.42101 50.9204 -46.7572
-    endloop
-  endfacet
-  facet normal 0 -0.994522 0.10453
-    outer loop
-      vertex 8.52701 50.9158 -46.801
-      vertex 6.42101 50.8689 -47.2475
-      vertex 8.52701 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal -4.97358e-008 -0.406738 0.913545
-    outer loop
-      vertex -12.3257 46.8541 -51.7063
-      vertex 12.1945 47.1942 -51.5549
-      vertex -11.9688 47.6556 -51.3495
-    endloop
-  endfacet
-  facet normal 0 -0.406741 0.913543
-    outer loop
-      vertex 12.1945 47.1942 -51.5549
-      vertex -12.3257 46.8541 -51.7063
-      vertex 12.3459 46.8541 -51.7063
-    endloop
-  endfacet
   facet normal 0 -1 0
     outer loop
       vertex -13.1512 45 -52
@@ -8168,18 +7440,18 @@ solid OpenSCAD_Model
       vertex 13.1714 45 -52
     endloop
   endfacet
-  facet normal 0.866025 0.5 0
+  facet normal 0.994519 0.10456 0
     outer loop
-      vertex -21.8451 14.0611 -47.6921
-      vertex -22.3677 14.9663 -52
-      vertex -22.3677 14.9663 -47.5325
+      vertex -22.6907 15.9604 -47.3572
+      vertex -22.8 17 -52
+      vertex -22.8 17 -47.1739
     endloop
   endfacet
-  facet normal 0.866025 0.5 0
+  facet normal 0.994519 0.10456 0
     outer loop
-      vertex -22.3677 14.9663 -52
-      vertex -21.8451 14.0611 -47.6921
-      vertex -21.8451 14.0611 -52
+      vertex -22.8 17 -52
+      vertex -22.6907 15.9604 -47.3572
+      vertex -22.6907 15.9604 -52
     endloop
   endfacet
   facet normal 0 1 -0
@@ -8196,84 +7468,84 @@ solid OpenSCAD_Model
       vertex -18.3226 12.0274 -52
     endloop
   endfacet
-  facet normal 0.994522 0.10453 0
+  facet normal 0.587762 0.809034 0
     outer loop
-      vertex -22.6907 15.9604 -47.3572
-      vertex -22.8 17 -52
-      vertex -22.8 17 -47.1739
-    endloop
-  endfacet
-  facet normal 0.994522 0.10453 0
-    outer loop
-      vertex -22.8 17 -52
-      vertex -22.6907 15.9604 -47.3572
-      vertex -22.6907 15.9604 -52
-    endloop
-  endfacet
-  facet normal 0.743145 0.669131 0
-    outer loop
-      vertex -21.1457 13.2843 -47.8291
-      vertex -21.8451 14.0611 -52
-      vertex -21.8451 14.0611 -47.6921
-    endloop
-  endfacet
-  facet normal 0.743145 0.669131 0
-    outer loop
-      vertex -21.8451 14.0611 -52
-      vertex -21.1457 13.2843 -47.8291
       vertex -21.1457 13.2843 -52
+      vertex -20.3 12.6699 -47.9374
+      vertex -20.3 12.6699 -52
     endloop
   endfacet
-  facet normal 0.207911 0.978148 0
+  facet normal 0.587762 0.809034 0
+    outer loop
+      vertex -20.3 12.6699 -47.9374
+      vertex -21.1457 13.2843 -52
+      vertex -21.1457 13.2843 -47.8291
+    endloop
+  endfacet
+  facet normal 0.207876 0.978155 0
     outer loop
       vertex -19.3451 12.2447 -52
       vertex -18.3226 12.0274 -48.0507
       vertex -18.3226 12.0274 -52
     endloop
   endfacet
-  facet normal 0.207911 0.978148 0
+  facet normal 0.207876 0.978155 0
     outer loop
       vertex -18.3226 12.0274 -48.0507
       vertex -19.3451 12.2447 -52
       vertex -19.3451 12.2447 -48.0124
     endloop
   endfacet
-  facet normal 0.587785 0.809017 0
+  facet normal 0.866033 0.499987 0
     outer loop
-      vertex -21.1457 13.2843 -52
-      vertex -20.3 12.6699 -47.9374
-      vertex -20.3 12.6699 -52
+      vertex -21.8451 14.0611 -47.6921
+      vertex -22.3677 14.9663 -52
+      vertex -22.3677 14.9663 -47.5325
     endloop
   endfacet
-  facet normal 0.587785 0.809017 0
+  facet normal 0.866033 0.499987 0
     outer loop
-      vertex -20.3 12.6699 -47.9374
-      vertex -21.1457 13.2843 -52
+      vertex -22.3677 14.9663 -52
+      vertex -21.8451 14.0611 -47.6921
+      vertex -21.8451 14.0611 -52
+    endloop
+  endfacet
+  facet normal 0.743161 0.669113 0
+    outer loop
       vertex -21.1457 13.2843 -47.8291
+      vertex -21.8451 14.0611 -52
+      vertex -21.8451 14.0611 -47.6921
     endloop
   endfacet
-  facet normal 0.951057 0.309016 0
+  facet normal 0.743161 0.669113 0
+    outer loop
+      vertex -21.8451 14.0611 -52
+      vertex -21.1457 13.2843 -47.8291
+      vertex -21.1457 13.2843 -52
+    endloop
+  endfacet
+  facet normal 0.951057 0.309015 0
     outer loop
       vertex -22.3677 14.9663 -47.5325
       vertex -22.6907 15.9604 -52
       vertex -22.6907 15.9604 -47.3572
     endloop
   endfacet
-  facet normal 0.951057 0.309016 0
+  facet normal 0.951057 0.309015 0
     outer loop
       vertex -22.6907 15.9604 -52
       vertex -22.3677 14.9663 -47.5325
       vertex -22.3677 14.9663 -52
     endloop
   endfacet
-  facet normal 0.406737 0.913545 0
+  facet normal 0.406777 0.913527 0
     outer loop
       vertex -20.3 12.6699 -52
       vertex -19.3451 12.2447 -48.0124
       vertex -19.3451 12.2447 -52
     endloop
   endfacet
-  facet normal 0.406737 0.913545 0
+  facet normal 0.406777 0.913527 0
     outer loop
       vertex -19.3451 12.2447 -48.0124
       vertex -20.3 12.6699 -52
@@ -8294,46 +7566,116 @@ solid OpenSCAD_Model
       vertex -17.8 12 -52
     endloop
   endfacet
-  facet normal -0.994522 0.104527 0
+  facet normal -0.994515 0.104592 0
     outer loop
       vertex 22.6907 15.9604 -47.3572
       vertex 22.7727 16.7401 -52
       vertex 22.6907 15.9604 -52
     endloop
   endfacet
-  facet normal -0.994522 0.104528 1.40121e-007
+  facet normal -0.994516 0.104587 -7.44205e-07
     outer loop
       vertex 22.7727 16.7401 -52
       vertex 22.6907 15.9604 -47.3572
       vertex 22.7298 16.3322 -47.2916
     endloop
   endfacet
-  facet normal -0.866025 0.5 0
+  facet normal -0.951057 0.309015 0
     outer loop
-      vertex 21.8451 14.0611 -47.6921
-      vertex 22.3677 14.9663 -52
-      vertex 21.8451 14.0611 -52
-    endloop
-  endfacet
-  facet normal -0.866025 0.5 0
-    outer loop
-      vertex 22.3677 14.9663 -52
-      vertex 21.8451 14.0611 -47.6921
       vertex 22.3677 14.9663 -47.5325
+      vertex 22.6907 15.9604 -52
+      vertex 22.3677 14.9663 -52
     endloop
   endfacet
-  facet normal -0.743145 0.669131 0
+  facet normal -0.951057 0.309015 0
+    outer loop
+      vertex 22.6907 15.9604 -52
+      vertex 22.3677 14.9663 -47.5325
+      vertex 22.6907 15.9604 -47.3572
+    endloop
+  endfacet
+  facet normal -0.994528 0.104466 -1.14105e-05
+    outer loop
+      vertex 22.7298 16.3322 -47.2916
+      vertex 22.8 17 -52
+      vertex 22.7727 16.7401 -52
+    endloop
+  endfacet
+  facet normal -0.99452 0.104545 0
+    outer loop
+      vertex 22.8 17 -52
+      vertex 22.7298 16.3322 -47.2916
+      vertex 22.8 17 -47.1739
+    endloop
+  endfacet
+  facet normal -0.743161 0.669113 0
     outer loop
       vertex 21.1457 13.2843 -47.8291
       vertex 21.8451 14.0611 -52
       vertex 21.1457 13.2843 -52
     endloop
   endfacet
-  facet normal -0.743145 0.669131 0
+  facet normal -0.743161 0.669113 0
     outer loop
       vertex 21.8451 14.0611 -52
       vertex 21.1457 13.2843 -47.8291
       vertex 21.8451 14.0611 -47.6921
+    endloop
+  endfacet
+  facet normal -0.866033 0.499987 0
+    outer loop
+      vertex 21.8451 14.0611 -47.6921
+      vertex 22.3677 14.9663 -52
+      vertex 21.8451 14.0611 -52
+    endloop
+  endfacet
+  facet normal -0.866033 0.499987 0
+    outer loop
+      vertex 22.3677 14.9663 -52
+      vertex 21.8451 14.0611 -47.6921
+      vertex 22.3677 14.9663 -47.5325
+    endloop
+  endfacet
+  facet normal -0.406777 0.913527 0
+    outer loop
+      vertex 20.3 12.6699 -52
+      vertex 19.3451 12.2447 -48.0124
+      vertex 20.3 12.6699 -47.9374
+    endloop
+  endfacet
+  facet normal -0.406777 0.913527 0
+    outer loop
+      vertex 19.3451 12.2447 -48.0124
+      vertex 20.3 12.6699 -52
+      vertex 19.3451 12.2447 -52
+    endloop
+  endfacet
+  facet normal -0.587762 0.809034 0
+    outer loop
+      vertex 21.1457 13.2843 -52
+      vertex 20.3 12.6699 -47.9374
+      vertex 21.1457 13.2843 -47.8291
+    endloop
+  endfacet
+  facet normal -0.587762 0.809034 0
+    outer loop
+      vertex 20.3 12.6699 -47.9374
+      vertex 21.1457 13.2843 -52
+      vertex 20.3 12.6699 -52
+    endloop
+  endfacet
+  facet normal -0.207876 0.978155 0
+    outer loop
+      vertex 19.3451 12.2447 -52
+      vertex 18.3226 12.0274 -48.0507
+      vertex 19.3451 12.2447 -48.0124
+    endloop
+  endfacet
+  facet normal -0.207876 0.978155 0
+    outer loop
+      vertex 18.3226 12.0274 -48.0507
+      vertex 19.3451 12.2447 -52
+      vertex 18.3226 12.0274 -52
     endloop
   endfacet
   facet normal 0 1 -0
@@ -8350,76 +7692,6 @@ solid OpenSCAD_Model
       vertex 17.8 12.0274 -52
     endloop
   endfacet
-  facet normal -0.994522 0.104529 2.56135e-007
-    outer loop
-      vertex 22.7298 16.3322 -47.2916
-      vertex 22.8 17 -52
-      vertex 22.7727 16.7401 -52
-    endloop
-  endfacet
-  facet normal -0.994522 0.104528 0
-    outer loop
-      vertex 22.8 17 -52
-      vertex 22.7298 16.3322 -47.2916
-      vertex 22.8 17 -47.1739
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex 22.3677 14.9663 -47.5325
-      vertex 22.6907 15.9604 -52
-      vertex 22.3677 14.9663 -52
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex 22.6907 15.9604 -52
-      vertex 22.3677 14.9663 -47.5325
-      vertex 22.6907 15.9604 -47.3572
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex 19.3451 12.2447 -52
-      vertex 18.3226 12.0274 -48.0507
-      vertex 19.3451 12.2447 -48.0124
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex 18.3226 12.0274 -48.0507
-      vertex 19.3451 12.2447 -52
-      vertex 18.3226 12.0274 -52
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex 21.1457 13.2843 -52
-      vertex 20.3 12.6699 -47.9374
-      vertex 21.1457 13.2843 -47.8291
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex 20.3 12.6699 -47.9374
-      vertex 21.1457 13.2843 -52
-      vertex 20.3 12.6699 -52
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 20.3 12.6699 -52
-      vertex 19.3451 12.2447 -48.0124
-      vertex 20.3 12.6699 -47.9374
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 19.3451 12.2447 -48.0124
-      vertex 20.3 12.6699 -52
-      vertex 19.3451 12.2447 -52
-    endloop
-  endfacet
   facet normal -1 0 0
     outer loop
       vertex 17.8 12 -48.0555
@@ -8434,574 +7706,574 @@ solid OpenSCAD_Model
       vertex 17.8 12.0274 -48.0507
     endloop
   endfacet
-  facet normal 0 0.173639 -0.984809
+  facet normal 0 0.172555 -0.985
     outer loop
       vertex -17.8 12.0274 -48.0507
       vertex -15.8 12 -48.0555
       vertex -17.8 12 -48.0555
     endloop
   endfacet
-  facet normal 0 0.17365 -0.984807
+  facet normal 0 0.17369 -0.9848
     outer loop
       vertex -8 28.8564 -45.0833
       vertex -8.71125 29.3287 -45
       vertex -6.93917 29.3287 -45
     endloop
   endfacet
-  facet normal -1.13169e-006 0.173648 -0.984808
+  facet normal -1.09354e-05 0.173674 -0.984803
     outer loop
       vertex -10.7061 26.8903 -45.43
       vertex -8.71125 29.3287 -45
       vertex -8 28.8564 -45.0833
     endloop
   endfacet
-  facet normal 0 0.173648 -0.984808
+  facet normal 0 0.173666 -0.984805
     outer loop
       vertex -10.7061 26.8903 -45.43
       vertex -12.0875 29.3287 -45
       vertex -8.71125 29.3287 -45
     endloop
   endfacet
-  facet normal 1.25097e-005 0.173654 -0.984807
+  facet normal -0.00014871 0.173584 -0.984819
     outer loop
       vertex -12.1971 29.3235 -45.0009
       vertex -12.0875 29.3287 -45
       vertex -10.7061 26.8903 -45.43
     endloop
   endfacet
-  facet normal 0 0.173908 -0.984762
+  facet normal 0 0.170541 -0.985351
     outer loop
       vertex -12.0875 29.3287 -45
       vertex -12.1971 29.3235 -45.0009
       vertex -12.1909 29.3287 -45
     endloop
   endfacet
-  facet normal 7.31459e-007 0.173647 -0.984808
+  facet normal -1.53131e-05 0.173663 -0.984805
     outer loop
       vertex -12.9443 24.4046 -45.8683
       vertex -12.1971 29.3235 -45.0009
       vertex -10.7061 26.8903 -45.43
     endloop
   endfacet
-  facet normal -4.411e-007 0.173648 -0.984808
+  facet normal 5.23263e-06 0.17366 -0.984806
     outer loop
       vertex -15.39 29.3287 -45
       vertex -12.1971 29.3235 -45.0009
       vertex -12.9443 24.4046 -45.8683
     endloop
   endfacet
-  facet normal 3.17643e-007 0.173648 -0.984808
+  facet normal -1.49397e-05 0.173629 -0.984811
     outer loop
       vertex -18.6074 28.5191 -45.1428
       vertex -12.9443 24.4046 -45.8683
       vertex -14.6167 21.5078 -46.379
     endloop
   endfacet
-  facet normal 0 0.173908 -0.984762
+  facet normal 0 0.170541 -0.985351
     outer loop
       vertex -12.1971 29.3235 -45.0009
       vertex -15.39 29.3287 -45
       vertex -12.2016 29.3287 -45
     endloop
   endfacet
-  facet normal 2.39212e-007 0.173648 -0.984808
+  facet normal 1.10254e-05 0.173665 -0.984805
     outer loop
       vertex -21.0115 24.3549 -45.877
       vertex -14.6167 21.5078 -46.379
       vertex -15.6504 18.3266 -46.94
     endloop
   endfacet
-  facet normal 0 0.173649 -0.984808
+  facet normal 0 0.173637 -0.98481
     outer loop
       vertex -15.8 17 -47.1739
       vertex -15.6504 18.3266 -46.94
       vertex -15.7898 17 -47.1739
     endloop
   endfacet
-  facet normal 1.83281e-007 0.173649 -0.984808
+  facet normal -1.27229e-05 0.173639 -0.984809
     outer loop
       vertex -22.4974 19.782 -46.6833
       vertex -15.6504 18.3266 -46.94
       vertex -15.8 17 -47.1739
     endloop
   endfacet
-  facet normal 1.31785e-007 0.173648 -0.984808
+  facet normal 1.53473e-05 0.173642 -0.984809
     outer loop
       vertex -15.8 12 -48.0555
       vertex -17.8 12.0274 -48.0507
       vertex -15.8 17 -47.1739
     endloop
   endfacet
-  facet normal 0 0.173648 -0.984808
+  facet normal 0 0.173647 -0.984808
     outer loop
       vertex -18.3226 12.0274 -48.0507
       vertex -15.8 17 -47.1739
       vertex -17.8 12.0274 -48.0507
     endloop
   endfacet
-  facet normal 4.85815e-008 0.173648 -0.984808
+  facet normal -2.57662e-06 0.173636 -0.98481
     outer loop
       vertex -18.6074 28.5191 -45.1428
       vertex -14.6167 21.5078 -46.379
       vertex -21.0115 24.3549 -45.877
     endloop
   endfacet
-  facet normal 1.56e-006 0.173647 -0.984808
+  facet normal 1.3648e-05 0.173641 -0.984809
     outer loop
       vertex -15.8 17 -47.1739
       vertex -18.3226 12.0274 -48.0507
       vertex -19.3451 12.2447 -48.0124
     endloop
   endfacet
-  facet normal 0 0.173649 -0.984808
+  facet normal 0 0.173702 -0.984798
     outer loop
       vertex -15.39 29.3287 -45
       vertex -18.6074 28.5191 -45.1428
       vertex -17.8784 29.3287 -45
     endloop
   endfacet
-  facet normal 5.07542e-008 0.173648 -0.984808
+  facet normal -1.90995e-05 0.173664 -0.984805
     outer loop
       vertex -15.8 17 -47.1739
       vertex -19.3451 12.2447 -48.0124
       vertex -20.3 12.6699 -47.9374
     endloop
   endfacet
-  facet normal -9.84235e-007 0.173649 -0.984808
+  facet normal 2.21533e-05 0.173623 -0.984812
     outer loop
       vertex -21.1457 13.2843 -47.8291
       vertex -15.8 17 -47.1739
       vertex -20.3 12.6699 -47.9374
     endloop
   endfacet
-  facet normal 2.13891e-007 0.173648 -0.984808
+  facet normal 1.02664e-05 0.173662 -0.984805
     outer loop
       vertex -12.9443 24.4046 -45.8683
       vertex -18.6074 28.5191 -45.1428
       vertex -15.39 29.3287 -45
     endloop
   endfacet
-  facet normal -9.30018e-008 0.173648 -0.984808
+  facet normal -1.33528e-05 0.173672 -0.984803
     outer loop
       vertex -21.8451 14.0611 -47.6921
       vertex -15.8 17 -47.1739
       vertex -21.1457 13.2843 -47.8291
     endloop
   endfacet
-  facet normal 6.42858e-008 0.173648 -0.984808
+  facet normal 3.68185e-06 0.173638 -0.984809
     outer loop
       vertex -22.3677 14.9663 -47.5325
       vertex -15.8 17 -47.1739
       vertex -21.8451 14.0611 -47.6921
     endloop
   endfacet
-  facet normal 4.56872e-007 0.173647 -0.984808
+  facet normal -3.20007e-06 0.17366 -0.984806
     outer loop
       vertex -22.6907 15.9604 -47.3572
       vertex -15.8 17 -47.1739
       vertex -22.3677 14.9663 -47.5325
     endloop
   endfacet
-  facet normal 1.0863e-007 0.173648 -0.984808
+  facet normal -1.10154e-05 0.173646 -0.984808
     outer loop
       vertex -15.6504 18.3266 -46.94
       vertex -22.4974 19.782 -46.6833
       vertex -21.0115 24.3549 -45.877
     endloop
   endfacet
-  facet normal 0 0.17365 -0.984808
+  facet normal 0 0.173639 -0.984809
     outer loop
       vertex -15.8 17 -47.1739
       vertex -22.6907 15.9604 -47.3572
       vertex -22.7898 17 -47.1739
     endloop
   endfacet
-  facet normal 0 0.173648 -0.984808
+  facet normal 0 0.173668 -0.984804
     outer loop
       vertex -15.8 17 -47.1739
       vertex -22.7898 17 -47.1739
       vertex -22.4974 19.782 -46.6833
     endloop
   endfacet
-  facet normal -0.000129774 0.173638 -0.98481
+  facet normal 0 0.173639 -0.984809
     outer loop
       vertex -22.8 17 -47.1739
       vertex -22.7898 17 -47.1739
       vertex -22.6907 15.9604 -47.3572
     endloop
   endfacet
-  facet normal 0 0.173639 -0.984809
+  facet normal 0 0.172555 -0.985
     outer loop
       vertex 17.8 12 -48.0555
       vertex 15.8 12 -48.0555
       vertex 17.8 12.0274 -48.0507
     endloop
   endfacet
-  facet normal 0.000129775 0.173639 -0.984809
+  facet normal 0 0.173575 -0.984821
     outer loop
       vertex 22.7298 16.3322 -47.2916
       vertex 22.7898 17 -47.1739
       vertex 22.8 17 -47.1739
     endloop
   endfacet
-  facet normal -1.46326e-007 0.173649 -0.984808
+  facet normal 1.7716e-05 0.173753 -0.984789
     outer loop
       vertex 15.8 17 -47.1739
       vertex 22.7298 16.3322 -47.2916
       vertex 22.6907 15.9604 -47.3572
     endloop
   endfacet
-  facet normal 0 0.17365 -0.984807
+  facet normal 0 0.173575 -0.984821
     outer loop
       vertex 22.7298 16.3322 -47.2916
       vertex 15.8 17 -47.1739
       vertex 22.7898 17 -47.1739
     endloop
   endfacet
-  facet normal -4.56872e-007 0.173647 -0.984808
+  facet normal 3.20007e-06 0.17366 -0.984806
     outer loop
       vertex 15.8 17 -47.1739
       vertex 22.6907 15.9604 -47.3572
       vertex 22.3677 14.9663 -47.5325
     endloop
   endfacet
-  facet normal -6.42858e-008 0.173648 -0.984808
+  facet normal -3.68185e-06 0.173638 -0.984809
     outer loop
       vertex 15.8 17 -47.1739
       vertex 22.3677 14.9663 -47.5325
       vertex 21.8451 14.0611 -47.6921
     endloop
   endfacet
-  facet normal 9.30018e-008 0.173648 -0.984808
+  facet normal 1.33528e-05 0.173672 -0.984803
     outer loop
       vertex 15.8 17 -47.1739
       vertex 21.8451 14.0611 -47.6921
       vertex 21.1457 13.2843 -47.8291
     endloop
   endfacet
-  facet normal 0 0.173648 -0.984808
+  facet normal 0 0.173668 -0.984804
     outer loop
       vertex 22.7898 17 -47.1739
       vertex 15.8 17 -47.1739
       vertex 22.4974 19.782 -46.6833
     endloop
   endfacet
-  facet normal 9.84235e-007 0.173649 -0.984808
+  facet normal -2.21533e-05 0.173623 -0.984812
     outer loop
       vertex 15.8 17 -47.1739
       vertex 21.1457 13.2843 -47.8291
       vertex 20.3 12.6699 -47.9374
     endloop
   endfacet
-  facet normal -5.07542e-008 0.173648 -0.984808
+  facet normal 1.90995e-05 0.173664 -0.984805
     outer loop
       vertex 15.8 17 -47.1739
       vertex 20.3 12.6699 -47.9374
       vertex 19.3451 12.2447 -48.0124
     endloop
   endfacet
-  facet normal -1.83281e-007 0.173649 -0.984808
+  facet normal 1.27229e-05 0.173639 -0.984809
     outer loop
       vertex 22.4974 19.782 -46.6833
       vertex 15.8 17 -47.1739
       vertex 15.6504 18.3266 -46.94
     endloop
   endfacet
-  facet normal -1.56001e-006 0.173647 -0.984808
+  facet normal -1.3648e-05 0.173641 -0.984809
     outer loop
       vertex 15.8 17 -47.1739
       vertex 19.3451 12.2447 -48.0124
       vertex 18.3226 12.0274 -48.0507
     endloop
   endfacet
-  facet normal -2.39212e-007 0.173648 -0.984808
+  facet normal -1.10254e-05 0.173665 -0.984805
     outer loop
       vertex 14.6167 21.5078 -46.379
       vertex 21.0115 24.3549 -45.877
       vertex 15.6504 18.3266 -46.94
     endloop
   endfacet
-  facet normal 0 0.173648 -0.984808
+  facet normal 0 0.173647 -0.984808
     outer loop
       vertex 15.8 17 -47.1739
       vertex 18.3226 12.0274 -48.0507
       vertex 17.8 12.0274 -48.0507
     endloop
   endfacet
-  facet normal -1.31785e-007 0.173648 -0.984808
+  facet normal -1.53473e-05 0.173642 -0.984809
     outer loop
       vertex 15.8 17 -47.1739
       vertex 17.8 12.0274 -48.0507
       vertex 15.8 12 -48.0555
     endloop
   endfacet
-  facet normal -1.0863e-007 0.173648 -0.984808
+  facet normal 1.10154e-05 0.173646 -0.984808
     outer loop
       vertex 22.4974 19.782 -46.6833
       vertex 15.6504 18.3266 -46.94
       vertex 21.0115 24.3549 -45.877
     endloop
   endfacet
-  facet normal 0 0.173649 -0.984808
+  facet normal 0 0.173637 -0.98481
     outer loop
       vertex 15.6504 18.3266 -46.94
       vertex 15.8 17 -47.1739
       vertex 15.7898 17 -47.1739
     endloop
   endfacet
-  facet normal -4.85815e-008 0.173648 -0.984808
+  facet normal 2.57662e-06 0.173636 -0.98481
     outer loop
       vertex 21.0115 24.3549 -45.877
       vertex 14.6167 21.5078 -46.379
       vertex 18.6074 28.5191 -45.1428
     endloop
   endfacet
-  facet normal -3.17643e-007 0.173648 -0.984808
+  facet normal 1.49397e-05 0.173629 -0.984811
     outer loop
       vertex 12.9443 24.4046 -45.8683
       vertex 18.6074 28.5191 -45.1428
       vertex 14.6167 21.5078 -46.379
     endloop
   endfacet
-  facet normal -2.13891e-007 0.173648 -0.984808
+  facet normal -1.02664e-05 0.173662 -0.984805
     outer loop
       vertex 15.39 29.3287 -45
       vertex 18.6074 28.5191 -45.1428
       vertex 12.9443 24.4046 -45.8683
     endloop
   endfacet
-  facet normal 0 0.173649 -0.984808
+  facet normal 0 0.173702 -0.984798
     outer loop
       vertex 18.6074 28.5191 -45.1428
       vertex 15.39 29.3287 -45
       vertex 17.8784 29.3287 -45
     endloop
   endfacet
-  facet normal 0 0.173648 -0.984808
+  facet normal 0 0.173658 -0.984806
     outer loop
       vertex 12.9443 24.4046 -45.8683
       vertex 12.0875 29.3287 -45
       vertex 15.39 29.3287 -45
     endloop
   endfacet
-  facet normal -3.59884e-007 0.173648 -0.984808
+  facet normal 1.1107e-05 0.173659 -0.984806
     outer loop
       vertex 10.7061 26.8903 -45.43
       vertex 12.0875 29.3287 -45
       vertex 12.9443 24.4046 -45.8683
     endloop
   endfacet
-  facet normal 0 0.173648 -0.984808
+  facet normal 0 0.173666 -0.984805
     outer loop
       vertex 10.7061 26.8903 -45.43
       vertex 8.71125 29.3287 -45
       vertex 12.0875 29.3287 -45
     endloop
   endfacet
-  facet normal 1.13169e-006 0.173648 -0.984808
+  facet normal 1.09354e-05 0.173674 -0.984803
     outer loop
       vertex 8 28.8564 -45.0833
       vertex 8.71125 29.3287 -45
       vertex 10.7061 26.8903 -45.43
     endloop
   endfacet
-  facet normal 0 0.17365 -0.984807
+  facet normal 0 0.17369 -0.9848
     outer loop
       vertex 8.71125 29.3287 -45
       vertex 8 28.8564 -45.0833
       vertex 6.93917 29.3287 -45
     endloop
   endfacet
-  facet normal 0.913542 -0.406743 0
+  facet normal 0.91328 -0.407332 0
     outer loop
       vertex -10.4798 51 -45
       vertex -10.4988 50.9574 -46.4055
       vertex -10.4798 51 -46
     endloop
   endfacet
-  facet normal 0.913546 -0.406736 -2.6104e-007
+  facet normal 0.913553 -0.406719 -2.22724e-05
     outer loop
       vertex -13.1512 45 -51.9671
       vertex -10.4988 50.9574 -46.4055
       vertex -10.4798 51 -45
     endloop
   endfacet
-  facet normal 0.913546 -0.406736 -1.59911e-007
+  facet normal 0.913537 -0.406756 2.60566e-05
     outer loop
       vertex -11.9688 47.6556 -51.3495
       vertex -10.4988 50.9574 -46.4055
       vertex -13.1512 45 -51.9671
     endloop
   endfacet
-  facet normal 0.913542 -0.406745 2.30656e-006
+  facet normal 0.913632 -0.406543 -2.14765e-05
     outer loop
       vertex -10.4988 50.9574 -46.4055
       vertex -10.7107 50.4813 -48.4404
       vertex -10.5382 50.8689 -47.2475
     endloop
   endfacet
-  facet normal 0.913544 -0.406739 2.65159e-006
+  facet normal 0.913589 -0.406638 -0.000112553
     outer loop
       vertex -10.7107 50.4813 -48.4404
       vertex -11.6775 48.3099 -50.971
       vertex -10.99 49.8541 -49.5267
     endloop
   endfacet
-  facet normal 0.913544 -0.406741 5.10638e-006
+  facet normal 0.913618 -0.406573 -0.000196106
     outer loop
       vertex -10.99 49.8541 -49.5267
       vertex -11.6775 48.3099 -50.971
       vertex -11.3637 49.0148 -50.4589
     endloop
   endfacet
-  facet normal 0.913546 -0.406736 -6.79511e-008
+  facet normal 0.913519 -0.406795 4.94087e-05
     outer loop
       vertex -10.7107 50.4813 -48.4404
       vertex -10.4988 50.9574 -46.4055
       vertex -11.6775 48.3099 -50.971
     endloop
   endfacet
-  facet normal 0.913544 -0.406741 8.24572e-006
+  facet normal 0.91368 -0.406435 -0.000593792
     outer loop
       vertex -11.6775 48.3099 -50.971
       vertex -11.9688 47.6556 -51.3495
       vertex -11.8155 48 -51.1962
     endloop
   endfacet
-  facet normal 0.913545 -0.406737 2.10259e-007
+  facet normal 0.913553 -0.40672 -3.06492e-06
     outer loop
       vertex -11.6775 48.3099 -50.971
       vertex -10.4988 50.9574 -46.4055
       vertex -11.9688 47.6556 -51.3495
     endloop
   endfacet
-  facet normal 0.913545 -0.406737 5.08335e-006
+  facet normal 0.913555 -0.406716 -0.000181778
     outer loop
       vertex -11.9688 47.6556 -51.3495
       vertex -13.1512 45 -51.9671
       vertex -12.3257 46.8541 -51.7063
     endloop
   endfacet
-  facet normal 0.913546 -0.406736 -5.46315e-006
+  facet normal 0.913517 -0.4068 0.000539095
     outer loop
       vertex -12.3257 46.8541 -51.7063
       vertex -13.1512 45 -51.9671
       vertex -12.8719 45.6272 -51.9671
     endloop
   endfacet
-  facet normal 0.913545 -0.406737 8.86068e-008
+  facet normal 0.913546 -0.406735 -5.83399e-06
     outer loop
       vertex -17 36.3553 -45
       vertex -13.1512 45 -51.9671
       vertex -10.4798 51 -45
     endloop
   endfacet
-  facet normal 0.913545 -0.406737 0
+  facet normal 0.913548 -0.406731 0
     outer loop
       vertex -17 36.3553 -52
       vertex -13.1512 45 -51.9671
       vertex -17 36.3553 -45
     endloop
   endfacet
-  facet normal 0.913545 -0.406737 0
+  facet normal 0.913548 -0.406731 0
     outer loop
       vertex -13.1512 45 -51.9671
       vertex -17 36.3553 -52
       vertex -13.1512 45 -52
     endloop
   endfacet
-  facet normal -0.913545 -0.406737 0
+  facet normal -0.913546 -0.406736 0
     outer loop
       vertex 13.1714 45 -52
       vertex 17 36.4008 -52
       vertex 13.1714 45 -51.9671
     endloop
   endfacet
-  facet normal -0.913545 -0.406737 1.9963e-007
+  facet normal -0.913523 -0.406788 5.76994e-05
     outer loop
       vertex 13.1714 45 -51.9671
       vertex 10.5 51 -46
       vertex 10.5394 50.9114 -46.8429
     endloop
   endfacet
-  facet normal -0.913546 -0.406734 -1.06526e-006
+  facet normal -0.913804 -0.406155 -0.000248848
     outer loop
       vertex 10.731 50.4813 -48.4404
       vertex 10.5394 50.9114 -46.8429
       vertex 10.5584 50.8689 -47.2475
     endloop
   endfacet
-  facet normal -0.913546 -0.406736 -5.38795e-007
+  facet normal -0.913607 -0.406599 -0.000105767
     outer loop
       vertex 10.5394 50.9114 -46.8429
       vertex 10.731 50.4813 -48.4404
       vertex 11.523 48.7023 -50.6859
     endloop
   endfacet
-  facet normal -0.913544 -0.40674 3.36843e-006
+  facet normal -0.91352 -0.406794 7.94744e-05
     outer loop
       vertex 11.523 48.7023 -50.6859
       vertex 10.731 50.4813 -48.4404
       vertex 11.0102 49.8541 -49.5267
     endloop
   endfacet
-  facet normal -0.913544 -0.406739 1.81206e-006
+  facet normal -0.913667 -0.406463 -0.000313828
     outer loop
       vertex 11.523 48.7023 -50.6859
       vertex 11.0102 49.8541 -49.5267
       vertex 11.3839 49.0148 -50.4589
     endloop
   endfacet
-  facet normal -0.913546 -0.406736 -2.94275e-007
+  facet normal -0.913544 -0.40674 -8.16268e-06
     outer loop
       vertex 10.5394 50.9114 -46.8429
       vertex 11.523 48.7023 -50.6859
       vertex 13.1714 45 -51.9671
     endloop
   endfacet
-  facet normal -0.913547 -0.406734 -5.10751e-006
+  facet normal -0.91352 -0.406794 6.64129e-05
     outer loop
       vertex 12.1945 47.1942 -51.5549
       vertex 11.523 48.7023 -50.6859
       vertex 11.8357 48 -51.1962
     endloop
   endfacet
-  facet normal -0.913546 -0.406737 3.17016e-007
+  facet normal -0.913556 -0.406714 -0.000101235
     outer loop
       vertex 13.1714 45 -51.9671
       vertex 11.523 48.7023 -50.6859
       vertex 12.1945 47.1942 -51.5549
     endloop
   endfacet
-  facet normal -0.913544 -0.406739 1.20428e-005
+  facet normal -0.913552 -0.406722 9.37512e-05
     outer loop
       vertex 12.8921 45.6272 -51.9671
       vertex 12.1945 47.1942 -51.5549
       vertex 12.3459 46.8541 -51.7063
     endloop
   endfacet
-  facet normal -0.913546 -0.406736 -2.10276e-006
+  facet normal -0.913517 -0.4068 0.000453628
     outer loop
       vertex 12.1945 47.1942 -51.5549
       vertex 12.8921 45.6272 -51.9671
       vertex 13.1714 45 -51.9671
     endloop
   endfacet
-  facet normal -0.913545 -0.406737 0
+  facet normal -0.913544 -0.40674 0
     outer loop
       vertex 10.5 51 -46
       vertex 13.1714 45 -51.9671
       vertex 10.5 51 -45
     endloop
   endfacet
-  facet normal -0.913545 -0.406737 -0
+  facet normal -0.913546 -0.406736 -0
     outer loop
       vertex 17 36.4008 -45
       vertex 13.1714 45 -51.9671
       vertex 17 36.4008 -52
     endloop
   endfacet
-  facet normal -0.913545 -0.406737 7.78239e-008
+  facet normal -0.913545 -0.406738 -2.72032e-06
     outer loop
       vertex 13.1714 45 -51.9671
       vertex 17 36.4008 -45
@@ -9190,508 +8462,81 @@ solid OpenSCAD_Model
       vertex 12.25 44 -45
     endloop
   endfacet
-  facet normal -0.994522 0.104529 5.21822e-007
+  facet normal -0.994525 0.104495 -4.99444e-05
     outer loop
       vertex 16.8408 13.4852 -53
       vertex 16.6847 12 -52
       vertex 16.7877 12.9803 -52
     endloop
   endfacet
-  facet normal -0.994522 0.104528 -9.39778e-007
+  facet normal -0.994521 0.104539 1.61461e-05
     outer loop
       vertex 16.6285 11.4655 -53
       vertex 16.6847 12 -52
       vertex 16.8408 13.4852 -53
     endloop
   endfacet
-  facet normal -0.994522 0.104527 0
+  facet normal -0.994518 0.104569 0
     outer loop
       vertex 16.6285 11.4655 -53
       vertex 16.6847 12 -50.0586
       vertex 16.6847 12 -52
     endloop
   endfacet
-  facet normal -0.994522 0.104527 0
+  facet normal -0.994518 0.104569 0
     outer loop
       vertex 16.6847 12 -50.0586
       vertex 16.6285 11.4655 -53
       vertex 16.6285 11.4655 -49
     endloop
   endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8 16.4296 -49
-      vertex 15.7898 17 -49
-      vertex 15.8 17 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.3694 16.3537 -49
-      vertex 15.7898 17 -49
-      vertex 15.8 16.4296 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 15.7898 17 -49
-      vertex 15.3694 16.3537 -49
-      vertex 15.7825 17.0692 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.2401 14.3977 -49
-      vertex 15.8 13.3483 -49
-      vertex 15.0152 12.2682 -49
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 14.7167 15.2232 -49
-      vertex 15.8 13.3483 -49
-      vertex 14.2401 14.3977 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8 13.3483 -49
-      vertex 14.7167 15.2232 -49
-      vertex 15.8 15.4142 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.2094 11 -49
-      vertex -15.8 12 -49
-      vertex -15.4199 11 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -16.6285 11.4655 -49
-      vertex -15.8 12 -49
-      vertex -16.2094 11 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.8 12 -49
-      vertex -16.6285 11.4655 -49
-      vertex -16.6847 12 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.8 12 -49
-      vertex -14.9773 12.216 -49
-      vertex -15.4199 11 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.9773 12.216 -49
-      vertex -15.8 12 -49
-      vertex -15.8 13.3483 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.6285 11.4655 -49
-      vertex 16.4773 11 -49
-      vertex 16.2094 11 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8 12 -49
-      vertex 16.6285 11.4655 -49
-      vertex 16.2094 11 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 16.6285 11.4655 -49
-      vertex 15.8 12 -49
-      vertex 16.6847 12 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.4768 11 -49
-      vertex 15.8 12 -49
-      vertex 16.2094 11 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.0152 12.2682 -49
-      vertex 15.8 12 -49
-      vertex 15.4768 11 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.8 12 -49
-      vertex 15.0152 12.2682 -49
-      vertex 15.8 13.3483 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.583 22.9715 -49
-      vertex 13.3397 23.7196 -49
-      vertex 12.5127 21.1741 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 13.3397 23.7196 -49
-      vertex 11.583 22.9715 -49
-      vertex 13.1416 24.0628 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.3262 23.229 -49
-      vertex 11.583 22.9715 -49
-      vertex 12.5127 21.1741 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.3262 23.229 -49
-      vertex 11.0095 23.7907 -49
-      vertex 11.583 22.9715 -49
-    endloop
-  endfacet
-  facet normal -0 -0 -1
-    outer loop
-      vertex 11.0095 23.7907 -49
-      vertex 11.3262 23.229 -49
-      vertex 10.6085 24.0262 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.6085 24.0262 -49
-      vertex 12.5351 24.859 -49
-      vertex 11.0095 23.7907 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.5351 24.859 -49
-      vertex 10.6085 24.0262 -49
-      vertex 11.1196 26.431 -49
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 16.7877 17.0197 -53
-      vertex 16.6285 18.5345 -52
-      vertex 16.6285 18.5345 -53
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 -1.11379e-006
-    outer loop
-      vertex 16.8306 16.6114 -52.1913
-      vertex 16.6285 18.5345 -52
-      vertex 16.7877 17.0197 -53
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104528 0
-    outer loop
-      vertex 16.6285 18.5345 -52
-      vertex 16.8306 16.6114 -52.1913
-      vertex 16.8306 16.6114 -52
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.77698 31.9069 -53
-      vertex -0.4 31.9069 -52
-      vertex -1.77698 31.9069 -52
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -0.4 31.9069 -52
-      vertex -1.77698 31.9069 -53
-      vertex -0.4 31.9069 -53
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 0.4 31.9069 -53
-      vertex 1.77698 31.9069 -52
-      vertex 0.4 31.9069 -52
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 1.77698 31.9069 -52
-      vertex 0.4 31.9069 -53
-      vertex 1.77698 31.9069 -53
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.4634 28.9233 -49
-      vertex -0.4 29 -49
-      vertex 0.4 29 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -0.4 29 -49
-      vertex 1.4634 28.9233 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -0.4 30 -49
-      vertex -0.4 29 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -1.9774 30 -49
-      vertex -0.4 30 -49
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -1.9774 30 -49
-      vertex -1.4634 28.9233 -49
-      vertex -2.1049 28.787 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.4634 28.9233 -49
-      vertex 1.9774 30 -49
-      vertex 2.1049 28.787 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.4 30 -49
-      vertex 1.4634 28.9233 -49
-      vertex 0.4 29 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.4634 28.9233 -49
-      vertex 0.4 30 -49
-      vertex 1.9774 30 -49
-    endloop
-  endfacet
-  facet normal 0.951056 0.309018 0
+  facet normal 0.951087 0.308924 0
     outer loop
       vertex -16.4773 11 -49
       vertex -16.6285 11.4655 -53
       vertex -16.6285 11.4655 -49
     endloop
   endfacet
-  facet normal 0.951056 0.309018 0
+  facet normal 0.951087 0.308924 0
     outer loop
       vertex -16.6285 11.4655 -53
       vertex -16.4773 11 -49
       vertex -16.4773 11 -53
     endloop
   endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 7 27.1244 -49
-      vertex 8.37996 28.5803 -49
-      vertex 8.13989 26.2962 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 8.37996 28.5803 -49
-      vertex 7 27.1244 -49
-      vertex 8 28.8564 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.67638 27.9185 -49
-      vertex 8 28.8564 -49
-      vertex 7 27.1244 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 8 28.8564 -49
-      vertex 5.67638 27.9185 -49
-      vertex 6.14856 29.6807 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 5.25329 27.902 -49
-      vertex 5.67638 27.9185 -49
-      vertex 7 27.1244 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 5.67638 27.9185 -49
-      vertex 5.25329 27.902 -49
-      vertex 5.25329 28.0319 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.3262 23.229 -49
-      vertex -11.0095 23.7907 -49
-      vertex -10.6085 24.0262 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -11.3262 23.229 -49
-      vertex -11.583 22.9715 -49
-      vertex -11.0095 23.7907 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.5127 21.1741 -49
-      vertex -11.583 22.9715 -49
-      vertex -11.3262 23.229 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.3397 23.7196 -49
-      vertex -11.583 22.9715 -49
-      vertex -12.5127 21.1741 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -11.583 22.9715 -49
-      vertex -13.3397 23.7196 -49
-      vertex -13.1416 24.0628 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.5351 24.859 -49
-      vertex -10.6085 24.0262 -49
-      vertex -11.0095 23.7907 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -10.6085 24.0262 -49
-      vertex -12.5351 24.859 -49
-      vertex -11.1196 26.431 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.2409 16.1311 -49
-      vertex -15.7898 17 -49
-      vertex -15.7825 17.0692 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.8 16.2296 -49
-      vertex -15.7898 17 -49
-      vertex -15.2409 16.1311 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -15.7898 17 -49
-      vertex -15.8 16.2296 -49
-      vertex -15.8 17 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.8 13.3483 -49
-      vertex -14.2052 14.3372 -49
-      vertex -14.9773 12.216 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.2052 14.3372 -49
-      vertex -15.8 13.3483 -49
-      vertex -14.5882 15.0005 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.5882 15.0005 -49
-      vertex -15.8 13.3483 -49
-      vertex -15.8 15.2142 -49
-    endloop
-  endfacet
-  facet normal 0.207912 -0.978148 0
-    outer loop
-      vertex -5.25329 31.168 -53
-      vertex -1.77698 31.9069 -52
-      vertex -5.25329 31.168 -52
-    endloop
-  endfacet
-  facet normal 0.207912 -0.978148 0
-    outer loop
-      vertex -1.77698 31.9069 -52
-      vertex -5.25329 31.168 -53
-      vertex -1.77698 31.9069 -53
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
+  facet normal -0.951087 0.308924 0
     outer loop
       vertex 16.4773 11 -53
       vertex 16.6285 11.4655 -49
       vertex 16.6285 11.4655 -53
     endloop
   endfacet
-  facet normal -0.951056 0.309018 0
+  facet normal -0.951087 0.308924 0
     outer loop
       vertex 16.6285 11.4655 -49
       vertex 16.4773 11 -53
       vertex 16.4773 11 -49
     endloop
   endfacet
-  facet normal 0.994522 -0.104528 0
+  facet normal -0.994518 0.104569 0
     outer loop
-      vertex -16.87 16.2366 -52
-      vertex -16.6285 18.5345 -53
-      vertex -16.6285 18.5345 -52
+      vertex 16.6847 12 -49
+      vertex 16.6847 12 -50.0586
+      vertex 16.6285 11.4655 -49
     endloop
   endfacet
-  facet normal 0.994522 -0.104528 0
+  facet normal -0.994523 0.104521 0
     outer loop
-      vertex -16.6285 18.5345 -53
-      vertex -16.87 16.2366 -52
-      vertex -16.87 16.2366 -53
+      vertex 16.8408 13.4852 -53
+      vertex 17 15 -52
+      vertex 17 15 -53
     endloop
   endfacet
-  facet normal 0.994522 -0.104528 0
+  facet normal -0.994521 0.104539 -2.74765e-05
     outer loop
-      vertex -17 15 -52
-      vertex -16.9561 15.4181 -53
-      vertex -16.9561 15.4181 -52
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104528 0
-    outer loop
-      vertex -16.9561 15.4181 -53
-      vertex -17 15 -52
-      vertex -17 15 -53
+      vertex 17 15 -52
+      vertex 16.8408 13.4852 -53
+      vertex 16.7877 12.9803 -52
     endloop
   endfacet
   facet normal 0 0 -1
@@ -9701,74 +8546,32 @@ solid OpenSCAD_Model
       vertex -16.6285 11.4655 -49
     endloop
   endfacet
-  facet normal -0.994522 0.104527 0
+  facet normal 0.951059 -0.30901 0
     outer loop
-      vertex 16.6847 12 -49
-      vertex 16.6847 12 -50.0586
-      vertex 16.6285 11.4655 -49
+      vertex -16.6285 18.5345 -52
+      vertex -15.5303 21.9145 -53
+      vertex -15.5303 21.9145 -52
     endloop
   endfacet
-  facet normal -0.994522 0.104528 -9.96861e-008
+  facet normal 0.951059 -0.30901 0
     outer loop
-      vertex 16.8408 13.4852 -53
-      vertex 17 15 -52
-      vertex 17 15 -53
+      vertex -15.5303 21.9145 -53
+      vertex -16.6285 18.5345 -52
+      vertex -16.6285 18.5345 -53
     endloop
   endfacet
-  facet normal -0.994522 0.104528 0
+  facet normal -0.951059 -0.30901 0
     outer loop
-      vertex 17 15 -52
-      vertex 16.8408 13.4852 -53
-      vertex 16.7877 12.9803 -52
+      vertex 16.6285 18.5345 -53
+      vertex 15.5303 21.9145 -52
+      vertex 15.5303 21.9145 -53
     endloop
   endfacet
-  facet normal -0.994522 -0.104525 0
+  facet normal -0.951059 -0.30901 0
     outer loop
-      vertex 16.8306 16.6114 -53
-      vertex 16.8306 16.6114 -52.1913
-      vertex 16.7877 17.0197 -53
-    endloop
-  endfacet
-  facet normal -0.994522 -0.10453 0
-    outer loop
-      vertex 16.9354 15.6144 -53
-      vertex 17 15 -52
-      vertex 16.9354 15.6144 -52
-    endloop
-  endfacet
-  facet normal -0.994522 -0.10453 9.96873e-008
-    outer loop
-      vertex 17 15 -52
-      vertex 16.9354 15.6144 -53
-      vertex 17 15 -53
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.36783 25.404 -49
-      vertex 11.1196 26.431 -49
-      vertex 10.6085 24.0262 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 11.1196 26.431 -49
-      vertex 9.36783 25.404 -49
-      vertex 10.7061 26.8903 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.13989 26.2962 -49
-      vertex 10.7061 26.8903 -49
-      vertex 9.36783 25.404 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 10.7061 26.8903 -49
-      vertex 8.13989 26.2962 -49
-      vertex 8.37996 28.5803 -49
+      vertex 15.5303 21.9145 -52
+      vertex 16.6285 18.5345 -53
+      vertex 16.6285 18.5345 -52
     endloop
   endfacet
   facet normal 0 0 -1
@@ -9806,235 +8609,32 @@ solid OpenSCAD_Model
       vertex 5.19884 30 -49
     endloop
   endfacet
-  facet normal -0.866025 -0.5 0
-    outer loop
-      vertex 15.5303 21.9145 -53
-      vertex 13.9594 24.6354 -52
-      vertex 13.9594 24.6354 -53
-    endloop
-  endfacet
-  facet normal -0.866025 -0.5 0
-    outer loop
-      vertex 13.9594 24.6354 -52
-      vertex 15.5303 21.9145 -53
-      vertex 15.5303 21.9145 -52
-    endloop
-  endfacet
-  facet normal -0.406736 -0.913546 0
-    outer loop
-      vertex 5.25329 31.168 -53
-      vertex 5.48424 31.0651 -52
-      vertex 5.25329 31.168 -52
-    endloop
-  endfacet
-  facet normal -0.406736 -0.913546 -0
-    outer loop
-      vertex 5.48424 31.0651 -52
-      vertex 5.25329 31.168 -53
-      vertex 5.48424 31.0651 -53
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 0
-    outer loop
-      vertex 6.40917 30.6533 -53
-      vertex 8.5 29.7224 -52
-      vertex 6.40917 30.6533 -52
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 -0
-    outer loop
-      vertex 8.5 29.7224 -52
-      vertex 6.40917 30.6533 -53
-      vertex 8.5 29.7224 -53
-    endloop
-  endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -5.25329 27.902 -49
-      vertex -5.67638 27.9185 -49
-      vertex -5.25329 28.0319 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -7 27.1244 -49
-      vertex -5.67638 27.9185 -49
-      vertex -5.25329 27.902 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8 28.8564 -49
-      vertex -5.67638 27.9185 -49
-      vertex -7 27.1244 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.67638 27.9185 -49
-      vertex -8 28.8564 -49
-      vertex -6.14856 29.6807 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -8.37996 28.5803 -49
-      vertex -7 27.1244 -49
+      vertex -10.7061 26.8903 -49
       vertex -8.13989 26.2962 -49
+      vertex -9.36783 25.404 -49
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -7 27.1244 -49
+      vertex -11.1196 26.431 -49
+      vertex -9.36783 25.404 -49
+      vertex -10.6085 24.0262 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.13989 26.2962 -49
+      vertex -10.7061 26.8903 -49
       vertex -8.37996 28.5803 -49
-      vertex -8 28.8564 -49
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -13.8 15.4505 -49
-      vertex -13.8845 15.8919 -49
-      vertex -13.8 17 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.8 15.4505 -49
-      vertex -14.0582 14.9071 -49
-      vertex -13.8845 15.8919 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -14.2052 14.3372 -49
-      vertex -14.0582 14.9071 -49
-      vertex -13.8 15.4505 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -14.0582 14.9071 -49
-      vertex -14.2052 14.3372 -49
-      vertex -14.5882 15.0005 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.8 17 -49
-      vertex -13.7043 17.8133 -49
-      vertex -13.7898 17 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.7825 17.0692 -49
-      vertex -13.7043 17.8133 -49
-      vertex -13.8 17 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -15.2409 16.1311 -49
-      vertex -13.8 17 -49
-      vertex -13.8845 15.8919 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.8 17 -49
-      vertex -15.2409 16.1311 -49
-      vertex -15.7825 17.0692 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -13.7043 17.8133 -49
-      vertex -15.6504 18.3266 -49
-      vertex -14.9257 20.5567 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -13.7043 17.8133 -49
-      vertex -15.7825 17.0692 -49
-      vertex -15.6504 18.3266 -49
-    endloop
-  endfacet
-  facet normal 0.994522 0.104527 0
-    outer loop
-      vertex -16.6847 12 -49
-      vertex -16.6285 11.4655 -49
-      vertex -16.6847 12 -52
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex -16.6847 12 -52
-      vertex -17 15 -53
-      vertex -17 15 -52
-    endloop
-  endfacet
-  facet normal 0.994522 0.104528 -9.43546e-007
-    outer loop
-      vertex -16.6847 12 -52
-      vertex -16.6285 11.4655 -53
-      vertex -17 15 -53
-    endloop
-  endfacet
-  facet normal 0.994522 0.104527 -0
-    outer loop
-      vertex -16.6285 11.4655 -53
-      vertex -16.6847 12 -52
-      vertex -16.6285 11.4655 -49
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 16.6285 18.5345 -53
-      vertex 15.5303 21.9145 -52
-      vertex 15.5303 21.9145 -53
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 15.5303 21.9145 -52
-      vertex 16.6285 18.5345 -53
-      vertex 16.6285 18.5345 -52
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.6941 17.9108 -49
-      vertex 14.9257 20.5567 -49
-      vertex 13.7043 17.8133 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.7896 20.6943 -49
-      vertex 14.9257 20.5567 -49
-      vertex 13.6941 17.9108 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.9257 20.5567 -49
-      vertex 12.7896 20.6943 -49
-      vertex 14.6167 21.5078 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.5127 21.1741 -49
-      vertex 14.6167 21.5078 -49
-      vertex 12.7896 20.6943 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.6167 21.5078 -49
-      vertex 12.5127 21.1741 -49
-      vertex 13.3397 23.7196 -49
+      vertex -9.36783 25.404 -49
+      vertex -11.1196 26.431 -49
+      vertex -10.7061 26.8903 -49
     endloop
   endfacet
   facet normal 0 0 -1
@@ -10107,46 +8707,809 @@ solid OpenSCAD_Model
       vertex 14.9257 20.5567 -49
     endloop
   endfacet
-  facet normal -0.587785 -0.809017 0
+  facet normal 0 0 -1
     outer loop
-      vertex 8.5 29.7224 -53
-      vertex 11.3752 27.6335 -52
-      vertex 8.5 29.7224 -52
+      vertex 16.6285 11.4655 -49
+      vertex 16.4773 11 -49
+      vertex 16.2094 11 -49
     endloop
   endfacet
-  facet normal -0.587785 -0.809017 -0
-    outer loop
-      vertex 11.3752 27.6335 -52
-      vertex 8.5 29.7224 -53
-      vertex 11.3752 27.6335 -53
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 13.3559 25.4337 -53
-      vertex 11.3752 27.6335 -52
-      vertex 11.3752 27.6335 -53
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 11.3752 27.6335 -52
-      vertex 13.3559 25.4337 -53
-      vertex 13.3559 25.4337 -52
-    endloop
-  endfacet
-  facet normal -0.207912 -0.978148 0
+  facet normal -0.207908 -0.978148 0
     outer loop
       vertex 1.77698 31.9069 -53
       vertex 5.25329 31.168 -52
       vertex 1.77698 31.9069 -52
     endloop
   endfacet
-  facet normal -0.207912 -0.978148 -0
+  facet normal -0.207908 -0.978148 -0
     outer loop
       vertex 5.25329 31.168 -52
       vertex 1.77698 31.9069 -53
       vertex 5.25329 31.168 -53
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 7 27.1244 -49
+      vertex 8.37996 28.5803 -49
+      vertex 8.13989 26.2962 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8.37996 28.5803 -49
+      vertex 7 27.1244 -49
+      vertex 8 28.8564 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.67638 27.9185 -49
+      vertex 8 28.8564 -49
+      vertex 7 27.1244 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 8 28.8564 -49
+      vertex 5.67638 27.9185 -49
+      vertex 6.14856 29.6807 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.25329 27.902 -49
+      vertex 5.67638 27.9185 -49
+      vertex 7 27.1244 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 5.67638 27.9185 -49
+      vertex 5.25329 27.902 -49
+      vertex 5.25329 28.0319 -49
+    endloop
+  endfacet
+  facet normal -0.866027 -0.499997 0
+    outer loop
+      vertex 15.5303 21.9145 -53
+      vertex 13.9594 24.6354 -52
+      vertex 13.9594 24.6354 -53
+    endloop
+  endfacet
+  facet normal -0.866027 -0.499997 0
+    outer loop
+      vertex 13.9594 24.6354 -52
+      vertex 15.5303 21.9145 -53
+      vertex 15.5303 21.9145 -52
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8 15.4505 -49
+      vertex -13.8845 15.8919 -49
+      vertex -13.8 17 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.8 15.4505 -49
+      vertex -14.0582 14.9071 -49
+      vertex -13.8845 15.8919 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.2052 14.3372 -49
+      vertex -14.0582 14.9071 -49
+      vertex -13.8 15.4505 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.0582 14.9071 -49
+      vertex -14.2052 14.3372 -49
+      vertex -14.5882 15.0005 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.8 17 -49
+      vertex -13.7043 17.8133 -49
+      vertex -13.7898 17 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.7825 17.0692 -49
+      vertex -13.7043 17.8133 -49
+      vertex -13.8 17 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.2409 16.1311 -49
+      vertex -13.8 17 -49
+      vertex -13.8845 15.8919 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.8 17 -49
+      vertex -15.2409 16.1311 -49
+      vertex -15.7825 17.0692 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.7043 17.8133 -49
+      vertex -15.6504 18.3266 -49
+      vertex -14.9257 20.5567 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.7043 17.8133 -49
+      vertex -15.7825 17.0692 -49
+      vertex -15.6504 18.3266 -49
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.77698 31.9069 -53
+      vertex -0.4 31.9069 -52
+      vertex -1.77698 31.9069 -52
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.4 31.9069 -52
+      vertex -1.77698 31.9069 -53
+      vertex -0.4 31.9069 -53
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.4 31.9069 -53
+      vertex 1.77698 31.9069 -52
+      vertex 0.4 31.9069 -52
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1.77698 31.9069 -52
+      vertex 0.4 31.9069 -53
+      vertex 1.77698 31.9069 -53
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.2094 11 -49
+      vertex -15.8 12 -49
+      vertex -15.4199 11 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.6285 11.4655 -49
+      vertex -15.8 12 -49
+      vertex -16.2094 11 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.8 12 -49
+      vertex -16.6285 11.4655 -49
+      vertex -16.6847 12 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8 12 -49
+      vertex -14.9773 12.216 -49
+      vertex -15.4199 11 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.9773 12.216 -49
+      vertex -15.8 12 -49
+      vertex -15.8 13.3483 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.2409 16.1311 -49
+      vertex -15.7898 17 -49
+      vertex -15.7825 17.0692 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8 16.2296 -49
+      vertex -15.7898 17 -49
+      vertex -15.2409 16.1311 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.7898 17 -49
+      vertex -15.8 16.2296 -49
+      vertex -15.8 17 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.8 13.3483 -49
+      vertex -14.2052 14.3372 -49
+      vertex -14.9773 12.216 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.2052 14.3372 -49
+      vertex -15.8 13.3483 -49
+      vertex -14.5882 15.0005 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.5882 15.0005 -49
+      vertex -15.8 13.3483 -49
+      vertex -15.8 15.2142 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8 16.4296 -49
+      vertex 15.7898 17 -49
+      vertex 15.8 17 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.3694 16.3537 -49
+      vertex 15.7898 17 -49
+      vertex 15.8 16.4296 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.7898 17 -49
+      vertex 15.3694 16.3537 -49
+      vertex 15.7825 17.0692 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.2401 14.3977 -49
+      vertex 15.8 13.3483 -49
+      vertex 15.0152 12.2682 -49
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 14.7167 15.2232 -49
+      vertex 15.8 13.3483 -49
+      vertex 14.2401 14.3977 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8 13.3483 -49
+      vertex 14.7167 15.2232 -49
+      vertex 15.8 15.4142 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8 12 -49
+      vertex 16.6285 11.4655 -49
+      vertex 16.2094 11 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.6285 11.4655 -49
+      vertex 15.8 12 -49
+      vertex 16.6847 12 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4768 11 -49
+      vertex 15.8 12 -49
+      vertex 16.2094 11 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.0152 12.2682 -49
+      vertex 15.8 12 -49
+      vertex 15.4768 11 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8 12 -49
+      vertex 15.0152 12.2682 -49
+      vertex 15.8 13.3483 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.36783 25.404 -49
+      vertex 11.1196 26.431 -49
+      vertex 10.6085 24.0262 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 11.1196 26.431 -49
+      vertex 9.36783 25.404 -49
+      vertex 10.7061 26.8903 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 8.13989 26.2962 -49
+      vertex 10.7061 26.8903 -49
+      vertex 9.36783 25.404 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10.7061 26.8903 -49
+      vertex 8.13989 26.2962 -49
+      vertex 8.37996 28.5803 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.583 22.9715 -49
+      vertex 13.3397 23.7196 -49
+      vertex 12.5127 21.1741 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 13.3397 23.7196 -49
+      vertex 11.583 22.9715 -49
+      vertex 13.1416 24.0628 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.3262 23.229 -49
+      vertex 11.583 22.9715 -49
+      vertex 12.5127 21.1741 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.3262 23.229 -49
+      vertex 11.0095 23.7907 -49
+      vertex 11.583 22.9715 -49
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex 11.0095 23.7907 -49
+      vertex 11.3262 23.229 -49
+      vertex 10.6085 24.0262 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10.6085 24.0262 -49
+      vertex 12.5351 24.859 -49
+      vertex 11.0095 23.7907 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.5351 24.859 -49
+      vertex 10.6085 24.0262 -49
+      vertex 11.1196 26.431 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6941 17.9108 -49
+      vertex 14.9257 20.5567 -49
+      vertex 13.7043 17.8133 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.7896 20.6943 -49
+      vertex 14.9257 20.5567 -49
+      vertex 13.6941 17.9108 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.9257 20.5567 -49
+      vertex 12.7896 20.6943 -49
+      vertex 14.6167 21.5078 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.5127 21.1741 -49
+      vertex 14.6167 21.5078 -49
+      vertex 12.7896 20.6943 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 14.6167 21.5078 -49
+      vertex 12.5127 21.1741 -49
+      vertex 13.3397 23.7196 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.25329 27.902 -49
+      vertex -5.67638 27.9185 -49
+      vertex -5.25329 28.0319 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7 27.1244 -49
+      vertex -5.67638 27.9185 -49
+      vertex -5.25329 27.902 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8 28.8564 -49
+      vertex -5.67638 27.9185 -49
+      vertex -7 27.1244 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.67638 27.9185 -49
+      vertex -8 28.8564 -49
+      vertex -6.14856 29.6807 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.37996 28.5803 -49
+      vertex -7 27.1244 -49
+      vertex -8.13989 26.2962 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7 27.1244 -49
+      vertex -8.37996 28.5803 -49
+      vertex -8 28.8564 -49
+    endloop
+  endfacet
+  facet normal 0.866027 -0.499997 0
+    outer loop
+      vertex -15.5303 21.9145 -52
+      vertex -13.9594 24.6354 -53
+      vertex -13.9594 24.6354 -52
+    endloop
+  endfacet
+  facet normal 0.866027 -0.499997 0
+    outer loop
+      vertex -13.9594 24.6354 -53
+      vertex -15.5303 21.9145 -52
+      vertex -15.5303 21.9145 -53
+    endloop
+  endfacet
+  facet normal 0.207908 -0.978148 0
+    outer loop
+      vertex -5.25329 31.168 -53
+      vertex -1.77698 31.9069 -52
+      vertex -5.25329 31.168 -52
+    endloop
+  endfacet
+  facet normal 0.207908 -0.978148 0
+    outer loop
+      vertex -1.77698 31.9069 -52
+      vertex -5.25329 31.168 -53
+      vertex -1.77698 31.9069 -53
+    endloop
+  endfacet
+  facet normal 0.994518 0.104569 0
+    outer loop
+      vertex -16.6847 12 -49
+      vertex -16.6285 11.4655 -49
+      vertex -16.6847 12 -52
+    endloop
+  endfacet
+  facet normal 0.994522 0.104524 0
+    outer loop
+      vertex -16.6847 12 -52
+      vertex -17 15 -53
+      vertex -17 15 -52
+    endloop
+  endfacet
+  facet normal 0.994522 0.104531 2.03012e-05
+    outer loop
+      vertex -16.6847 12 -52
+      vertex -16.6285 11.4655 -53
+      vertex -17 15 -53
+    endloop
+  endfacet
+  facet normal 0.994518 0.104569 -0
+    outer loop
+      vertex -16.6285 11.4655 -53
+      vertex -16.6847 12 -52
+      vertex -16.6285 11.4655 -49
+    endloop
+  endfacet
+  facet normal 0.994523 -0.10452 0
+    outer loop
+      vertex -16.87 16.2366 -52
+      vertex -16.6285 18.5345 -53
+      vertex -16.6285 18.5345 -52
+    endloop
+  endfacet
+  facet normal 0.994523 -0.10452 0
+    outer loop
+      vertex -16.6285 18.5345 -53
+      vertex -16.87 16.2366 -52
+      vertex -16.87 16.2366 -53
+    endloop
+  endfacet
+  facet normal 0.994533 -0.104425 0
+    outer loop
+      vertex -17 15 -52
+      vertex -16.9561 15.4181 -53
+      vertex -16.9561 15.4181 -52
+    endloop
+  endfacet
+  facet normal 0.994533 -0.104425 0
+    outer loop
+      vertex -16.9561 15.4181 -53
+      vertex -17 15 -52
+      vertex -17 15 -53
+    endloop
+  endfacet
+  facet normal -0.406982 -0.913436 0
+    outer loop
+      vertex 5.25329 31.168 -53
+      vertex 5.48424 31.0651 -52
+      vertex 5.25329 31.168 -52
+    endloop
+  endfacet
+  facet normal -0.406982 -0.913436 -0
+    outer loop
+      vertex 5.48424 31.0651 -52
+      vertex 5.25329 31.168 -53
+      vertex 5.48424 31.0651 -53
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 0
+    outer loop
+      vertex 6.40917 30.6533 -53
+      vertex 8.5 29.7224 -52
+      vertex 6.40917 30.6533 -52
+    endloop
+  endfacet
+  facet normal -0.406738 -0.913545 -0
+    outer loop
+      vertex 8.5 29.7224 -52
+      vertex 6.40917 30.6533 -53
+      vertex 8.5 29.7224 -53
+    endloop
+  endfacet
+  facet normal -0.587775 -0.809024 0
+    outer loop
+      vertex 8.5 29.7224 -53
+      vertex 11.3752 27.6335 -52
+      vertex 8.5 29.7224 -52
+    endloop
+  endfacet
+  facet normal -0.587775 -0.809024 -0
+    outer loop
+      vertex 11.3752 27.6335 -52
+      vertex 8.5 29.7224 -53
+      vertex 11.3752 27.6335 -53
+    endloop
+  endfacet
+  facet normal -0.743146 -0.669129 0
+    outer loop
+      vertex 13.3559 25.4337 -53
+      vertex 11.3752 27.6335 -52
+      vertex 11.3752 27.6335 -53
+    endloop
+  endfacet
+  facet normal -0.743146 -0.669129 0
+    outer loop
+      vertex 11.3752 27.6335 -52
+      vertex 13.3559 25.4337 -53
+      vertex 13.3559 25.4337 -52
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104521 0
+    outer loop
+      vertex 16.7877 17.0197 -53
+      vertex 16.6285 18.5345 -52
+      vertex 16.6285 18.5345 -53
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104514 -1.00103e-05
+    outer loop
+      vertex 16.8306 16.6114 -52.1913
+      vertex 16.6285 18.5345 -52
+      vertex 16.7877 17.0197 -53
+    endloop
+  endfacet
+  facet normal -0.994523 -0.104515 0
+    outer loop
+      vertex 16.6285 18.5345 -52
+      vertex 16.8306 16.6114 -52.1913
+      vertex 16.8306 16.6114 -52
+    endloop
+  endfacet
+  facet normal -0.994525 -0.104495 0
+    outer loop
+      vertex 16.8306 16.6114 -53
+      vertex 16.8306 16.6114 -52.1913
+      vertex 16.7877 17.0197 -53
+    endloop
+  endfacet
+  facet normal -0.994518 -0.104567 0
+    outer loop
+      vertex 16.9354 15.6144 -53
+      vertex 17 15 -52
+      vertex 16.9354 15.6144 -52
+    endloop
+  endfacet
+  facet normal -0.994518 -0.104567 -0
+    outer loop
+      vertex 17 15 -52
+      vertex 16.9354 15.6144 -53
+      vertex 17 15 -53
+    endloop
+  endfacet
+  facet normal 0.406982 -0.913436 0
+    outer loop
+      vertex -5.48424 31.0651 -53
+      vertex -5.25329 31.168 -52
+      vertex -5.48424 31.0651 -52
+    endloop
+  endfacet
+  facet normal 0.406982 -0.913436 0
+    outer loop
+      vertex -5.25329 31.168 -52
+      vertex -5.48424 31.0651 -53
+      vertex -5.25329 31.168 -53
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -8.5 29.7224 -53
+      vertex -6.40917 30.6533 -52
+      vertex -8.5 29.7224 -52
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -6.40917 30.6533 -52
+      vertex -8.5 29.7224 -53
+      vertex -6.40917 30.6533 -53
+    endloop
+  endfacet
+  facet normal 0.587775 -0.809024 0
+    outer loop
+      vertex -11.3752 27.6335 -53
+      vertex -8.5 29.7224 -52
+      vertex -11.3752 27.6335 -52
+    endloop
+  endfacet
+  facet normal 0.587775 -0.809024 0
+    outer loop
+      vertex -8.5 29.7224 -52
+      vertex -11.3752 27.6335 -53
+      vertex -8.5 29.7224 -53
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.6167 21.5078 -49
+      vertex -12.5127 21.1741 -49
+      vertex -12.7896 20.6943 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9257 20.5567 -49
+      vertex -12.7896 20.6943 -49
+      vertex -13.6941 17.9108 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.9257 20.5567 -49
+      vertex -13.6941 17.9108 -49
+      vertex -13.7043 17.8133 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5127 21.1741 -49
+      vertex -14.6167 21.5078 -49
+      vertex -13.3397 23.7196 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.7896 20.6943 -49
+      vertex -14.9257 20.5567 -49
+      vertex -14.6167 21.5078 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.3262 23.229 -49
+      vertex -11.0095 23.7907 -49
+      vertex -10.6085 24.0262 -49
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -11.3262 23.229 -49
+      vertex -11.583 22.9715 -49
+      vertex -11.0095 23.7907 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5127 21.1741 -49
+      vertex -11.583 22.9715 -49
+      vertex -11.3262 23.229 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.3397 23.7196 -49
+      vertex -11.583 22.9715 -49
+      vertex -12.5127 21.1741 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.583 22.9715 -49
+      vertex -13.3397 23.7196 -49
+      vertex -13.1416 24.0628 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5351 24.859 -49
+      vertex -10.6085 24.0262 -49
+      vertex -11.0095 23.7907 -49
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6085 24.0262 -49
+      vertex -12.5351 24.859 -49
+      vertex -11.1196 26.431 -49
+    endloop
+  endfacet
+  facet normal 0.743146 -0.669129 0
+    outer loop
+      vertex -13.3559 25.4337 -52
+      vertex -11.3752 27.6335 -53
+      vertex -11.3752 27.6335 -52
+    endloop
+  endfacet
+  facet normal 0.743146 -0.669129 0
+    outer loop
+      vertex -11.3752 27.6335 -53
+      vertex -13.3559 25.4337 -52
+      vertex -13.3559 25.4337 -53
     endloop
   endfacet
   facet normal 0 0 -1
@@ -10186,302 +9549,239 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10.7061 26.8903 -49
-      vertex -8.13989 26.2962 -49
-      vertex -9.36783 25.404 -49
+      vertex 1.4634 28.9233 -49
+      vertex -0.4 29 -49
+      vertex 0.4 29 -49
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -11.1196 26.431 -49
-      vertex -9.36783 25.404 -49
-      vertex -10.6085 24.0262 -49
+      vertex -1.4634 28.9233 -49
+      vertex -0.4 29 -49
+      vertex 1.4634 28.9233 -49
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -8.13989 26.2962 -49
-      vertex -10.7061 26.8903 -49
-      vertex -8.37996 28.5803 -49
+      vertex -1.4634 28.9233 -49
+      vertex -0.4 30 -49
+      vertex -0.4 29 -49
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -9.36783 25.404 -49
-      vertex -11.1196 26.431 -49
-      vertex -10.7061 26.8903 -49
+      vertex -1.4634 28.9233 -49
+      vertex -1.9774 30 -49
+      vertex -0.4 30 -49
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -1.9774 30 -49
+      vertex -1.4634 28.9233 -49
+      vertex -2.1049 28.787 -49
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -14.6167 21.5078 -49
-      vertex -12.5127 21.1741 -49
-      vertex -12.7896 20.6943 -49
+      vertex 1.4634 28.9233 -49
+      vertex 1.9774 30 -49
+      vertex 2.1049 28.787 -49
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -14.9257 20.5567 -49
-      vertex -12.7896 20.6943 -49
-      vertex -13.6941 17.9108 -49
+      vertex 0.4 30 -49
+      vertex 1.4634 28.9233 -49
+      vertex 0.4 29 -49
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -14.9257 20.5567 -49
-      vertex -13.6941 17.9108 -49
-      vertex -13.7043 17.8133 -49
+      vertex 1.4634 28.9233 -49
+      vertex 0.4 30 -49
+      vertex 1.9774 30 -49
     endloop
   endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -12.5127 21.1741 -49
-      vertex -14.6167 21.5078 -49
-      vertex -13.3397 23.7196 -49
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -12.7896 20.6943 -49
-      vertex -14.9257 20.5567 -49
-      vertex -14.6167 21.5078 -49
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex -16.6285 18.5345 -52
-      vertex -15.5303 21.9145 -53
-      vertex -15.5303 21.9145 -52
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex -15.5303 21.9145 -53
-      vertex -16.6285 18.5345 -52
-      vertex -16.6285 18.5345 -53
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex -11.3752 27.6335 -53
-      vertex -8.5 29.7224 -52
-      vertex -11.3752 27.6335 -52
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex -8.5 29.7224 -52
-      vertex -11.3752 27.6335 -53
-      vertex -8.5 29.7224 -53
-    endloop
-  endfacet
-  facet normal 0.406737 -0.913545 0
-    outer loop
-      vertex -8.5 29.7224 -53
-      vertex -6.40917 30.6533 -52
-      vertex -8.5 29.7224 -52
-    endloop
-  endfacet
-  facet normal 0.406737 -0.913545 0
-    outer loop
-      vertex -6.40917 30.6533 -52
-      vertex -8.5 29.7224 -53
-      vertex -6.40917 30.6533 -53
-    endloop
-  endfacet
-  facet normal 0.406736 -0.913546 0
-    outer loop
-      vertex -5.48424 31.0651 -53
-      vertex -5.25329 31.168 -52
-      vertex -5.48424 31.0651 -52
-    endloop
-  endfacet
-  facet normal 0.406736 -0.913546 0
-    outer loop
-      vertex -5.25329 31.168 -52
-      vertex -5.48424 31.0651 -53
-      vertex -5.25329 31.168 -53
-    endloop
-  endfacet
-  facet normal 0.866025 -0.5 0
-    outer loop
-      vertex -15.5303 21.9145 -52
-      vertex -13.9594 24.6354 -53
-      vertex -13.9594 24.6354 -52
-    endloop
-  endfacet
-  facet normal 0.866025 -0.5 0
-    outer loop
-      vertex -13.9594 24.6354 -53
-      vertex -15.5303 21.9145 -52
-      vertex -15.5303 21.9145 -53
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex -13.3559 25.4337 -52
-      vertex -11.3752 27.6335 -53
-      vertex -11.3752 27.6335 -52
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex -11.3752 27.6335 -53
-      vertex -13.3559 25.4337 -52
-      vertex -13.3559 25.4337 -53
-    endloop
-  endfacet
-  facet normal -0.939693 -0.34202 0
+  facet normal -0.939696 -0.342011 0
     outer loop
       vertex 14.2401 14.3977 -49
       vertex 13.8 15.6069 -46.5379
       vertex 13.8 15.6069 -49
     endloop
   endfacet
-  facet normal -0.939693 -0.34202 -3.27758e-007
+  facet normal -0.939689 -0.34203 1.03897e-05
     outer loop
       vertex 15.0152 12.2682 -49
       vertex 13.8 15.6069 -46.5379
       vertex 14.2401 14.3977 -49
     endloop
   endfacet
-  facet normal -0.939693 -0.34202 -0
+  facet normal -0.93969 -0.342029 -0
     outer loop
       vertex 15.4768 11 -47.3502
       vertex 15.0152 12.2682 -49
       vertex 15.4768 11 -49
     endloop
   endfacet
-  facet normal -0.939693 -0.34202 7.58629e-008
+  facet normal -0.939691 -0.342025 2.97021e-06
     outer loop
       vertex 15.0152 12.2682 -49
       vertex 15.4768 11 -47.3502
       vertex 13.8 15.6069 -46.5379
     endloop
   endfacet
-  facet normal 0.939693 -0.34202 0
+  facet normal 0.939695 -0.342014 0
     outer loop
       vertex -13.8 15.4505 -46.5655
       vertex -14.2052 14.3372 -49
       vertex -13.8 15.4505 -49
     endloop
   endfacet
-  facet normal 0.939693 -0.34202 -2.81187e-007
+  facet normal 0.939686 -0.342038 1.24993e-05
     outer loop
       vertex -13.8 15.4505 -46.5655
       vertex -14.9773 12.216 -49
       vertex -14.2052 14.3372 -49
     endloop
   endfacet
-  facet normal 0.939693 -0.34202 1.04907e-007
+  facet normal 0.939689 -0.342029 -8.04157e-07
     outer loop
       vertex -15.4199 11 -47.3502
       vertex -14.9773 12.216 -49
       vertex -13.8 15.4505 -46.5655
     endloop
   endfacet
-  facet normal 0.939693 -0.34202 0
+  facet normal 0.93969 -0.342028 0
     outer loop
       vertex -14.9773 12.216 -49
       vertex -15.4199 11 -47.3502
       vertex -15.4199 11 -49
     endloop
   endfacet
-  facet normal -0.173648 -0.984808 0
+  facet normal -0.173637 -0.98481 0
     outer loop
       vertex -17.0126 15.428 -48
       vertex -15.8 15.2142 -49
       vertex -15.8 15.2142 -48
     endloop
   endfacet
-  facet normal -0.173648 -0.984808 -6.08548e-008
+  facet normal -0.173669 -0.984804 -7.43601e-06
     outer loop
       vertex -16.9561 15.4181 -52
       vertex -14.5882 15.0005 -49
       vertex -15.8 15.2142 -49
     endloop
   endfacet
-  facet normal -0.173648 -0.984808 0
+  facet normal -0.173637 -0.98481 0
     outer loop
       vertex -17.0126 15.428 -52
       vertex -15.8 15.2142 -49
       vertex -17.0126 15.428 -48
     endloop
   endfacet
-  facet normal -0.173648 -0.984808 -1.84303e-007
+  facet normal -0.172592 -0.984993 -0.000435605
     outer loop
       vertex -16.9561 15.4181 -52
       vertex -15.8 15.2142 -49
       vertex -17.0126 15.428 -52
     endloop
   endfacet
-  facet normal -0.173648 -0.984808 -1.76633e-008
+  facet normal -0.17366 -0.984806 -1.47913e-05
     outer loop
       vertex -14.5882 15.0005 -49
       vertex -16.9561 15.4181 -52
       vertex -14.0582 14.9071 -53
     endloop
   endfacet
-  facet normal -0.173648 -0.984808 0
+  facet normal -0.173655 -0.984806 0
     outer loop
       vertex -14.0582 14.9071 -53
       vertex -16.9561 15.4181 -52
       vertex -16.9561 15.4181 -53
     endloop
   endfacet
-  facet normal -0.173648 -0.984808 0
+  facet normal -0.173552 -0.984825 0
     outer loop
       vertex -14.5882 15.0005 -49
       vertex -14.0582 14.9071 -53
       vertex -14.0582 14.9071 -49
     endloop
   endfacet
-  facet normal 0.984808 -0.173648 0
+  facet normal 0.984799 -0.1737 0
     outer loop
       vertex -14.0582 14.9071 -49
       vertex -13.8845 15.8919 -53
       vertex -13.8845 15.8919 -49
     endloop
   endfacet
-  facet normal 0.984808 -0.173648 0
+  facet normal 0.984799 -0.1737 0
     outer loop
       vertex -13.8845 15.8919 -53
       vertex -14.0582 14.9071 -49
       vertex -14.0582 14.9071 -53
     endloop
   endfacet
-  facet normal 0.173649 0.984808 -0
+  facet normal 0.173669 0.984804 -0
     outer loop
       vertex -13.8845 15.8919 -53
       vertex -15.2409 16.1311 -49
       vertex -13.8845 15.8919 -49
     endloop
   endfacet
-  facet normal 0.173648 0.984808 -1.9608e-007
+  facet normal 0.173635 0.98481 -1.19768e-05
     outer loop
       vertex -16.8389 16.4128 -53
       vertex -15.2409 16.1311 -49
       vertex -13.8845 15.8919 -53
     endloop
   endfacet
-  facet normal 0.173648 0.984808 -0
+  facet normal 0.173661 0.984805 -0
     outer loop
       vertex -15.8 16.2296 -49
       vertex -16.8389 16.4128 -48
       vertex -15.8 16.2296 -48
     endloop
   endfacet
-  facet normal 0.173647 0.984808 4.78641e-007
+  facet normal 0.173504 0.984833 4.20417e-05
     outer loop
       vertex -15.2409 16.1311 -49
       vertex -16.8389 16.4128 -53
       vertex -15.8 16.2296 -49
     endloop
   endfacet
-  facet normal 0.173648 0.984808 0
+  facet normal 0.173661 0.984805 0
     outer loop
       vertex -15.8 16.2296 -49
       vertex -16.8389 16.4128 -53
+      vertex -16.8389 16.4128 -48
+    endloop
+  endfacet
+  facet normal -0.984778 0.173817 0
+    outer loop
+      vertex -16.87 16.2366 -52
+      vertex -16.8389 16.4128 -53
+      vertex -16.87 16.2366 -53
+    endloop
+  endfacet
+  facet normal -0.984778 0.173817 0
+    outer loop
+      vertex -16.8389 16.4128 -53
+      vertex -16.87 16.2366 -52
+      vertex -16.8389 16.4128 -48
+    endloop
+  endfacet
+  facet normal -0.984803 0.173674 0
+    outer loop
+      vertex -17.0126 15.428 -48
+      vertex -16.87 16.2366 -52
+      vertex -17.0126 15.428 -52
+    endloop
+  endfacet
+  facet normal -0.984799 0.1737 5.33499e-06
+    outer loop
+      vertex -16.87 16.2366 -52
+      vertex -17.0126 15.428 -48
       vertex -16.8389 16.4128 -48
     endloop
   endfacet
@@ -10499,147 +9799,119 @@ solid OpenSCAD_Model
       vertex -15.8 15.2142 -48
     endloop
   endfacet
-  facet normal -0.984807 0.17365 0
-    outer loop
-      vertex -16.87 16.2366 -52
-      vertex -16.8389 16.4128 -53
-      vertex -16.87 16.2366 -53
-    endloop
-  endfacet
-  facet normal -0.984807 0.17365 0
-    outer loop
-      vertex -16.8389 16.4128 -53
-      vertex -16.87 16.2366 -52
-      vertex -16.8389 16.4128 -48
-    endloop
-  endfacet
-  facet normal -0.984808 0.173646 0
-    outer loop
-      vertex -17.0126 15.428 -48
-      vertex -16.87 16.2366 -52
-      vertex -17.0126 15.428 -52
-    endloop
-  endfacet
-  facet normal -0.984808 0.173647 1.29646e-007
-    outer loop
-      vertex -16.87 16.2366 -52
-      vertex -17.0126 15.428 -48
-      vertex -16.8389 16.4128 -48
-    endloop
-  endfacet
-  facet normal -0.173647 0.984808 0
+  facet normal -0.173661 0.984805 0
     outer loop
       vertex 16.8389 16.6128 -48
       vertex 15.8 16.4296 -49
       vertex 15.8 16.4296 -48
     endloop
   endfacet
-  facet normal -0.173649 0.984808 -4.73636e-007
+  facet normal -0.17359 0.984818 4.61533e-05
     outer loop
       vertex 16.8306 16.6114 -52
       vertex 15.3694 16.3537 -49
       vertex 15.8 16.4296 -49
     endloop
   endfacet
-  facet normal -0.173647 0.984808 0
+  facet normal -0.173661 0.984805 0
     outer loop
       vertex 16.8389 16.6128 -52
       vertex 15.8 16.4296 -49
       vertex 16.8389 16.6128 -48
     endloop
   endfacet
-  facet normal -0.173553 0.984824 3.33262e-005
+  facet normal -0.166325 0.986068 0.00261763
     outer loop
       vertex 16.8306 16.6114 -52
       vertex 15.8 16.4296 -49
       vertex 16.8389 16.6128 -52
     endloop
   endfacet
-  facet normal -0.173648 0.984808 -3.12569e-007
+  facet normal -0.173659 0.984806 1.11461e-05
     outer loop
       vertex 13.8845 16.0919 -53
       vertex 15.3694 16.3537 -49
       vertex 16.8306 16.6114 -52
     endloop
   endfacet
-  facet normal -0.173648 0.984808 0
+  facet normal -0.173656 0.984806 0
     outer loop
       vertex 13.8845 16.0919 -53
       vertex 16.8306 16.6114 -52
       vertex 16.8306 16.6114 -52.1913
     endloop
   endfacet
-  facet normal -0.173648 0.984808 0
+  facet normal -0.173656 0.984806 0
     outer loop
       vertex 13.8845 16.0919 -53
       vertex 16.8306 16.6114 -52.1913
       vertex 16.8306 16.6114 -53
     endloop
   endfacet
-  facet normal -0.173649 0.984808 0
+  facet normal -0.17363 0.984811 0
     outer loop
       vertex 15.3694 16.3537 -49
       vertex 13.8845 16.0919 -53
       vertex 13.8845 16.0919 -49
     endloop
   endfacet
-  facet normal -0.984808 -0.173648 0
+  facet normal -0.984799 -0.1737 0
     outer loop
       vertex 14.0582 15.1071 -53
       vertex 13.8845 16.0919 -49
       vertex 13.8845 16.0919 -53
     endloop
   endfacet
-  facet normal -0.984808 -0.173648 0
+  facet normal -0.984799 -0.1737 0
     outer loop
       vertex 13.8845 16.0919 -49
       vertex 14.0582 15.1071 -53
       vertex 14.0582 15.1071 -49
     endloop
   endfacet
-  facet normal 0.173648 -0.984808 0
+  facet normal 0.173632 -0.984811 0
     outer loop
       vertex 14.0582 15.1071 -53
       vertex 14.7167 15.2232 -49
       vertex 14.0582 15.1071 -49
     endloop
   endfacet
-  facet normal 0.173648 -0.984808 -8.25843e-008
+  facet normal 0.173639 -0.984809 -1.28249e-06
     outer loop
       vertex 16.9354 15.6144 -52
       vertex 14.7167 15.2232 -49
       vertex 14.0582 15.1071 -53
     endloop
   endfacet
-  facet normal 0.173648 -0.984808 -4.91688e-009
+  facet normal 0.173635 -0.98481 -4.6242e-06
     outer loop
       vertex 14.7167 15.2232 -49
       vertex 16.9354 15.6144 -52
       vertex 15.8 15.4142 -49
     endloop
   endfacet
-  facet normal 0.173648 -0.984808 0
+  facet normal 0.173639 -0.984809 0
     outer loop
       vertex 16.9354 15.6144 -52
       vertex 14.0582 15.1071 -53
       vertex 16.9354 15.6144 -53
     endloop
   endfacet
-  facet normal 0.173648 -0.984808 0
+  facet normal 0.173637 -0.98481 0
     outer loop
       vertex 15.8 15.4142 -49
       vertex 17.0126 15.628 -48
       vertex 15.8 15.4142 -48
     endloop
   endfacet
-  facet normal 0.173647 -0.984808 -4.92472e-007
+  facet normal 0.173494 -0.984835 -5.95323e-05
     outer loop
       vertex 17.0126 15.628 -52
       vertex 15.8 15.4142 -49
       vertex 16.9354 15.6144 -52
     endloop
   endfacet
-  facet normal 0.173648 -0.984808 0
+  facet normal 0.173637 -0.98481 0
     outer loop
       vertex 15.8 15.4142 -49
       vertex 17.0126 15.628 -52
@@ -10660,70 +9932,70 @@ solid OpenSCAD_Model
       vertex 15.8 15.4142 -48
     endloop
   endfacet
-  facet normal 0.984808 0.173647 0
+  facet normal 0.984799 0.1737 0
     outer loop
       vertex 17.0126 15.628 -48
       vertex 16.8389 16.6128 -52
       vertex 16.8389 16.6128 -48
     endloop
   endfacet
-  facet normal 0.984808 0.173647 0
+  facet normal 0.984799 0.1737 0
     outer loop
       vertex 16.8389 16.6128 -52
       vertex 17.0126 15.628 -48
       vertex 17.0126 15.628 -52
     endloop
   endfacet
-  facet normal -0.573576 -0.819152 0
+  facet normal -0.57359 -0.819142 0
     outer loop
       vertex -14.8596 25.2658 -48
       vertex -13.1416 24.0628 -49
       vertex -13.1416 24.0628 -48
     endloop
   endfacet
-  facet normal -0.573576 -0.819152 0
+  facet normal -0.57359 -0.819142 0
     outer loop
       vertex -14.8596 25.2658 -52
       vertex -13.1416 24.0628 -49
       vertex -14.8596 25.2658 -48
     endloop
   endfacet
-  facet normal -0.573575 -0.819153 -7.31615e-007
+  facet normal -0.573621 -0.819121 2.62667e-05
     outer loop
       vertex -13.9594 24.6354 -52
       vertex -13.1416 24.0628 -49
       vertex -14.8596 25.2658 -52
     endloop
   endfacet
-  facet normal -0.573576 -0.819152 -3.29728e-007
+  facet normal -0.573561 -0.819163 1.88857e-06
     outer loop
       vertex -13.1416 24.0628 -49
       vertex -13.9594 24.6354 -52
       vertex -11.583 22.9715 -49
     endloop
   endfacet
-  facet normal -0.573577 -0.819152 0
+  facet normal -0.57356 -0.819164 0
     outer loop
       vertex -11.583 22.9715 -53
       vertex -13.9594 24.6354 -52
       vertex -13.9594 24.6354 -53
     endloop
   endfacet
-  facet normal -0.573577 -0.819152 0
+  facet normal -0.57356 -0.819164 0
     outer loop
       vertex -13.9594 24.6354 -52
       vertex -11.583 22.9715 -53
       vertex -11.583 22.9715 -49
     endloop
   endfacet
-  facet normal 0.819153 -0.573576 0
+  facet normal 0.819204 -0.573503 0
     outer loop
       vertex -11.583 22.9715 -49
       vertex -11.0095 23.7907 -53
       vertex -11.0095 23.7907 -49
     endloop
   endfacet
-  facet normal 0.819153 -0.573576 0
+  facet normal 0.819204 -0.573503 0
     outer loop
       vertex -11.0095 23.7907 -53
       vertex -11.583 22.9715 -49
@@ -10751,154 +10023,154 @@ solid OpenSCAD_Model
       vertex -13.1416 24.0628 -48
     endloop
   endfacet
-  facet normal -0.819152 0.573576 0
+  facet normal -0.819204 0.573503 0
     outer loop
       vertex -14.8596 25.2658 -52
       vertex -14.2861 26.085 -48
       vertex -14.2861 26.085 -52
     endloop
   endfacet
-  facet normal -0.819152 0.573576 0
+  facet normal -0.819204 0.573503 0
     outer loop
       vertex -14.2861 26.085 -48
       vertex -14.8596 25.2658 -52
       vertex -14.8596 25.2658 -48
     endloop
   endfacet
-  facet normal 0.573577 0.819152 -6.55584e-007
+  facet normal 0.573599 0.819136 -1.75969e-05
     outer loop
       vertex -11.0095 23.7907 -49
       vertex -13.3559 25.4337 -52
       vertex -12.5351 24.859 -49
     endloop
   endfacet
-  facet normal 0.573576 0.819152 -0
+  facet normal 0.573584 0.819147 -0
     outer loop
       vertex -11.0095 23.7907 -53
       vertex -13.3559 25.4337 -52
       vertex -11.0095 23.7907 -49
     endloop
   endfacet
-  facet normal 0.573576 0.819152 0
+  facet normal 0.573584 0.819147 0
     outer loop
       vertex -13.3559 25.4337 -52
       vertex -11.0095 23.7907 -53
       vertex -13.3559 25.4337 -53
     endloop
   endfacet
-  facet normal 0.573576 0.819152 -0
+  facet normal 0.573557 0.819166 -0
     outer loop
       vertex -12.5351 24.859 -49
       vertex -14.2861 26.085 -48
       vertex -12.5351 24.859 -48
     endloop
   endfacet
-  facet normal 0.573577 0.819152 -6.26434e-007
+  facet normal 0.573557 0.819166 -3.22899e-07
     outer loop
       vertex -14.2861 26.085 -52
       vertex -12.5351 24.859 -49
       vertex -13.3559 25.4337 -52
     endloop
   endfacet
-  facet normal 0.573576 0.819152 0
+  facet normal 0.573557 0.819166 0
     outer loop
       vertex -12.5351 24.859 -49
       vertex -14.2861 26.085 -52
       vertex -14.2861 26.085 -48
     endloop
   endfacet
-  facet normal 0.573576 -0.819152 -3.29728e-007
+  facet normal 0.573561 -0.819163 1.88857e-06
     outer loop
       vertex 11.583 22.9715 -49
       vertex 13.9594 24.6354 -52
       vertex 13.1416 24.0628 -49
     endloop
   endfacet
-  facet normal 0.573577 -0.819152 0
+  facet normal 0.57356 -0.819164 0
     outer loop
       vertex 11.583 22.9715 -53
       vertex 13.9594 24.6354 -52
       vertex 11.583 22.9715 -49
     endloop
   endfacet
-  facet normal 0.573577 -0.819152 0
+  facet normal 0.57356 -0.819164 0
     outer loop
       vertex 13.9594 24.6354 -52
       vertex 11.583 22.9715 -53
       vertex 13.9594 24.6354 -53
     endloop
   endfacet
-  facet normal 0.573576 -0.819152 0
+  facet normal 0.57359 -0.819142 0
     outer loop
       vertex 13.1416 24.0628 -49
       vertex 14.8596 25.2658 -48
       vertex 13.1416 24.0628 -48
     endloop
   endfacet
-  facet normal 0.573575 -0.819153 -7.31615e-007
+  facet normal 0.573621 -0.819121 2.62667e-05
     outer loop
       vertex 14.8596 25.2658 -52
       vertex 13.1416 24.0628 -49
       vertex 13.9594 24.6354 -52
     endloop
   endfacet
-  facet normal 0.573576 -0.819152 0
+  facet normal 0.57359 -0.819142 0
     outer loop
       vertex 13.1416 24.0628 -49
       vertex 14.8596 25.2658 -52
       vertex 14.8596 25.2658 -48
     endloop
   endfacet
-  facet normal -0.819153 -0.573576 0
+  facet normal -0.819204 -0.573503 0
     outer loop
       vertex 11.583 22.9715 -53
       vertex 11.0095 23.7907 -49
       vertex 11.0095 23.7907 -53
     endloop
   endfacet
-  facet normal -0.819153 -0.573576 0
+  facet normal -0.819204 -0.573503 0
     outer loop
       vertex 11.0095 23.7907 -49
       vertex 11.583 22.9715 -53
       vertex 11.583 22.9715 -49
     endloop
   endfacet
-  facet normal -0.573576 0.819152 0
+  facet normal -0.573557 0.819166 0
     outer loop
       vertex 14.2861 26.085 -48
       vertex 12.5351 24.859 -49
       vertex 12.5351 24.859 -48
     endloop
   endfacet
-  facet normal -0.573576 0.819152 0
+  facet normal -0.573557 0.819166 0
     outer loop
       vertex 14.2861 26.085 -52
       vertex 12.5351 24.859 -49
       vertex 14.2861 26.085 -48
     endloop
   endfacet
-  facet normal -0.573577 0.819152 -6.26434e-007
+  facet normal -0.573557 0.819166 -3.22899e-07
     outer loop
       vertex 13.3559 25.4337 -52
       vertex 12.5351 24.859 -49
       vertex 14.2861 26.085 -52
     endloop
   endfacet
-  facet normal -0.573577 0.819152 -6.55584e-007
+  facet normal -0.573599 0.819136 -1.75969e-05
     outer loop
       vertex 12.5351 24.859 -49
       vertex 13.3559 25.4337 -52
       vertex 11.0095 23.7907 -49
     endloop
   endfacet
-  facet normal -0.573576 0.819152 0
+  facet normal -0.573584 0.819147 0
     outer loop
       vertex 11.0095 23.7907 -53
       vertex 13.3559 25.4337 -52
       vertex 13.3559 25.4337 -53
     endloop
   endfacet
-  facet normal -0.573576 0.819152 0
+  facet normal -0.573584 0.819147 0
     outer loop
       vertex 13.3559 25.4337 -52
       vertex 11.0095 23.7907 -53
@@ -10926,14 +10198,14 @@ solid OpenSCAD_Model
       vertex 12.5351 24.859 -48
     endloop
   endfacet
-  facet normal 0.819152 0.573576 0
+  facet normal 0.819204 0.573503 0
     outer loop
       vertex 14.8596 25.2658 -48
       vertex 14.2861 26.085 -52
       vertex 14.2861 26.085 -48
     endloop
   endfacet
-  facet normal 0.819152 0.573576 0
+  facet normal 0.819204 0.573503 0
     outer loop
       vertex 14.2861 26.085 -52
       vertex 14.8596 25.2658 -48
@@ -10961,49 +10233,49 @@ solid OpenSCAD_Model
       vertex -6.14856 29.6807 -48
     endloop
   endfacet
-  facet normal 0.258819 -0.965926 0
+  facet normal 0.25889 -0.965907 0
     outer loop
       vertex -5.67638 27.9185 -53
       vertex -5.25329 28.0319 -49
       vertex -5.67638 27.9185 -49
     endloop
   endfacet
-  facet normal 0.258818 -0.965926 1.16016e-007
+  facet normal 0.2588 -0.965931 1.01925e-05
     outer loop
       vertex -4.71045 28.1773 -53
       vertex -5.25329 28.0319 -49
       vertex -5.67638 27.9185 -53
     endloop
   endfacet
-  facet normal 0.258817 -0.965926 0
+  facet normal 0.25873 -0.96595 0
     outer loop
       vertex -5.25329 28.0319 -49
       vertex -4.71045 28.1773 -53
       vertex -4.71045 28.1773 -49
     endloop
   endfacet
-  facet normal 0.965926 0.258819 0
+  facet normal 0.965925 0.258822 0
     outer loop
       vertex -5.19884 30 -49
       vertex -5.74573 32.041 -52
       vertex -5.74573 32.041 -48
     endloop
   endfacet
-  facet normal 0.965926 0.258819 -0
+  facet normal 0.965925 0.258822 -0
     outer loop
       vertex -5.19884 30 -49
       vertex -5.74573 32.041 -48
       vertex -5.19884 30 -48
     endloop
   endfacet
-  facet normal 0.965926 0.258819 -2.01287e-007
+  facet normal 0.965926 0.258818 -2.92348e-06
     outer loop
       vertex -5.74573 32.041 -52
       vertex -5.19884 30 -49
       vertex -5.48424 31.0651 -52
     endloop
   endfacet
-  facet normal 0.965926 0.258819 -5.96798e-008
+  facet normal 0.965925 0.258821 -1.42886e-06
     outer loop
       vertex -4.71045 28.1773 -53
       vertex -5.48424 31.0651 -52
@@ -11017,88 +10289,130 @@ solid OpenSCAD_Model
       vertex -4.71045 28.1773 -49
     endloop
   endfacet
-  facet normal 0.965926 0.258819 0
+  facet normal 0.965925 0.258821 0
     outer loop
       vertex -5.48424 31.0651 -52
       vertex -4.71045 28.1773 -53
       vertex -5.48424 31.0651 -53
     endloop
   endfacet
-  facet normal -0.965926 -0.258819 0
+  facet normal -0.965926 -0.25882 0
     outer loop
       vertex -5.67638 27.9185 -53
       vertex -6.40917 30.6533 -52
       vertex -6.40917 30.6533 -53
     endloop
   endfacet
-  facet normal -0.965926 -0.258819 -0
+  facet normal -0.965926 -0.25882 -0
     outer loop
       vertex -5.67638 27.9185 -49
       vertex -6.40917 30.6533 -52
       vertex -5.67638 27.9185 -53
     endloop
   endfacet
-  facet normal -0.965926 -0.258819 -8.66598e-008
+  facet normal -0.965926 -0.258819 8.53996e-07
     outer loop
       vertex -6.40917 30.6533 -52
       vertex -5.67638 27.9185 -49
       vertex -6.14856 29.6807 -49
     endloop
   endfacet
-  facet normal -0.965926 -0.258819 -2.72459e-008
+  facet normal -0.965925 -0.258821 2.43856e-07
     outer loop
       vertex -6.14856 29.6807 -49
       vertex -6.71166 31.7822 -52
       vertex -6.40917 30.6533 -52
     endloop
   endfacet
-  facet normal -0.965926 -0.258819 0
+  facet normal -0.965925 -0.258821 0
     outer loop
       vertex -6.71166 31.7822 -52
       vertex -6.14856 29.6807 -49
       vertex -6.71166 31.7822 -48
     endloop
   endfacet
-  facet normal -0.965926 -0.258819 0
+  facet normal -0.965925 -0.258821 0
     outer loop
       vertex -6.71166 31.7822 -48
       vertex -6.14856 29.6807 -49
       vertex -6.14856 29.6807 -48
     endloop
   endfacet
-  facet normal -0.258819 0.965926 0
+  facet normal -0.2588 0.965931 0
     outer loop
       vertex -5.74573 32.041 -52
       vertex -6.71166 31.7822 -48
       vertex -5.74573 32.041 -48
     endloop
   endfacet
-  facet normal -0.258819 0.965926 0
+  facet normal -0.2588 0.965931 0
     outer loop
       vertex -6.71166 31.7822 -48
       vertex -5.74573 32.041 -52
       vertex -6.71166 31.7822 -52
     endloop
   endfacet
-  facet normal -0.258817 -0.965926 0
+  facet normal -0.25873 -0.96595 0
     outer loop
       vertex 4.71045 28.1773 -53
       vertex 5.25329 28.0319 -49
       vertex 4.71045 28.1773 -49
     endloop
   endfacet
-  facet normal -0.258818 -0.965926 1.16016e-007
+  facet normal -0.2588 -0.965931 1.01925e-05
     outer loop
       vertex 5.67638 27.9185 -53
       vertex 5.25329 28.0319 -49
       vertex 4.71045 28.1773 -53
     endloop
   endfacet
-  facet normal -0.258819 -0.965926 0
+  facet normal -0.25889 -0.965907 0
     outer loop
       vertex 5.25329 28.0319 -49
       vertex 5.67638 27.9185 -53
       vertex 5.67638 27.9185 -49
+    endloop
+  endfacet
+  facet normal 0.965925 -0.258821 0
+    outer loop
+      vertex 6.14856 29.6807 -49
+      vertex 6.71166 31.7822 -52
+      vertex 6.71166 31.7822 -48
+    endloop
+  endfacet
+  facet normal 0.965925 -0.258821 0
+    outer loop
+      vertex 6.14856 29.6807 -49
+      vertex 6.71166 31.7822 -48
+      vertex 6.14856 29.6807 -48
+    endloop
+  endfacet
+  facet normal 0.965925 -0.258821 2.43856e-07
+    outer loop
+      vertex 6.71166 31.7822 -52
+      vertex 6.14856 29.6807 -49
+      vertex 6.40917 30.6533 -52
+    endloop
+  endfacet
+  facet normal 0.965926 -0.258819 8.53996e-07
+    outer loop
+      vertex 5.67638 27.9185 -49
+      vertex 6.40917 30.6533 -52
+      vertex 6.14856 29.6807 -49
+    endloop
+  endfacet
+  facet normal 0.965926 -0.25882 0
+    outer loop
+      vertex 6.40917 30.6533 -52
+      vertex 5.67638 27.9185 -49
+      vertex 5.67638 27.9185 -53
+    endloop
+  endfacet
+  facet normal 0.965926 -0.25882 0
+    outer loop
+      vertex 6.40917 30.6533 -52
+      vertex 5.67638 27.9185 -53
+      vertex 6.40917 30.6533 -53
     endloop
   endfacet
   facet normal 0 0 1
@@ -11122,14 +10436,14 @@ solid OpenSCAD_Model
       vertex 5.19884 30 -48
     endloop
   endfacet
-  facet normal -0.965926 0.258819 0
+  facet normal -0.965925 0.258821 0
     outer loop
       vertex 4.71045 28.1773 -53
       vertex 5.48424 31.0651 -52
       vertex 5.48424 31.0651 -53
     endloop
   endfacet
-  facet normal -0.965926 0.258819 -5.96798e-008
+  facet normal -0.965925 0.258821 -1.42886e-06
     outer loop
       vertex 5.48424 31.0651 -52
       vertex 4.71045 28.1773 -53
@@ -11143,81 +10457,39 @@ solid OpenSCAD_Model
       vertex 4.71045 28.1773 -49
     endloop
   endfacet
-  facet normal -0.965926 0.258819 -2.01287e-007
+  facet normal -0.965926 0.258818 -2.92348e-06
     outer loop
       vertex 5.19884 30 -49
       vertex 5.74573 32.041 -52
       vertex 5.48424 31.0651 -52
     endloop
   endfacet
-  facet normal -0.965926 0.258819 0
+  facet normal -0.965925 0.258822 0
     outer loop
       vertex 5.74573 32.041 -52
       vertex 5.19884 30 -49
       vertex 5.74573 32.041 -48
     endloop
   endfacet
-  facet normal -0.965926 0.258819 0
+  facet normal -0.965925 0.258822 0
     outer loop
       vertex 5.74573 32.041 -48
       vertex 5.19884 30 -49
       vertex 5.19884 30 -48
     endloop
   endfacet
-  facet normal 0.258819 0.965926 -0
+  facet normal 0.2588 0.965931 -0
     outer loop
       vertex 6.71166 31.7822 -52
       vertex 5.74573 32.041 -48
       vertex 6.71166 31.7822 -48
     endloop
   endfacet
-  facet normal 0.258819 0.965926 0
+  facet normal 0.2588 0.965931 0
     outer loop
       vertex 5.74573 32.041 -48
       vertex 6.71166 31.7822 -52
       vertex 5.74573 32.041 -52
-    endloop
-  endfacet
-  facet normal 0.965926 -0.258819 0
-    outer loop
-      vertex 6.14856 29.6807 -49
-      vertex 6.71166 31.7822 -52
-      vertex 6.71166 31.7822 -48
-    endloop
-  endfacet
-  facet normal 0.965926 -0.258819 0
-    outer loop
-      vertex 6.14856 29.6807 -49
-      vertex 6.71166 31.7822 -48
-      vertex 6.14856 29.6807 -48
-    endloop
-  endfacet
-  facet normal 0.965926 -0.258819 -2.72459e-008
-    outer loop
-      vertex 6.71166 31.7822 -52
-      vertex 6.14856 29.6807 -49
-      vertex 6.40917 30.6533 -52
-    endloop
-  endfacet
-  facet normal 0.965926 -0.258819 -8.66598e-008
-    outer loop
-      vertex 5.67638 27.9185 -49
-      vertex 6.40917 30.6533 -52
-      vertex 6.14856 29.6807 -49
-    endloop
-  endfacet
-  facet normal 0.965926 -0.258819 0
-    outer loop
-      vertex 6.40917 30.6533 -52
-      vertex 5.67638 27.9185 -49
-      vertex 5.67638 27.9185 -53
-    endloop
-  endfacet
-  facet normal 0.965926 -0.258819 0
-    outer loop
-      vertex 6.40917 30.6533 -52
-      vertex 5.67638 27.9185 -53
-      vertex 6.40917 30.6533 -53
     endloop
   endfacet
   facet normal -1 0 0
@@ -11360,98 +10632,98 @@ solid OpenSCAD_Model
       vertex 11.9114 29.3363 -44.117
     endloop
   endfacet
-  facet normal 0.766044 -0.642788 0
+  facet normal 0.766026 -0.642809 0
     outer loop
       vertex 12.0672 29.522 -45
       vertex 12.4256 29.9491 -52
       vertex 12.4256 29.9491 -45
     endloop
   endfacet
-  facet normal 0.766047 -0.642785 0
+  facet normal 0.766087 -0.642737 0
     outer loop
       vertex 11.9114 29.3363 -52
       vertex 12.0672 29.522 -45
       vertex 11.9114 29.3363 -45
     endloop
   endfacet
-  facet normal 0.766045 -0.642787 1.10034e-007
+  facet normal 0.766045 -0.642787 2.26799e-06
     outer loop
       vertex 12.0672 29.522 -45
       vertex 11.9114 29.3363 -52
       vertex 12.4256 29.9491 -52
     endloop
   endfacet
-  facet normal 0.642789 0.766043 -0
+  facet normal 0.643162 0.76573 -0
     outer loop
       vertex 12.4256 29.9491 -44.009
       vertex 12.365 30 -44
       vertex 12.4256 29.9491 -44
     endloop
   endfacet
-  facet normal 0.642788 0.766044 -0
+  facet normal 0.642855 0.765988 -0
     outer loop
       vertex 12.4256 29.9491 -52
       vertex 11.9833 30.3203 -45
       vertex 12.4256 29.9491 -45
     endloop
   endfacet
-  facet normal 0.642788 0.766044 -3.18916e-008
+  facet normal 0.642788 0.766045 -7.25609e-06
     outer loop
       vertex 11.9833 30.3203 -45
       vertex 12.4256 29.9491 -52
       vertex 7.74447 33.8771 -45
     endloop
   endfacet
-  facet normal 0.642788 0.766045 -1.48112e-007
+  facet normal 0.642788 0.766044 -6.24167e-06
     outer loop
       vertex 5.91423 35.4128 -52
       vertex 7.74447 33.8771 -45
       vertex 12.4256 29.9491 -52
     endloop
   endfacet
-  facet normal 0.642787 0.766045 0
+  facet normal 0.642774 0.766056 0
     outer loop
       vertex 7.74447 33.8771 -45
       vertex 5.91423 35.4128 -52
       vertex 5.91423 35.4128 -45
     endloop
   endfacet
-  facet normal -0.766044 0.642788 0
+  facet normal -0.766026 0.642809 0
     outer loop
       vertex 5.4 34.8 -52
       vertex 5.91423 35.4128 -45
       vertex 5.91423 35.4128 -52
     endloop
   endfacet
-  facet normal -0.766044 0.642788 0
+  facet normal -0.766026 0.642809 0
     outer loop
       vertex 5.91423 35.4128 -45
       vertex 5.4 34.8 -52
       vertex 5.4 34.8 -45
     endloop
   endfacet
-  facet normal -0.642788 -0.766044 -0
+  facet normal -0.642772 -0.766058 -0
     outer loop
       vertex 11.9114 29.3363 -44
       vertex 11.1204 30 -44
       vertex 11.9114 29.3363 -44.117
     endloop
   endfacet
-  facet normal -0.642788 -0.766044 0
+  facet normal -0.642782 -0.76605 0
     outer loop
       vertex 5.4 34.8 -52
       vertex 8.01463 32.6061 -45
       vertex 5.4 34.8 -45
     endloop
   endfacet
-  facet normal -0.642788 -0.766044 -1.60743e-007
+  facet normal -0.642787 -0.766045 3.25161e-06
     outer loop
       vertex 11.9114 29.3363 -52
       vertex 8.01463 32.6061 -45
       vertex 5.4 34.8 -52
     endloop
   endfacet
-  facet normal -0.642788 -0.766045 0
+  facet normal -0.64279 -0.766042 0
     outer loop
       vertex 8.01463 32.6061 -45
       vertex 11.9114 29.3363 -52
@@ -11472,84 +10744,84 @@ solid OpenSCAD_Model
       vertex 11.1204 30 -44
     endloop
   endfacet
-  facet normal 0.642788 -0.766045 0
+  facet normal 0.642798 -0.766036 0
     outer loop
       vertex -12.1971 29.3235 -44
       vertex -12.1971 29.3235 -44.1193
       vertex -11.3909 30 -44
     endloop
   endfacet
-  facet normal 0.64279 -0.766042 -0.000418348
+  facet normal 0.642574 -0.766224 0.000450455
     outer loop
       vertex -12.1971 29.3235 -45.0009
       vertex -12.0775 29.4238 -45
       vertex -12.1909 29.3287 -45
     endloop
   endfacet
-  facet normal 0.642788 -0.766044 1.64352e-008
+  facet normal 0.642797 -0.766037 -6.42879e-06
     outer loop
       vertex -12.0775 29.4238 -45
       vertex -12.1971 29.3235 -52
       vertex -7.95592 32.8823 -45
     endloop
   endfacet
-  facet normal 0.642788 -0.766044 0
+  facet normal 0.642576 -0.766222 0
     outer loop
       vertex -12.0775 29.4238 -45
       vertex -12.1971 29.3235 -45.0009
       vertex -12.1971 29.3235 -52
     endloop
   endfacet
-  facet normal 0.642788 -0.766045 2.11838e-007
+  facet normal 0.642791 -0.766042 -2.34656e-07
     outer loop
       vertex -5.68577 34.7872 -52
       vertex -7.95592 32.8823 -45
       vertex -12.1971 29.3235 -52
     endloop
   endfacet
-  facet normal 0.642787 -0.766045 0
+  facet normal 0.642791 -0.766041 0
     outer loop
       vertex -7.95592 32.8823 -45
       vertex -5.68577 34.7872 -52
       vertex -5.68577 34.7872 -45
     endloop
   endfacet
-  facet normal -0.766044 -0.642788 -0
+  facet normal -0.765983 -0.642861 -0
     outer loop
       vertex -12.1971 29.3235 -44
       vertex -12.7114 29.9363 -44.0112
       vertex -12.1971 29.3235 -44.1193
     endloop
   endfacet
-  facet normal -0.766044 -0.642788 0
+  facet normal -0.765983 -0.642861 0
     outer loop
       vertex -12.7114 29.9363 -44.0112
       vertex -12.1971 29.3235 -44
       vertex -12.7114 29.9363 -44
     endloop
   endfacet
-  facet normal -0.766044 -0.642788 0
+  facet normal -0.765983 -0.642861 0
     outer loop
       vertex -12.1971 29.3235 -45.0009
       vertex -12.7114 29.9363 -45
       vertex -12.7114 29.9363 -52
     endloop
   endfacet
-  facet normal -0.766044 -0.642788 -0
+  facet normal -0.765983 -0.642861 -0
     outer loop
       vertex -12.1971 29.3235 -45.0009
       vertex -12.7114 29.9363 -52
       vertex -12.1971 29.3235 -52
     endloop
   endfacet
-  facet normal -0.766045 -0.642787 -0.000471976
+  facet normal -0.760911 -0.638434 -0.115826
     outer loop
       vertex -12.7114 29.9363 -45
       vertex -12.1971 29.3235 -45.0009
       vertex -12.2016 29.3287 -45
     endloop
   endfacet
-  facet normal -0.642793 0.76604 0
+  facet normal -0.642861 0.765983 0
     outer loop
       vertex -12.6355 30 -44
       vertex -12.7114 29.9363 -44.0112
@@ -11563,21 +10835,21 @@ solid OpenSCAD_Model
       vertex -6.2 35.4 -45
     endloop
   endfacet
-  facet normal -0.642788 0.766044 -1.10835e-007
+  facet normal -0.642787 0.766045 2.59966e-07
     outer loop
       vertex -12.7114 29.9363 -52
       vertex -7.68576 34.1533 -45
       vertex -6.2 35.4 -52
     endloop
   endfacet
-  facet normal -0.642788 0.766044 -1.23404e-007
+  facet normal -0.64279 0.766043 3.98514e-06
     outer loop
       vertex -7.68576 34.1533 -45
       vertex -12.7114 29.9363 -52
       vertex -11.9571 30.5692 -45
     endloop
   endfacet
-  facet normal -0.642788 0.766044 0
+  facet normal -0.642768 0.766061 0
     outer loop
       vertex -11.9571 30.5692 -45
       vertex -12.7114 29.9363 -52
@@ -11598,4043 +10870,2811 @@ solid OpenSCAD_Model
       vertex -12.7114 29.9363 -44
     endloop
   endfacet
-  facet normal 0.766044 0.642788 0
+  facet normal 0.766026 0.642809 0
     outer loop
       vertex -5.68577 34.7872 -45
       vertex -6.2 35.4 -52
       vertex -6.2 35.4 -45
     endloop
   endfacet
-  facet normal 0.766044 0.642788 0
+  facet normal 0.766026 0.642809 0
     outer loop
       vertex -6.2 35.4 -52
       vertex -5.68577 34.7872 -45
       vertex -5.68577 34.7872 -52
     endloop
   endfacet
-  facet normal -0.866025 -0.5 0
+  facet normal -0.866025 -0.500001 0
     outer loop
       vertex 12.65 36.5029 -52
       vertex 10.4 40.4 -45
       vertex 10.4 40.4 -52
     endloop
   endfacet
-  facet normal -0.866025 -0.5 0
+  facet normal -0.866025 -0.500001 0
     outer loop
       vertex 10.4 40.4 -45
       vertex 12.65 36.5029 -52
       vertex 12.65 36.5029 -45
     endloop
   endfacet
-  facet normal 0.500001 -0.866025 0
+  facet normal 0.500011 -0.866019 0
     outer loop
       vertex 12.65 36.5029 -52
       vertex 13.3428 36.9029 -45
       vertex 12.65 36.5029 -45
     endloop
   endfacet
-  facet normal 0.500001 -0.866025 0
+  facet normal 0.500011 -0.866019 0
     outer loop
       vertex 13.3428 36.9029 -45
       vertex 12.65 36.5029 -52
       vertex 13.3428 36.9029 -52
     endloop
   endfacet
-  facet normal -0.500001 0.866025 0
+  facet normal -0.500011 0.866019 0
     outer loop
       vertex 11.0928 40.8 -52
       vertex 10.4 40.4 -45
       vertex 11.0928 40.8 -45
     endloop
   endfacet
-  facet normal -0.500001 0.866025 0
+  facet normal -0.500011 0.866019 0
     outer loop
       vertex 10.4 40.4 -45
       vertex 11.0928 40.8 -52
       vertex 10.4 40.4 -52
     endloop
   endfacet
-  facet normal 0.866025 0.5 0
+  facet normal 0.866025 0.500001 0
     outer loop
       vertex 13.3428 36.9029 -45
       vertex 11.0928 40.8 -52
       vertex 11.0928 40.8 -45
     endloop
   endfacet
-  facet normal 0.866025 0.5 0
+  facet normal 0.866025 0.500001 0
     outer loop
       vertex 11.0928 40.8 -52
       vertex 13.3428 36.9029 -45
       vertex 13.3428 36.9029 -52
     endloop
   endfacet
-  facet normal -0.500001 -0.866025 0
-    outer loop
-      vertex -13.45 37.1029 -52
-      vertex -12.7572 36.7029 -45
-      vertex -13.45 37.1029 -45
-    endloop
-  endfacet
-  facet normal -0.500001 -0.866025 -0
-    outer loop
-      vertex -12.7572 36.7029 -45
-      vertex -13.45 37.1029 -52
-      vertex -12.7572 36.7029 -52
-    endloop
-  endfacet
-  facet normal -0.866025 0.5 0
+  facet normal -0.866025 0.500001 0
     outer loop
       vertex -13.45 37.1029 -52
       vertex -11.2 41 -45
       vertex -11.2 41 -52
     endloop
   endfacet
-  facet normal -0.866025 0.5 0
+  facet normal -0.866025 0.500001 0
     outer loop
       vertex -11.2 41 -45
       vertex -13.45 37.1029 -52
       vertex -13.45 37.1029 -45
     endloop
   endfacet
-  facet normal 0.500001 0.866025 -0
+  facet normal -0.500011 -0.866019 0
+    outer loop
+      vertex -13.45 37.1029 -52
+      vertex -12.7572 36.7029 -45
+      vertex -13.45 37.1029 -45
+    endloop
+  endfacet
+  facet normal -0.500011 -0.866019 -0
+    outer loop
+      vertex -12.7572 36.7029 -45
+      vertex -13.45 37.1029 -52
+      vertex -12.7572 36.7029 -52
+    endloop
+  endfacet
+  facet normal 0.500011 0.866019 -0
     outer loop
       vertex -10.5072 40.6 -52
       vertex -11.2 41 -45
       vertex -10.5072 40.6 -45
     endloop
   endfacet
-  facet normal 0.500001 0.866025 0
+  facet normal 0.500011 0.866019 0
     outer loop
       vertex -11.2 41 -45
       vertex -10.5072 40.6 -52
       vertex -11.2 41 -52
     endloop
   endfacet
-  facet normal 0.866025 -0.5 0
+  facet normal 0.866025 -0.500001 0
     outer loop
       vertex -12.7572 36.7029 -45
       vertex -10.5072 40.6 -52
       vertex -10.5072 40.6 -45
     endloop
   endfacet
-  facet normal 0.866025 -0.5 0
+  facet normal 0.866025 -0.500001 0
     outer loop
       vertex -10.5072 40.6 -52
       vertex -12.7572 36.7029 -45
       vertex -12.7572 36.7029 -52
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 1 -0
     outer loop
-      vertex -9.05876 50.8 -46.1753
-      vertex -8.94154 50.8 -46.9684
-      vertex -8.58543 50.8 -46.899
+      vertex -1.7849 52.8 -51
+      vertex -2.83589 52.8 -46.904
+      vertex -1.7849 52.8 -46.904
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 1 0
     outer loop
-      vertex -9.15521 50.8 -47.1768
-      vertex -10.0102 50.8 -46.7572
-      vertex -10.1499 50.8 -47.0882
+      vertex -2.83589 52.8 -46.904
+      vertex -1.7849 52.8 -51
+      vertex -2.83589 52.8 -51
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 1 0
     outer loop
-      vertex -9.77744 50.8 -46.49
-      vertex -9.15521 50.8 -47.1768
-      vertex -8.94154 50.8 -46.9684
+      vertex -1.7849 52.8 -46.904
+      vertex -0.282898 52.8 -46.008
+      vertex -0.282898 52.8 -46.904
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 1 0
     outer loop
-      vertex -9.21319 50.8 -47.4595
-      vertex -10.1499 50.8 -47.0882
-      vertex -10.1937 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -10.1499 50.8 -47.0882
-      vertex -9.21319 50.8 -47.4595
-      vertex -9.15521 50.8 -47.1768
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.58543 50.8 -46.899
-      vertex -8.57843 50.8 -46.136
-      vertex -9.05876 50.8 -46.1753
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.39432 50.8 -46.917
-      vertex -8.57843 50.8 -46.136
-      vertex -8.58543 50.8 -46.899
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.94154 50.8 -46.9684
-      vertex -9.05876 50.8 -46.1753
-      vertex -9.45844 50.8 -46.2933
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.57843 50.8 -46.136
-      vertex -8.39432 50.8 -46.917
-      vertex -8.12955 50.8 -46.1746
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.94154 50.8 -46.9684
-      vertex -9.45844 50.8 -46.2933
-      vertex -9.77744 50.8 -46.49
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.23566 50.8 -46.971
-      vertex -8.12955 50.8 -46.1746
-      vertex -8.39432 50.8 -46.917
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -9.15521 50.8 -47.1768
-      vertex -9.77744 50.8 -46.49
-      vertex -10.0102 50.8 -46.7572
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -8.12955 50.8 -46.1746
-      vertex -8.23566 50.8 -46.971
-      vertex -7.74821 50.8 -46.2902
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.10944 50.8 -47.061
-      vertex -7.74821 50.8 -46.2902
-      vertex -8.23566 50.8 -46.971
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -7.74821 50.8 -46.2902
-      vertex -8.10944 50.8 -47.061
-      vertex -7.43443 50.8 -46.483
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -8.01244 50.8 -47.1862
-      vertex -7.43443 50.8 -46.483
-      vertex -8.10944 50.8 -47.061
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -7.43443 50.8 -46.483
-      vertex -8.01244 50.8 -47.1862
-      vertex -7.19199 50.8 -46.7491
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -7.94144 50.8 -47.3472
-      vertex -7.19199 50.8 -46.7491
-      vertex -8.01244 50.8 -47.1862
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -7.19199 50.8 -46.7491
-      vertex -7.94144 50.8 -47.3472
-      vertex -7.02466 50.8 -47.0848
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -7.91576 50.8 -47.4595
-      vertex -7.02466 50.8 -47.0848
-      vertex -7.94144 50.8 -47.3472
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -7.02466 50.8 -47.0848
-      vertex -7.91576 50.8 -47.4595
-      vertex -6.93938 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 5.416 50.8 -47.4595
-      vertex 6.42101 50.8 -46.2
-      vertex 5.416 50.8 -46.2
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 6.42101 50.8 -46.2
-      vertex 5.416 50.8 -47.4595
-      vertex 6.42101 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 8.52701 50.8 -47.4595
-      vertex 9.53201 50.8 -46.2
-      vertex 8.52701 50.8 -46.2
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 9.53201 50.8 -46.2
-      vertex 8.52701 50.8 -47.4595
-      vertex 9.53201 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 2.36508 50.8 -46.136
-      vertex 1.95354 50.8 -46.9749
-      vertex 2.36508 50.8 -46.926
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1.06242 50.8 -46.4262
-      vertex 1.6082 50.8 -47.1216
-      vertex 1.95354 50.8 -46.9749
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1.27087 50.8 -47.4595
-      vertex 0.578079 50.8 -46.789
-      vertex 0.220306 50.8 -47.2778
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1.06242 50.8 -46.4262
-      vertex 1.32909 50.8 -47.366
-      vertex 1.6082 50.8 -47.1216
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1.27087 50.8 -47.4595
-      vertex 0.220306 50.8 -47.2778
-      vertex 0.154976 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 0.578079 50.8 -46.789
-      vertex 1.27087 50.8 -47.4595
-      vertex 1.32909 50.8 -47.366
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1.95354 50.8 -46.9749
-      vertex 2.36508 50.8 -46.136
-      vertex 1.65808 50.8 -46.2086
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 2.7823 50.8 -46.9746
-      vertex 2.36508 50.8 -46.136
-      vertex 2.36508 50.8 -46.926
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1.95354 50.8 -46.9749
-      vertex 1.65808 50.8 -46.2086
-      vertex 1.06242 50.8 -46.4262
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 2.36508 50.8 -46.136
-      vertex 2.7823 50.8 -46.9746
-      vertex 3.07198 50.8 -46.2078
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1.32909 50.8 -47.366
-      vertex 1.06242 50.8 -46.4262
-      vertex 0.578079 50.8 -46.789
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 3.1313 50.8 -47.1202
-      vertex 3.07198 50.8 -46.2078
-      vertex 2.7823 50.8 -46.9746
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 3.07198 50.8 -46.2078
-      vertex 3.1313 50.8 -47.1202
-      vertex 3.66731 50.8 -46.4231
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 3.41208 50.8 -47.363
-      vertex 3.66731 50.8 -46.4231
-      vertex 3.1313 50.8 -47.1202
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 3.66731 50.8 -46.4231
-      vertex 3.41208 50.8 -47.363
-      vertex 4.15109 50.8 -46.782
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 3.47219 50.8 -47.4595
-      vertex 4.15109 50.8 -46.782
-      vertex 3.41208 50.8 -47.363
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 4.15109 50.8 -46.782
-      vertex 3.47219 50.8 -47.4595
-      vertex 4.50775 50.8 -47.2684
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 4.50775 50.8 -47.2684
-      vertex 3.47219 50.8 -47.4595
-      vertex 4.57596 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.83774 50.8 -47.4595
-      vertex -1.83275 50.8 -46.977
-      vertex -2.83774 50.8 -46.977
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -1.83275 50.8 -46.977
-      vertex -2.83774 50.8 -47.4595
-      vertex -1.83275 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -2.83774 50.8 -46.977
-      vertex -4.36874 50.8 -46.2
-      vertex -4.36874 50.8 -46.977
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -4.36874 50.8 -46.2
-      vertex -2.83774 50.8 -46.977
-      vertex -0.296738 50.8 -46.2
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.83275 50.8 -46.977
-      vertex -0.296738 50.8 -46.2
-      vertex -2.83774 50.8 -46.977
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -0.296738 50.8 -46.2
-      vertex -1.83275 50.8 -46.977
-      vertex -0.296738 50.8 -46.977
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -5.9574 50.8 -47.4595
-      vertex -4.99588 50.8 -46.2
-      vertex -5.99788 50.8 -46.2
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -4.99588 50.8 -46.2
-      vertex -5.9574 50.8 -47.4595
-      vertex -5.03635 50.8 -47.4595
+      vertex -0.282898 52.8 -46.008
+      vertex -1.7849 52.8 -46.904
+      vertex -4.33089 52.8 -46.008
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 2.7823 52.8 -46.9746
-      vertex 2.36508 52.8 -46.136
-      vertex 3.07198 52.8 -46.2078
+      vertex -2.83589 52.8 -46.904
+      vertex -4.33089 52.8 -46.008
+      vertex -1.7849 52.8 -46.904
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -4.33089 52.8 -46.008
+      vertex -2.83589 52.8 -46.904
+      vertex -4.33089 52.8 -46.904
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 3.1313 52.8 -47.1202
-      vertex 3.07198 52.8 -46.2078
-      vertex 3.66731 52.8 -46.4231
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.36508 52.8 -46.136
-      vertex 2.7823 52.8 -46.9746
-      vertex 2.36508 52.8 -46.926
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.41208 52.8 -47.363
-      vertex 3.66731 52.8 -46.4231
-      vertex 4.15109 52.8 -46.782
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.36508 52.8 -46.136
-      vertex 1.95354 52.8 -46.9749
-      vertex 1.65808 52.8 -46.2086
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.6082 52.8 -47.1216
-      vertex 1.65808 52.8 -46.2086
-      vertex 1.95354 52.8 -46.9749
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.95354 52.8 -46.9749
-      vertex 2.36508 52.8 -46.136
-      vertex 2.36508 52.8 -46.926
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.07198 52.8 -46.2078
-      vertex 3.1313 52.8 -47.1202
-      vertex 2.7823 52.8 -46.9746
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.61708 52.8 -47.692
-      vertex 4.15109 52.8 -46.782
-      vertex 4.50775 52.8 -47.2684
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.66731 52.8 -46.4231
-      vertex 3.41208 52.8 -47.363
-      vertex 3.1313 52.8 -47.1202
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.15109 52.8 -46.782
-      vertex 3.61708 52.8 -47.692
-      vertex 3.41208 52.8 -47.363
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.72176 52.8 -47.8678
-      vertex 3.61708 52.8 -47.692
-      vertex 4.50775 52.8 -47.2684
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.72176 52.8 -47.8678
-      vertex 3.74008 52.8 -48.0977
-      vertex 3.61708 52.8 -47.692
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.79309 52.8 -48.58
-      vertex 3.74008 52.8 -48.0977
-      vertex 4.72176 52.8 -47.8678
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.79309 52.8 -48.58
-      vertex 3.78108 52.8 -48.58
-      vertex 3.74008 52.8 -48.0977
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.79309 52.8 -48.58
-      vertex 3.73909 52.8 -49.0677
-      vertex 3.78108 52.8 -48.58
+      vertex 2.74963 52.8 -46.826
+      vertex 2.36452 52.8 -45.88
+      vertex 3.02242 52.8 -45.9443
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 4.72163 52.8 -49.2956
-      vertex 3.73909 52.8 -49.0677
-      vertex 4.79309 52.8 -48.58
+      vertex 3.07997 52.8 -46.976
+      vertex 3.02242 52.8 -45.9443
+      vertex 3.56808 52.8 -46.1373
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 4.72163 52.8 -49.2956
-      vertex 3.61308 52.8 -49.4813
-      vertex 3.73909 52.8 -49.0677
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 4.50731 52.8 -49.9022
-      vertex 3.61308 52.8 -49.4813
-      vertex 4.72163 52.8 -49.2956
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 4.15009 52.8 -50.4
-      vertex 3.61308 52.8 -49.4813
-      vertex 4.50731 52.8 -49.9022
+      vertex 1.97864 52.8 -46.8261
+      vertex 2.36452 52.8 -45.88
+      vertex 2.36353 52.8 -46.776
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 3.61308 52.8 -49.4813
-      vertex 4.15009 52.8 -50.4
-      vertex 3.40309 52.8 -49.821
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 3.66631 52.8 -50.7689
-      vertex 3.40309 52.8 -49.821
-      vertex 4.15009 52.8 -50.4
+      vertex 3.07997 52.8 -46.976
+      vertex 3.56808 52.8 -46.1373
+      vertex 4.00153 52.8 -46.459
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 3.07364 52.8 -50.9902
-      vertex 3.12053 52.8 -50.0727
-      vertex 3.66631 52.8 -50.7689
+      vertex 2.36452 52.8 -45.88
+      vertex 1.97864 52.8 -46.8261
+      vertex 1.70609 52.8 -45.9443
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 3.40309 52.8 -49.821
-      vertex 3.66631 52.8 -50.7689
-      vertex 3.12053 52.8 -50.0727
+      vertex 1.65063 52.8 -46.9765
+      vertex 1.70609 52.8 -45.9443
+      vertex 1.97864 52.8 -46.8261
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 1.65808 52.8 -46.2086
-      vertex 1.6082 52.8 -47.1216
-      vertex 1.06242 52.8 -46.4262
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.32909 52.8 -47.366
-      vertex 1.06242 52.8 -46.4262
-      vertex 1.6082 52.8 -47.1216
+      vertex 2.36452 52.8 -45.88
+      vertex 2.74963 52.8 -46.826
+      vertex 2.36353 52.8 -46.776
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 1.06242 52.8 -46.4262
-      vertex 1.32909 52.8 -47.366
-      vertex 0.578079 52.8 -46.789
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.12354 52.8 -47.696
-      vertex 0.578079 52.8 -46.789
-      vertex 1.32909 52.8 -47.366
+      vertex 3.02242 52.8 -45.9443
+      vertex 3.07997 52.8 -46.976
+      vertex 2.74963 52.8 -46.826
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0.578079 52.8 -46.789
-      vertex 1.12354 52.8 -47.696
-      vertex 0.220306 52.8 -47.2778
+      vertex 3.35452 52.8 -47.226
+      vertex 4.00153 52.8 -46.459
+      vertex 4.42375 52.8 -46.9898
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 1.12354 52.8 -47.696
-      vertex 0.00564575 52.8 -47.8748
-      vertex 0.220306 52.8 -47.2778
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 1.0002 52.8 -48.1007
-      vertex 0.00564575 52.8 -47.8748
-      vertex 1.12354 52.8 -47.696
+      vertex 4.00153 52.8 -46.459
+      vertex 3.35452 52.8 -47.226
+      vertex 3.07997 52.8 -46.976
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.065918 52.8 -48.58
-      vertex 1.0002 52.8 -48.1007
-      vertex 0.959091 52.8 -48.58
+      vertex 4.42375 52.8 -46.9898
+      vertex 3.55952 52.8 -47.5676
+      vertex 3.35452 52.8 -47.226
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 1.0002 52.8 -48.1007
-      vertex -0.065918 52.8 -48.58
-      vertex 0.00564575 52.8 -47.8748
+      vertex 4.67708 52.8 -47.6714
+      vertex 3.55952 52.8 -47.5676
+      vertex 4.42375 52.8 -46.9898
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0.959091 52.8 -48.58
-      vertex -0.0329132 52.8 -49.0581
-      vertex -0.065918 52.8 -48.58
+      vertex 4.67708 52.8 -47.6714
+      vertex 3.68253 52.8 -47.9936
+      vertex 3.55952 52.8 -47.5676
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0.999969 52.8 -49.0797
-      vertex -0.0329132 52.8 -49.0581
-      vertex 0.959091 52.8 -48.58
+      vertex 4.76152 52.8 -48.504
+      vertex 3.68253 52.8 -47.9936
+      vertex 4.67708 52.8 -47.6714
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0.999969 52.8 -49.0797
-      vertex 0.0660858 52.8 -49.4964
-      vertex -0.0329132 52.8 -49.0581
+      vertex 4.76152 52.8 -48.504
+      vertex 3.72353 52.8 -48.504
+      vertex 3.68253 52.8 -47.9936
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 1.12263 52.8 -49.4973
-      vertex 0.0660858 52.8 -49.4964
-      vertex 0.999969 52.8 -49.0797
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 0.457535 52.8 -50.2435
-      vertex 1.12263 52.8 -49.4973
-      vertex 1.32709 52.8 -49.833
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.12263 52.8 -49.4973
-      vertex 0.231079 52.8 -49.895
-      vertex 0.0660858 52.8 -49.4964
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.08109 52.8 -50.763
-      vertex 1.32709 52.8 -49.833
-      vertex 1.60631 52.8 -50.078
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.47031 52.8 -50.9302
-      vertex 1.60631 52.8 -50.078
-      vertex 1.95464 52.8 -50.225
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.12263 52.8 -49.4973
-      vertex 0.457535 52.8 -50.2435
-      vertex 0.231079 52.8 -49.895
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.90063 52.8 -51.0305
-      vertex 1.95464 52.8 -50.225
-      vertex 2.37209 52.8 -50.274
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3.12053 52.8 -50.0727
-      vertex 3.07364 52.8 -50.9902
-      vertex 2.77687 52.8 -50.2237
-    endloop
-  endfacet
-  facet normal -0 1 0
-    outer loop
-      vertex 1.90063 52.8 -51.0305
-      vertex 2.37209 52.8 -50.274
-      vertex 2.37209 52.8 -51.064
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.95464 52.8 -50.225
-      vertex 1.90063 52.8 -51.0305
-      vertex 1.47031 52.8 -50.9302
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.37209 52.8 -51.064
-      vertex 2.77687 52.8 -50.2237
-      vertex 3.07364 52.8 -50.9902
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.60631 52.8 -50.078
-      vertex 1.47031 52.8 -50.9302
-      vertex 1.08109 52.8 -50.763
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.77687 52.8 -50.2237
-      vertex 2.37209 52.8 -51.064
-      vertex 2.37209 52.8 -50.274
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.32709 52.8 -49.833
-      vertex 1.08109 52.8 -50.763
-      vertex 0.74086 52.8 -50.5328
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 1.32709 52.8 -49.833
-      vertex 0.74086 52.8 -50.5328
-      vertex 0.457535 52.8 -50.2435
+      vertex 4.76152 52.8 -48.504
+      vertex 3.68253 52.8 -49.0146
+      vertex 3.72353 52.8 -48.504
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -8.39432 52.8 -46.917
-      vertex -8.57843 52.8 -46.136
-      vertex -8.12955 52.8 -46.1746
+      vertex 4.67708 52.8 -49.325
+      vertex 3.68253 52.8 -49.0146
+      vertex 4.76152 52.8 -48.504
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -8.23566 52.8 -46.971
-      vertex -8.12955 52.8 -46.1746
-      vertex -7.74821 52.8 -46.2902
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.57843 52.8 -46.136
-      vertex -8.39432 52.8 -46.917
-      vertex -8.58543 52.8 -46.899
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.10944 52.8 -47.061
-      vertex -7.74821 52.8 -46.2902
-      vertex -7.43443 52.8 -46.483
+      vertex 4.67708 52.8 -49.325
+      vertex 3.55952 52.8 -49.4409
+      vertex 3.68253 52.8 -49.0146
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -8.94154 52.8 -46.9684
-      vertex -9.05876 52.8 -46.1753
-      vertex -8.58543 52.8 -46.899
+      vertex 4.42375 52.8 -50.0067
+      vertex 3.55952 52.8 -49.4409
+      vertex 4.67708 52.8 -49.325
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -8.01244 52.8 -47.1862
-      vertex -7.43443 52.8 -46.483
-      vertex -7.19199 52.8 -46.7491
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.05876 52.8 -46.1753
-      vertex -8.94154 52.8 -46.9684
-      vertex -9.45844 52.8 -46.2933
+      vertex 3.55952 52.8 -49.4409
+      vertex 4.42375 52.8 -50.0067
+      vertex 3.35452 52.8 -49.783
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -9.15521 52.8 -47.1768
-      vertex -9.45844 52.8 -46.2933
-      vertex -8.94154 52.8 -46.9684
+      vertex 4.00153 52.8 -50.549
+      vertex 3.35452 52.8 -49.783
+      vertex 4.42375 52.8 -50.0067
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -8.57843 52.8 -46.136
-      vertex -8.58543 52.8 -46.899
-      vertex -9.05876 52.8 -46.1753
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.12955 52.8 -46.1746
-      vertex -8.23566 52.8 -46.971
-      vertex -8.39432 52.8 -46.917
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.74821 52.8 -46.2902
-      vertex -8.10944 52.8 -47.061
-      vertex -8.23566 52.8 -46.971
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.94144 52.8 -47.3472
-      vertex -7.19199 52.8 -46.7491
-      vertex -7.02466 52.8 -47.0848
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.43443 52.8 -46.483
-      vertex -8.01244 52.8 -47.1862
-      vertex -8.10944 52.8 -47.061
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.19199 52.8 -46.7491
-      vertex -7.94144 52.8 -47.3472
-      vertex -8.01244 52.8 -47.1862
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.89642 52.8 -47.544
-      vertex -7.02466 52.8 -47.0848
-      vertex -6.93243 52.8 -47.49
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.02466 52.8 -47.0848
-      vertex -7.89642 52.8 -47.544
-      vertex -7.94144 52.8 -47.3472
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.45844 52.8 -46.2933
-      vertex -9.15521 52.8 -47.1768
-      vertex -9.77744 52.8 -46.49
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.77744 52.8 -46.49
-      vertex -9.15521 52.8 -47.1768
-      vertex -10.0102 52.8 -46.7572
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.0102 52.8 -46.7572
-      vertex -9.15521 52.8 -47.1768
-      vertex -10.1499 52.8 -47.0882
+      vertex 3.35452 52.8 -49.783
+      vertex 4.00153 52.8 -50.549
+      vertex 3.07997 52.8 -50.0325
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -9.22643 52.8 -47.524
-      vertex -10.1499 52.8 -47.0882
-      vertex -9.15521 52.8 -47.1768
+      vertex 3.56808 52.8 -50.8707
+      vertex 3.07997 52.8 -50.0325
+      vertex 4.00153 52.8 -50.549
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -10.1499 52.8 -47.0882
-      vertex -9.22643 52.8 -47.524
-      vertex -10.1964 52.8 -47.483
+      vertex 3.02242 52.8 -51.0637
+      vertex 3.07997 52.8 -50.0325
+      vertex 3.56808 52.8 -50.8707
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -10.1815 52.8 -47.6999
-      vertex -9.22643 52.8 -47.524
-      vertex -9.20366 52.8 -47.6952
+      vertex 1.70609 52.8 -45.9443
+      vertex 1.65063 52.8 -46.9765
+      vertex 1.16008 52.8 -46.1373
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -9.22643 52.8 -47.524
-      vertex -10.1815 52.8 -47.6999
-      vertex -10.1964 52.8 -47.483
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -10.0624 52.8 -48.091
-      vertex -9.20366 52.8 -47.6952
-      vertex -9.13531 52.8 -47.8689
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.20366 52.8 -47.6952
-      vertex -10.1369 52.8 -47.9026
-      vertex -10.1815 52.8 -47.6999
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.84999 52.8 -48.435
-      vertex -9.13531 52.8 -47.8689
-      vertex -9.02142 52.8 -48.045
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.20366 52.8 -47.6952
-      vertex -10.0624 52.8 -48.091
-      vertex -10.1369 52.8 -47.9026
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.57321 52.8 -48.7426
-      vertex -9.02142 52.8 -48.045
-      vertex -8.85155 52.8 -48.2376
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.13531 52.8 -47.8689
-      vertex -9.96465 52.8 -48.2677
-      vertex -10.0624 52.8 -48.091
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.13531 52.8 -47.8689
-      vertex -9.84999 52.8 -48.435
-      vertex -9.96465 52.8 -48.2677
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.25143 52.8 -49.023
-      vertex -8.85155 52.8 -48.2376
-      vertex -8.61388 52.8 -48.4619
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.02142 52.8 -48.045
-      vertex -9.71843 52.8 -48.593
-      vertex -9.84999 52.8 -48.435
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -9.02142 52.8 -48.045
-      vertex -9.57321 52.8 -48.7426
-      vertex -9.71843 52.8 -48.593
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.85155 52.8 -48.2376
-      vertex -9.41754 52.8 -48.8859
-      vertex -9.57321 52.8 -48.7426
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.75443 52.8 -49.414
-      vertex -8.61388 52.8 -48.4619
-      vertex -7.9752 52.8 -48.9976
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.85155 52.8 -48.2376
-      vertex -9.25143 52.8 -49.023
-      vertex -9.41754 52.8 -48.8859
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.45309 52.8 -49.6691
-      vertex -7.9752 52.8 -48.9976
-      vertex -7.68221 52.8 -49.2696
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.61388 52.8 -48.4619
-      vertex -8.75443 52.8 -49.414
-      vertex -9.25143 52.8 -49.023
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.19577 52.8 -49.9303
-      vertex -7.68221 52.8 -49.2696
-      vertex -7.42943 52.8 -49.534
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.9752 52.8 -48.9976
-      vertex -8.59909 52.8 -49.5411
-      vertex -8.75443 52.8 -49.414
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.9752 52.8 -48.9976
-      vertex -8.45309 52.8 -49.6691
-      vertex -8.59909 52.8 -49.5411
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.02243 52.8 -50.213
-      vertex -7.42943 52.8 -49.534
-      vertex -7.21454 52.8 -49.797
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.68221 52.8 -49.2696
-      vertex -8.31644 52.8 -49.798
-      vertex -8.45309 52.8 -49.6691
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.68221 52.8 -49.2696
-      vertex -8.19577 52.8 -49.9303
-      vertex -8.31644 52.8 -49.798
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.02243 52.8 -50.213
-      vertex -7.21454 52.8 -49.797
-      vertex -7.0352 52.8 -50.0647
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.42943 52.8 -49.534
-      vertex -8.09776 52.8 -50.0687
-      vertex -8.19577 52.8 -49.9303
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -7.42943 52.8 -49.534
-      vertex -8.02243 52.8 -50.213
-      vertex -8.09776 52.8 -50.0687
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -6.89143 52.8 -50.337
-      vertex -8.02243 52.8 -50.213
-      vertex -7.0352 52.8 -50.0647
+      vertex 1.16008 52.8 -46.1373
+      vertex 1.65063 52.8 -46.9765
+      vertex 0.726517 52.8 -46.459
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -6.89143 52.8 -51
-      vertex -8.02243 52.8 -50.213
-      vertex -6.89143 52.8 -50.337
+      vertex 1.37952 52.8 -47.227
+      vertex 0.726517 52.8 -46.459
+      vertex 1.65063 52.8 -46.9765
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -8.02243 52.8 -50.213
-      vertex -6.89143 52.8 -51
-      vertex -10.2714 52.8 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -8.02243 52.8 -50.213
-      vertex -10.2714 52.8 -51
-      vertex -10.2714 52.8 -50.213
+      vertex 0.726517 52.8 -46.459
+      vertex 1.37952 52.8 -47.227
+      vertex 0.306519 52.8 -46.9898
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -1.83275 52.8 -51
-      vertex -2.83774 52.8 -46.977
-      vertex -1.83275 52.8 -46.977
+      vertex 1.17674 52.8 -47.5693
+      vertex 0.306519 52.8 -46.9898
+      vertex 1.37952 52.8 -47.227
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -2.83774 52.8 -46.977
-      vertex -1.83275 52.8 -51
-      vertex -2.83774 52.8 -51
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -1.83275 52.8 -46.977
-      vertex -0.296738 52.8 -46.2
-      vertex -0.296738 52.8 -46.977
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.296738 52.8 -46.2
-      vertex -1.83275 52.8 -46.977
-      vertex -4.36874 52.8 -46.2
+      vertex 1.17674 52.8 -47.5693
+      vertex 0.0545197 52.8 -47.6714
+      vertex 0.306519 52.8 -46.9898
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -2.83774 52.8 -46.977
-      vertex -4.36874 52.8 -46.2
-      vertex -1.83275 52.8 -46.977
+      vertex 1.05508 52.8 -47.995
+      vertex 0.0545197 52.8 -47.6714
+      vertex 1.17674 52.8 -47.5693
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -4.36874 52.8 -46.2
-      vertex -2.83774 52.8 -46.977
-      vertex -4.36874 52.8 -46.977
+      vertex -0.02948 52.8 -48.504
+      vertex 1.05508 52.8 -47.995
+      vertex 1.01453 52.8 -48.504
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.05508 52.8 -47.995
+      vertex -0.02948 52.8 -48.504
+      vertex 0.0545197 52.8 -47.6714
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.05508 52.8 -49.0146
+      vertex -0.02948 52.8 -48.504
+      vertex 1.01453 52.8 -48.504
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.05508 52.8 -49.0146
+      vertex 0.0545197 52.8 -49.325
+      vertex -0.02948 52.8 -48.504
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.17674 52.8 -49.4409
+      vertex 0.0545197 52.8 -49.325
+      vertex 1.05508 52.8 -49.0146
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.306519 52.8 -50.0067
+      vertex 1.17674 52.8 -49.4409
+      vertex 1.37952 52.8 -49.783
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.17674 52.8 -49.4409
+      vertex 0.306519 52.8 -50.0067
+      vertex 0.0545197 52.8 -49.325
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.726517 52.8 -50.549
+      vertex 1.37952 52.8 -49.783
+      vertex 1.65063 52.8 -50.0325
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -4.99588 52.8 -51
-      vertex -5.97687 52.8 -50.104
-      vertex -4.99588 52.8 -50.104
+      vertex 1.70609 52.8 -51.0637
+      vertex 1.65063 52.8 -50.0325
+      vertex 1.97864 52.8 -50.1821
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -5.97687 52.8 -50.104
-      vertex -4.99588 52.8 -51
-      vertex -5.97687 52.8 -51
+      vertex 2.36452 52.8 -51.128
+      vertex 1.97864 52.8 -50.1821
+      vertex 2.36353 52.8 -50.232
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.53201 52.8 -46.2
-      vertex 8.52701 52.8 -48.12
-      vertex 8.52701 52.8 -46.2
+      vertex 3.07997 52.8 -50.0325
+      vertex 3.02242 52.8 -51.0637
+      vertex 2.74963 52.8 -50.1821
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 8.52701 52.8 -48.12
-      vertex 8.52701 52.8 -48.951
-      vertex 6.42101 52.8 -48.12
+      vertex 1.97864 52.8 -50.1821
+      vertex 2.36452 52.8 -51.128
+      vertex 1.70609 52.8 -51.0637
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 9.53201 52.8 -46.2
-      vertex 8.52701 52.8 -48.951
-      vertex 8.52701 52.8 -48.12
+      vertex 2.36452 52.8 -51.128
+      vertex 2.74963 52.8 -50.1821
+      vertex 3.02242 52.8 -51.0637
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.65063 52.8 -50.0325
+      vertex 1.70609 52.8 -51.0637
+      vertex 1.16008 52.8 -50.8707
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 2.74963 52.8 -50.1821
+      vertex 2.36452 52.8 -51.128
+      vertex 2.36353 52.8 -50.232
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.37952 52.8 -49.783
+      vertex 0.726517 52.8 -50.549
+      vertex 0.306519 52.8 -50.0067
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.65063 52.8 -50.0325
+      vertex 1.16008 52.8 -50.8707
+      vertex 0.726517 52.8 -50.549
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 9.47801 52.8 -46.008
+      vertex 8.444 52.8 -47.928
+      vertex 8.444 52.8 -46.008
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 8.444 52.8 -47.928
+      vertex 8.444 52.8 -48.824
+      vertex 6.49101 52.8 -47.928
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 9.47801 52.8 -46.008
+      vertex 8.444 52.8 -48.824
+      vertex 8.444 52.8 -47.928
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 9.53201 52.8 -51
-      vertex 8.52701 52.8 -48.951
-      vertex 9.53201 52.8 -46.2
+      vertex 9.47801 52.8 -51
+      vertex 8.444 52.8 -48.824
+      vertex 9.47801 52.8 -46.008
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 8.52701 52.8 -48.951
-      vertex 9.53201 52.8 -51
-      vertex 8.52701 52.8 -51
+      vertex 8.444 52.8 -48.824
+      vertex 9.47801 52.8 -51
+      vertex 8.444 52.8 -51
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 6.42101 52.8 -48.12
-      vertex 5.416 52.8 -46.2
-      vertex 6.42101 52.8 -46.2
+      vertex 6.49101 52.8 -47.928
+      vertex 5.453 52.8 -46.008
+      vertex 6.49101 52.8 -46.008
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 6.42101 52.8 -48.951
-      vertex 6.42101 52.8 -48.12
-      vertex 8.52701 52.8 -48.951
+      vertex 6.49101 52.8 -48.824
+      vertex 6.49101 52.8 -47.928
+      vertex 8.444 52.8 -48.824
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 6.42101 52.8 -48.951
-      vertex 5.416 52.8 -46.2
-      vertex 6.42101 52.8 -48.12
+      vertex 6.49101 52.8 -48.824
+      vertex 5.453 52.8 -46.008
+      vertex 6.49101 52.8 -47.928
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 5.416 52.8 -51
-      vertex 6.42101 52.8 -48.951
-      vertex 6.42101 52.8 -51
+      vertex 5.453 52.8 -51
+      vertex 6.49101 52.8 -48.824
+      vertex 6.49101 52.8 -51
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 6.42101 52.8 -48.951
-      vertex 5.416 52.8 -51
-      vertex 5.416 52.8 -46.2
+      vertex 6.49101 52.8 -48.824
+      vertex 5.453 52.8 -51
+      vertex 5.453 52.8 -46.008
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex -5.10487 52.8 -49.592
-      vertex -5.99788 52.8 -46.2
-      vertex -4.99588 52.8 -46.2
+      vertex -5.07549 52.8 -47.27
+      vertex -6.13649 52.8 -46.008
+      vertex -5.07549 52.8 -46.008
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -5.99788 52.8 -46.2
-      vertex -5.10487 52.8 -49.592
-      vertex -5.88887 52.8 -49.592
+      vertex -5.07549 52.8 -47.27
+      vertex -6.13649 52.8 -47.27
+      vertex -6.13649 52.8 -46.008
     endloop
   endfacet
-  facet normal -0.227018 0 -0.973891
+  facet normal 0 1 -0
     outer loop
-      vertex 1.47031 52 -50.9302
-      vertex 1.90063 52.8 -51.0305
-      vertex 1.90063 52 -51.0305
+      vertex -5.35649 52.8 -49.592
+      vertex -6.13649 52.8 -47.27
+      vertex -5.07549 52.8 -47.27
     endloop
   endfacet
-  facet normal -0.227018 0 -0.973891
+  facet normal 0 1 0
     outer loop
-      vertex 1.90063 52.8 -51.0305
-      vertex 1.47031 52 -50.9302
-      vertex 1.47031 52.8 -50.9302
+      vertex -6.13649 52.8 -47.27
+      vertex -5.35649 52.8 -49.592
+      vertex -5.86249 52.8 -49.592
     endloop
   endfacet
-  facet normal -0.394771 0 -0.918779
+  facet normal 0 1 -0
     outer loop
-      vertex 1.08109 52 -50.763
-      vertex 1.47031 52.8 -50.9302
-      vertex 1.47031 52 -50.9302
+      vertex -7.85262 52.8 -46.9391
+      vertex -8.06828 52.8 -46.072
+      vertex -7.47694 52.8 -46.1528
     endloop
   endfacet
-  facet normal -0.394771 0 -0.918779
+  facet normal 0 1 0
     outer loop
-      vertex 1.47031 52.8 -50.9302
-      vertex 1.08109 52 -50.763
-      vertex 1.08109 52.8 -50.763
+      vertex -8.31339 52.8 -46.9267
+      vertex -8.06828 52.8 -46.072
+      vertex -8.11528 52.8 -46.904
     endloop
   endfacet
-  facet normal -0.560405 0 -0.828219
+  facet normal 0 1 0
     outer loop
-      vertex 0.74086 52 -50.5328
-      vertex 1.08109 52.8 -50.763
-      vertex 1.08109 52 -50.763
+      vertex -7.65262 52.8 -47.0444
+      vertex -7.47694 52.8 -46.1528
+      vertex -7.01895 52.8 -46.3951
     endloop
   endfacet
-  facet normal -0.560405 0 -0.828219
+  facet normal 0 1 0
     outer loop
-      vertex 1.08109 52.8 -50.763
-      vertex 0.74086 52 -50.5328
-      vertex 0.74086 52.8 -50.5328
+      vertex -8.06828 52.8 -46.072
+      vertex -8.31339 52.8 -46.9267
+      vertex -8.55284 52.8 -46.1199
     endloop
   endfacet
-  facet normal -0.714491 0 -0.699645
+  facet normal 0 1 0
     outer loop
-      vertex 0.74086 52 -50.5328
-      vertex 0.457535 52.8 -50.2435
-      vertex 0.74086 52.8 -50.5328
+      vertex -7.51527 52.8 -47.22
+      vertex -7.01895 52.8 -46.3951
+      vertex -6.69427 52.8 -46.799
     endloop
   endfacet
-  facet normal -0.714491 -0 -0.699645
+  facet normal 0 1 -0
     outer loop
-      vertex 0.457535 52.8 -50.2435
-      vertex 0.74086 52 -50.5328
-      vertex 0.457535 52 -50.2435
+      vertex -8.47839 52.8 -46.9947
+      vertex -8.55284 52.8 -46.1199
+      vertex -8.31339 52.8 -46.9267
     endloop
   endfacet
-  facet normal -0.838484 0 -0.544926
+  facet normal 0 1 0
     outer loop
-      vertex 0.457535 52 -50.2435
-      vertex 0.231079 52.8 -49.895
-      vertex 0.457535 52.8 -50.2435
+      vertex -8.55284 52.8 -46.1199
+      vertex -8.47839 52.8 -46.9947
+      vertex -8.96651 52.8 -46.2636
     endloop
   endfacet
-  facet normal -0.838484 -0 -0.544926
+  facet normal 0 1 0
     outer loop
-      vertex 0.231079 52.8 -49.895
-      vertex 0.457535 52 -50.2435
-      vertex 0.231079 52 -49.895
+      vertex -8.06828 52.8 -46.072
+      vertex -7.85262 52.8 -46.9391
+      vertex -8.11528 52.8 -46.904
     endloop
   endfacet
-  facet normal -0.923958 0 -0.382494
+  facet normal 0 1 0
     outer loop
-      vertex 0.231079 52 -49.895
-      vertex 0.0660858 52.8 -49.4964
-      vertex 0.231079 52.8 -49.895
+      vertex -7.47694 52.8 -46.1528
+      vertex -7.65262 52.8 -47.0444
+      vertex -7.85262 52.8 -46.9391
     endloop
   endfacet
-  facet normal -0.923958 -0 -0.382494
+  facet normal 0 1 0
     outer loop
-      vertex 0.0660858 52.8 -49.4964
-      vertex 0.231079 52 -49.895
-      vertex 0.0660858 52 -49.4964
+      vertex -7.51527 52.8 -47.22
+      vertex -6.69427 52.8 -46.799
+      vertex -6.57884 52.8 -47.0796
     endloop
   endfacet
-  facet normal -0.97543 0 -0.220309
+  facet normal 0 1 0
     outer loop
-      vertex 0.0660858 52 -49.4964
-      vertex -0.0329132 52.8 -49.0581
-      vertex 0.0660858 52.8 -49.4964
+      vertex -7.01895 52.8 -46.3951
+      vertex -7.51527 52.8 -47.22
+      vertex -7.65262 52.8 -47.0444
     endloop
   endfacet
-  facet normal -0.97543 -0 -0.220309
+  facet normal 0 1 0
     outer loop
-      vertex -0.0329132 52.8 -49.0581
-      vertex 0.0660858 52 -49.4964
-      vertex -0.0329132 52 -49.0581
+      vertex -6.57884 52.8 -47.0796
+      vertex -7.46228 52.8 -47.3658
+      vertex -7.51527 52.8 -47.22
     endloop
   endfacet
-  facet normal -0.997626 0 -0.0688666
+  facet normal 0 1 0
     outer loop
-      vertex -0.0329132 52 -49.0581
-      vertex -0.065918 52.8 -48.58
-      vertex -0.0329132 52.8 -49.0581
+      vertex -6.50317 52.8 -47.4132
+      vertex -7.46228 52.8 -47.3658
+      vertex -6.57884 52.8 -47.0796
     endloop
   endfacet
-  facet normal -0.997626 -0 -0.0688666
+  facet normal 0 1 0
     outer loop
-      vertex -0.065918 52.8 -48.58
-      vertex -0.0329132 52 -49.0581
-      vertex -0.065918 52 -48.58
+      vertex -6.50317 52.8 -47.4132
+      vertex -7.42595 52.8 -47.5591
+      vertex -7.46228 52.8 -47.3658
     endloop
   endfacet
-  facet normal -0.994891 0 0.100959
+  facet normal 0 1 0
     outer loop
-      vertex -0.065918 52 -48.58
-      vertex 0.00564575 52.8 -47.8748
-      vertex -0.065918 52.8 -48.58
+      vertex -7.40628 52.8 -47.8
+      vertex -6.50317 52.8 -47.4132
+      vertex -6.46729 52.8 -47.8
     endloop
   endfacet
-  facet normal -0.994891 0 0.100959
+  facet normal 0 1 0
     outer loop
-      vertex 0.00564575 52.8 -47.8748
-      vertex -0.065918 52 -48.58
-      vertex 0.00564575 52 -47.8748
+      vertex -6.50317 52.8 -47.4132
+      vertex -7.40628 52.8 -47.8
+      vertex -7.42595 52.8 -47.5591
     endloop
   endfacet
-  facet normal -0.941019 0 0.338355
+  facet normal 0 1 -0
     outer loop
-      vertex 0.220306 50.8 -47.2778
-      vertex 0.220306 50.859 -47.2778
-      vertex 0.154976 50.8 -47.4595
+      vertex -8.61028 52.8 -47.108
+      vertex -8.96651 52.8 -46.2636
+      vertex -8.47839 52.8 -46.9947
     endloop
   endfacet
-  facet normal -0.941018 0 0.338357
+  facet normal 0 1 0
     outer loop
-      vertex 0.00564575 52 -47.8748
-      vertex 0.220306 52.8 -47.2778
-      vertex 0.00564575 52.8 -47.8748
+      vertex -8.96651 52.8 -46.2636
+      vertex -8.61028 52.8 -47.108
+      vertex -9.30928 52.8 -46.503
     endloop
   endfacet
-  facet normal -0.941018 0 0.338357
+  facet normal 0 1 -0
     outer loop
-      vertex 0.220306 52.8 -47.2778
-      vertex 0.00564575 52 -47.8748
-      vertex 0.220306 52 -47.2778
+      vertex -8.70639 52.8 -47.2548
+      vertex -9.30928 52.8 -46.503
+      vertex -8.61028 52.8 -47.108
     endloop
   endfacet
-  facet normal -0.806923 0 0.590657
+  facet normal 0 1 0
     outer loop
-      vertex 0.220306 50.8 -47.2778
-      vertex 0.242497 50.8689 -47.2475
-      vertex 0.220306 50.859 -47.2778
+      vertex -9.30928 52.8 -46.503
+      vertex -8.70639 52.8 -47.2548
+      vertex -9.5654 52.8 -46.8213
     endloop
   endfacet
-  facet normal -0.806932 8.23788e-006 0.590645
+  facet normal 0 1 -0
     outer loop
-      vertex 0.242497 50.8689 -47.2475
-      vertex 0.220306 50.8 -47.2778
-      vertex 0.578079 50.8 -46.789
+      vertex -8.76405 52.8 -47.4245
+      vertex -9.5654 52.8 -46.8213
+      vertex -8.70639 52.8 -47.2548
     endloop
   endfacet
-  facet normal -0.806932 0 0.590644
+  facet normal 0 1 0
     outer loop
-      vertex 0.242497 50.8689 -47.2475
-      vertex 0.578079 50.8 -46.789
-      vertex 0.578079 50.9171 -46.789
+      vertex -9.5654 52.8 -46.8213
+      vertex -8.76405 52.8 -47.4245
+      vertex -9.71906 52.8 -47.2017
     endloop
   endfacet
-  facet normal -0.806932 0 0.590645
+  facet normal 0 1 -0
     outer loop
-      vertex 0.220306 52 -47.2778
-      vertex 0.578079 52.8 -46.789
-      vertex 0.220306 52.8 -47.2778
+      vertex -8.78328 52.8 -47.617
+      vertex -9.71906 52.8 -47.2017
+      vertex -8.76405 52.8 -47.4245
     endloop
   endfacet
-  facet normal -0.806932 0 0.590645
+  facet normal 0 1 0
     outer loop
-      vertex 0.578079 52.8 -46.789
-      vertex 0.220306 52 -47.2778
-      vertex 0.578079 52 -46.789
+      vertex -8.78328 52.8 -47.617
+      vertex -9.77028 52.8 -47.644
+      vertex -9.71906 52.8 -47.2017
     endloop
   endfacet
-  facet normal -0.599491 0 0.800381
+  facet normal 0 1 0
     outer loop
-      vertex 0.777154 50.9327 -46.6399
-      vertex 1.06242 50.8 -46.4262
-      vertex 1.06242 50.9552 -46.4262
+      vertex -9.73405 52.8 -47.9931
+      vertex -8.78328 52.8 -47.617
+      vertex -8.74973 52.8 -47.8617
     endloop
   endfacet
-  facet normal -0.599492 0 0.800381
+  facet normal 0 1 0
     outer loop
-      vertex 0.578079 50.8 -46.789
-      vertex 0.777154 50.9327 -46.6399
-      vertex 0.578079 50.9171 -46.789
+      vertex -8.78328 52.8 -47.617
+      vertex -9.73405 52.8 -47.9931
+      vertex -9.77028 52.8 -47.644
     endloop
   endfacet
-  facet normal -0.599492 -1.78204e-006 0.800381
+  facet normal 0 1 0
     outer loop
-      vertex 0.777154 50.9327 -46.6399
-      vertex 0.578079 50.8 -46.789
-      vertex 1.06242 50.8 -46.4262
+      vertex -9.6254 52.8 -48.3151
+      vertex -8.74973 52.8 -47.8617
+      vertex -8.64906 52.8 -48.093
     endloop
   endfacet
-  facet normal -0.599492 0 0.800381
+  facet normal 0 1 0
     outer loop
-      vertex 0.578079 52.8 -46.789
-      vertex 1.06242 52 -46.4262
-      vertex 1.06242 52.8 -46.4262
+      vertex -9.27162 52.8 -48.805
+      vertex -8.64906 52.8 -48.093
+      vertex -8.48128 52.8 -48.311
     endloop
   endfacet
-  facet normal -0.599492 0 0.800381
+  facet normal 0 1 0
     outer loop
-      vertex 1.06242 52 -46.4262
-      vertex 0.578079 52.8 -46.789
-      vertex 0.578079 52 -46.789
+      vertex -8.74973 52.8 -47.8617
+      vertex -9.6254 52.8 -48.3151
+      vertex -9.73405 52.8 -47.9931
     endloop
   endfacet
-  facet normal -0.343224 0 0.939253
+  facet normal 0 1 0
     outer loop
-      vertex 1.06242 50.9552 -46.4262
-      vertex 1.65808 50.8 -46.2086
-      vertex 1.65808 50.9781 -46.2086
+      vertex -9.03761 52.8 -49.0153
+      vertex -8.48128 52.8 -48.311
+      vertex -8.29817 52.8 -48.4776
     endloop
   endfacet
-  facet normal -0.343224 0 0.939253
+  facet normal 0 1 0
     outer loop
-      vertex 1.65808 50.8 -46.2086
-      vertex 1.06242 50.9552 -46.4262
-      vertex 1.06242 50.8 -46.4262
+      vertex -8.64906 52.8 -48.093
+      vertex -9.44427 52.8 -48.61
+      vertex -9.6254 52.8 -48.3151
     endloop
   endfacet
-  facet normal -0.343224 0 0.939253
+  facet normal 0 1 0
     outer loop
-      vertex 1.06242 52.8 -46.4262
-      vertex 1.65808 52 -46.2086
-      vertex 1.65808 52.8 -46.2086
+      vertex -8.74228 52.8 -49.241
+      vertex -8.29817 52.8 -48.4776
+      vertex -8.01018 52.8 -48.7066
     endloop
   endfacet
-  facet normal -0.343224 0 0.939253
+  facet normal 0 1 0
     outer loop
-      vertex 1.65808 52 -46.2086
-      vertex 1.06242 52.8 -46.4262
-      vertex 1.06242 52 -46.4262
+      vertex -8.64906 52.8 -48.093
+      vertex -9.27162 52.8 -48.805
+      vertex -9.44427 52.8 -48.61
     endloop
   endfacet
-  facet normal -0.102088 0 0.994775
+  facet normal 0 1 0
     outer loop
-      vertex 1.65808 50.9781 -46.2086
-      vertex 2.36508 50.8 -46.136
-      vertex 2.36508 50.9857 -46.136
+      vertex -8.35628 52.8 -49.519
+      vertex -8.01018 52.8 -48.7066
+      vertex -7.61728 52.8 -48.998
     endloop
   endfacet
-  facet normal -0.102088 0 0.994775
+  facet normal 0 1 0
     outer loop
-      vertex 2.36508 50.8 -46.136
-      vertex 1.65808 50.9781 -46.2086
-      vertex 1.65808 50.8 -46.2086
+      vertex -8.48128 52.8 -48.311
+      vertex -9.03761 52.8 -49.0153
+      vertex -9.27162 52.8 -48.805
     endloop
   endfacet
-  facet normal -0.102088 0 0.994775
+  facet normal 0 1 0
     outer loop
-      vertex 1.65808 52.8 -46.2086
-      vertex 2.36508 52 -46.136
-      vertex 2.36508 52.8 -46.136
+      vertex -8.29817 52.8 -48.4776
+      vertex -8.74228 52.8 -49.241
+      vertex -9.03761 52.8 -49.0153
     endloop
   endfacet
-  facet normal -0.102088 0 0.994775
+  facet normal 0 1 0
     outer loop
-      vertex 2.36508 52 -46.136
-      vertex 1.65808 52.8 -46.2086
-      vertex 1.65808 52 -46.2086
+      vertex -7.97406 52.8 -49.803
+      vertex -7.61728 52.8 -48.998
+      vertex -7.1665 52.8 -49.3611
     endloop
   endfacet
-  facet normal 0.10102 -0 0.994884
+  facet normal 0 1 0
     outer loop
-      vertex 2.36508 50.8 -46.136
-      vertex 3.07198 50.9782 -46.2078
-      vertex 2.36508 50.9857 -46.136
+      vertex -8.01018 52.8 -48.7066
+      vertex -8.35628 52.8 -49.519
+      vertex -8.74228 52.8 -49.241
     endloop
   endfacet
-  facet normal 0.10102 0 0.994884
+  facet normal 0 1 0
     outer loop
-      vertex 3.07198 50.9782 -46.2078
-      vertex 2.36508 50.8 -46.136
-      vertex 3.07198 50.8 -46.2078
+      vertex -7.61728 52.8 -48.998
+      vertex -8.13972 52.8 -49.677
+      vertex -8.35628 52.8 -49.519
     endloop
   endfacet
-  facet normal 0.10102 0 0.994884
+  facet normal 0 1 0
     outer loop
-      vertex 2.36508 52.8 -46.136
-      vertex 3.07198 52 -46.2078
-      vertex 3.07198 52.8 -46.2078
+      vertex -7.69972 52.8 -50.069
+      vertex -7.1665 52.8 -49.3611
+      vertex -6.84084 52.8 -49.7091
     endloop
   endfacet
-  facet normal 0.10102 0 0.994884
+  facet normal 0 1 0
     outer loop
-      vertex 3.07198 52 -46.2078
-      vertex 2.36508 52.8 -46.136
-      vertex 2.36508 52 -46.136
+      vertex -7.61728 52.8 -48.998
+      vertex -7.97406 52.8 -49.803
+      vertex -8.13972 52.8 -49.677
     endloop
   endfacet
-  facet normal 0.340154 -0 0.94037
+  facet normal 0 1 0
     outer loop
-      vertex 3.07198 50.8 -46.2078
-      vertex 3.66731 50.9555 -46.4231
-      vertex 3.07198 50.9782 -46.2078
+      vertex -7.1665 52.8 -49.3611
+      vertex -7.85928 52.8 -49.897
+      vertex -7.97406 52.8 -49.803
     endloop
   endfacet
-  facet normal 0.340154 0 0.94037
+  facet normal 0 1 0
     outer loop
-      vertex 3.66731 50.9555 -46.4231
-      vertex 3.07198 50.8 -46.2078
-      vertex 3.66731 50.8 -46.4231
+      vertex -7.1665 52.8 -49.3611
+      vertex -7.77472 52.8 -49.9787
+      vertex -7.85928 52.8 -49.897
     endloop
   endfacet
-  facet normal 0.340154 0 0.94037
+  facet normal 0 1 0
     outer loop
-      vertex 3.07198 52.8 -46.2078
-      vertex 3.66731 52 -46.4231
-      vertex 3.66731 52.8 -46.4231
+      vertex -7.63428 52.8 -50.168
+      vertex -6.84084 52.8 -49.7091
+      vertex -6.64027 52.8 -50.042
     endloop
   endfacet
-  facet normal 0.340154 0 0.94037
+  facet normal 0 1 0
     outer loop
-      vertex 3.66731 52 -46.4231
-      vertex 3.07198 52.8 -46.2078
-      vertex 3.07198 52 -46.2078
+      vertex -7.1665 52.8 -49.3611
+      vertex -7.69972 52.8 -50.069
+      vertex -7.77472 52.8 -49.9787
     endloop
   endfacet
-  facet normal 0.595796 0 0.803136
+  facet normal 0 1 0
     outer loop
-      vertex 4.05128 50.9256 -46.708
-      vertex 4.15109 50.8 -46.782
-      vertex 4.15109 50.9178 -46.782
+      vertex -6.84084 52.8 -49.7091
+      vertex -7.63428 52.8 -50.168
+      vertex -7.69972 52.8 -50.069
     endloop
   endfacet
-  facet normal 0.595797 -0 0.803135
+  facet normal 0 1 0
     outer loop
-      vertex 3.66731 50.8 -46.4231
-      vertex 4.05128 50.9256 -46.708
-      vertex 3.66731 50.9555 -46.4231
+      vertex -6.52039 52.8 -50.3409
+      vertex -7.63428 52.8 -50.168
+      vertex -6.64027 52.8 -50.042
     endloop
   endfacet
-  facet normal 0.595797 1.15797e-006 0.803135
+  facet normal 0 1 0
     outer loop
-      vertex 4.05128 50.9256 -46.708
-      vertex 3.66731 50.8 -46.4231
-      vertex 4.15109 50.8 -46.782
+      vertex -6.44473 52.8 -50.6602
+      vertex -7.63428 52.8 -50.168
+      vertex -6.52039 52.8 -50.3409
     endloop
   endfacet
-  facet normal 0.595797 0 0.803135
+  facet normal 0 1 0
     outer loop
-      vertex 3.66731 52.8 -46.4231
-      vertex 4.15109 52 -46.782
-      vertex 4.15109 52.8 -46.782
+      vertex -6.41328 52.8 -51
+      vertex -7.63428 52.8 -50.168
+      vertex -6.44473 52.8 -50.6602
     endloop
   endfacet
-  facet normal 0.595797 0 0.803135
+  facet normal 0 1 0
     outer loop
-      vertex 4.15109 52 -46.782
-      vertex 3.66731 52.8 -46.4231
-      vertex 3.66731 52 -46.4231
+      vertex -7.63428 52.8 -50.168
+      vertex -6.41328 52.8 -51
+      vertex -9.78029 52.8 -51
     endloop
   endfacet
-  facet normal 0.806453 -0 0.591298
+  facet normal 0 1 0
     outer loop
-      vertex 4.15109 50.8 -46.782
-      vertex 4.49237 50.8689 -47.2475
-      vertex 4.15109 50.9178 -46.782
+      vertex -7.63428 52.8 -50.168
+      vertex -9.78029 52.8 -51
+      vertex -9.78029 52.8 -50.168
     endloop
   endfacet
-  facet normal 0.806452 9.08741e-006 0.591299
+  facet normal 0 1 -0
     outer loop
-      vertex 4.50775 50.8 -47.2684
-      vertex 4.49237 50.8689 -47.2475
-      vertex 4.15109 50.8 -46.782
+      vertex -5.09949 52.8 -51
+      vertex -6.1095 52.8 -49.976
+      vertex -5.09949 52.8 -49.976
     endloop
   endfacet
-  facet normal 0.806438 0 0.591318
+  facet normal 0 1 0
     outer loop
-      vertex 4.49237 50.8689 -47.2475
-      vertex 4.50775 50.8 -47.2684
-      vertex 4.50775 50.8621 -47.2684
+      vertex -6.1095 52.8 -49.976
+      vertex -5.09949 52.8 -51
+      vertex -6.1095 52.8 -51
     endloop
   endfacet
-  facet normal 0.806452 -0 0.591299
+  facet normal -0.333266 0 -0.942833
     outer loop
-      vertex 4.15109 52 -46.782
-      vertex 4.50775 52.8 -47.2684
-      vertex 4.15109 52.8 -46.782
+      vertex 1.16008 52 -50.8707
+      vertex 1.70609 52.8 -51.0637
+      vertex 1.70609 52 -51.0637
     endloop
   endfacet
-  facet normal 0.806452 0 0.591299
+  facet normal -0.333266 0 -0.942833
     outer loop
-      vertex 4.50775 52.8 -47.2684
-      vertex 4.15109 52 -46.782
-      vertex 4.50775 52 -47.2684
+      vertex 1.70609 52.8 -51.0637
+      vertex 1.16008 52 -50.8707
+      vertex 1.16008 52.8 -50.8707
     endloop
   endfacet
-  facet normal 0.941764 -0 0.336274
+  facet normal -0.595876 0 -0.803077
     outer loop
-      vertex 4.50775 50.8 -47.2684
-      vertex 4.57596 50.8 -47.4595
-      vertex 4.50775 50.8621 -47.2684
+      vertex 0.726517 52 -50.549
+      vertex 1.16008 52.8 -50.8707
+      vertex 1.16008 52 -50.8707
     endloop
   endfacet
-  facet normal 0.941764 -0 0.336276
+  facet normal -0.595876 0 -0.803077
     outer loop
-      vertex 4.50775 52 -47.2684
-      vertex 4.72176 52.8 -47.8678
-      vertex 4.50775 52.8 -47.2684
+      vertex 1.16008 52.8 -50.8707
+      vertex 0.726517 52 -50.549
+      vertex 0.726517 52.8 -50.549
     endloop
   endfacet
-  facet normal 0.941764 0 0.336276
+  facet normal -0.790616 0 -0.612313
     outer loop
-      vertex 4.72176 52.8 -47.8678
-      vertex 4.50775 52 -47.2684
-      vertex 4.72176 52 -47.8678
+      vertex 0.726517 52 -50.549
+      vertex 0.306519 52.8 -50.0067
+      vertex 0.726517 52.8 -50.549
     endloop
   endfacet
-  facet normal 0.995022 -0 0.0996599
+  facet normal -0.790616 -0 -0.612313
     outer loop
-      vertex 4.72176 52 -47.8678
-      vertex 4.79309 52.8 -48.58
-      vertex 4.72176 52.8 -47.8678
+      vertex 0.306519 52.8 -50.0067
+      vertex 0.726517 52 -50.549
+      vertex 0.306519 52 -50.0067
     endloop
   endfacet
-  facet normal 0.995022 0 0.0996599
+  facet normal -0.937965 0 -0.346731
     outer loop
-      vertex 4.79309 52.8 -48.58
-      vertex 4.72176 52 -47.8678
-      vertex 4.79309 52 -48.58
+      vertex 0.306519 52 -50.0067
+      vertex 0.0545197 52.8 -49.325
+      vertex 0.306519 52.8 -50.0067
     endloop
   endfacet
-  facet normal 0.995051 0 -0.0993672
+  facet normal -0.937965 -0 -0.346731
     outer loop
-      vertex 4.79309 52 -48.58
-      vertex 4.72163 52.8 -49.2956
-      vertex 4.79309 52.8 -48.58
+      vertex 0.0545197 52.8 -49.325
+      vertex 0.306519 52 -50.0067
+      vertex 0.0545197 52 -49.325
     endloop
   endfacet
-  facet normal 0.995051 0 -0.0993672
+  facet normal -0.994807 0 -0.101783
     outer loop
-      vertex 4.72163 52.8 -49.2956
-      vertex 4.79309 52 -48.58
-      vertex 4.72163 52 -49.2956
+      vertex 0.0545197 52 -49.325
+      vertex -0.02948 52.8 -48.504
+      vertex 0.0545197 52.8 -49.325
     endloop
   endfacet
-  facet normal 0.94289 0 -0.333103
+  facet normal -0.994807 -0 -0.101783
     outer loop
-      vertex 4.72163 52 -49.2956
-      vertex 4.50731 52.8 -49.9022
-      vertex 4.72163 52.8 -49.2956
+      vertex -0.02948 52.8 -48.504
+      vertex 0.0545197 52 -49.325
+      vertex -0.02948 52 -48.504
     endloop
   endfacet
-  facet normal 0.94289 0 -0.333103
+  facet normal -0.994949 0 0.100379
     outer loop
-      vertex 4.50731 52.8 -49.9022
-      vertex 4.72163 52 -49.2956
-      vertex 4.50731 52 -49.9022
+      vertex -0.02948 52 -48.504
+      vertex 0.0545197 52.8 -47.6714
+      vertex -0.02948 52.8 -48.504
     endloop
   endfacet
-  facet normal 0.812441 0 -0.583044
+  facet normal -0.994949 0 0.100379
     outer loop
-      vertex 4.50731 52 -49.9022
-      vertex 4.15009 52.8 -50.4
-      vertex 4.50731 52.8 -49.9022
+      vertex 0.0545197 52.8 -47.6714
+      vertex -0.02948 52 -48.504
+      vertex 0.0545197 52 -47.6714
     endloop
   endfacet
-  facet normal 0.812441 0 -0.583044
+  facet normal -0.937948 0 0.346776
     outer loop
-      vertex 4.15009 52.8 -50.4
-      vertex 4.50731 52 -49.9022
-      vertex 4.15009 52 -50.4
+      vertex 0.0545197 52 -47.6714
+      vertex 0.306519 52.8 -46.9898
+      vertex 0.0545197 52.8 -47.6714
     endloop
   endfacet
-  facet normal 0.606342 0 -0.795204
+  facet normal -0.937948 0 0.346776
     outer loop
-      vertex 3.66631 52 -50.7689
-      vertex 4.15009 52.8 -50.4
-      vertex 4.15009 52 -50.4
+      vertex 0.306519 52.8 -46.9898
+      vertex 0.0545197 52 -47.6714
+      vertex 0.306519 52 -46.9898
     endloop
   endfacet
-  facet normal 0.606342 0 -0.795204
+  facet normal -0.784203 0 0.620504
     outer loop
-      vertex 4.15009 52.8 -50.4
-      vertex 3.66631 52 -50.7689
-      vertex 3.66631 52.8 -50.7689
+      vertex 0.306519 52 -46.9898
+      vertex 0.726517 52.8 -46.459
+      vertex 0.306519 52.8 -46.9898
     endloop
   endfacet
-  facet normal 0.349868 0 -0.936799
+  facet normal -0.784203 0 0.620504
     outer loop
-      vertex 3.07364 52 -50.9902
-      vertex 3.66631 52.8 -50.7689
-      vertex 3.66631 52 -50.7689
+      vertex 0.726517 52.8 -46.459
+      vertex 0.306519 52 -46.9898
+      vertex 0.726517 52 -46.459
     endloop
   endfacet
-  facet normal 0.349868 0 -0.936799
+  facet normal -0.595876 0 0.803077
     outer loop
-      vertex 3.66631 52.8 -50.7689
-      vertex 3.07364 52 -50.9902
-      vertex 3.07364 52.8 -50.9902
+      vertex 0.726517 52.8 -46.459
+      vertex 1.16008 52 -46.1373
+      vertex 1.16008 52.8 -46.1373
     endloop
   endfacet
-  facet normal 0.104563 0 -0.994518
+  facet normal -0.595876 0 0.803077
     outer loop
-      vertex 2.37209 52 -51.064
-      vertex 3.07364 52.8 -50.9902
-      vertex 3.07364 52 -50.9902
+      vertex 1.16008 52 -46.1373
+      vertex 0.726517 52.8 -46.459
+      vertex 0.726517 52 -46.459
     endloop
   endfacet
-  facet normal 0.104563 0 -0.994518
+  facet normal -0.333266 0 0.942833
     outer loop
-      vertex 3.07364 52.8 -50.9902
-      vertex 2.37209 52 -51.064
-      vertex 2.37209 52.8 -51.064
+      vertex 1.16008 52.8 -46.1373
+      vertex 1.70609 52 -45.9443
+      vertex 1.70609 52.8 -45.9443
     endloop
   endfacet
-  facet normal -0.0707675 0 -0.997493
+  facet normal -0.333266 0 0.942833
     outer loop
-      vertex 1.90063 52 -51.0305
-      vertex 2.37209 52.8 -51.064
-      vertex 2.37209 52 -51.064
+      vertex 1.70609 52 -45.9443
+      vertex 1.16008 52.8 -46.1373
+      vertex 1.16008 52 -46.1373
     endloop
   endfacet
-  facet normal -0.0707675 0 -0.997493
+  facet normal -0.0971942 0 0.995265
     outer loop
-      vertex 2.37209 52.8 -51.064
-      vertex 1.90063 52 -51.0305
-      vertex 1.90063 52.8 -51.0305
+      vertex 1.70609 52.8 -45.9443
+      vertex 2.36452 52 -45.88
+      vertex 2.36452 52.8 -45.88
     endloop
   endfacet
-  facet normal -0.402273 0 0.91552
+  facet normal -0.0971942 0 0.995265
     outer loop
-      vertex 2.77687 52.8 -50.2237
-      vertex 3.12053 52 -50.0727
-      vertex 3.12053 52.8 -50.0727
+      vertex 2.36452 52 -45.88
+      vertex 1.70609 52.8 -45.9443
+      vertex 1.70609 52 -45.9443
     endloop
   endfacet
-  facet normal -0.402273 0 0.91552
+  facet normal 0.0972717 0 0.995258
     outer loop
-      vertex 3.12053 52 -50.0727
-      vertex 2.77687 52.8 -50.2237
-      vertex 2.77687 52 -50.2237
+      vertex 2.36452 52.8 -45.88
+      vertex 3.02242 52 -45.9443
+      vertex 3.02242 52.8 -45.9443
     endloop
   endfacet
-  facet normal -0.665097 0 0.746757
+  facet normal 0.0972717 0 0.995258
     outer loop
-      vertex 3.12053 52.8 -50.0727
-      vertex 3.40309 52 -49.821
-      vertex 3.40309 52.8 -49.821
+      vertex 3.02242 52 -45.9443
+      vertex 2.36452 52.8 -45.88
+      vertex 2.36452 52 -45.88
     endloop
   endfacet
-  facet normal -0.665097 0 0.746757
+  facet normal 0.333456 0 0.942766
     outer loop
-      vertex 3.40309 52 -49.821
-      vertex 3.12053 52.8 -50.0727
-      vertex 3.12053 52 -50.0727
+      vertex 3.02242 52.8 -45.9443
+      vertex 3.56808 52 -46.1373
+      vertex 3.56808 52.8 -46.1373
     endloop
   endfacet
-  facet normal -0.850583 0 0.52584
+  facet normal 0.333456 0 0.942766
     outer loop
-      vertex 3.40309 52 -49.821
-      vertex 3.61308 52.8 -49.4813
-      vertex 3.40309 52.8 -49.821
+      vertex 3.56808 52 -46.1373
+      vertex 3.02242 52.8 -45.9443
+      vertex 3.02242 52 -45.9443
     endloop
   endfacet
-  facet normal -0.850583 0 0.52584
+  facet normal 0.595976 0 0.803002
     outer loop
-      vertex 3.61308 52.8 -49.4813
-      vertex 3.40309 52 -49.821
-      vertex 3.61308 52 -49.4813
+      vertex 3.56808 52.8 -46.1373
+      vertex 4.00153 52 -46.459
+      vertex 4.00153 52.8 -46.459
     endloop
   endfacet
-  facet normal -0.956604 0 0.291392
+  facet normal 0.595976 0 0.803002
     outer loop
-      vertex 3.61308 52 -49.4813
-      vertex 3.73909 52.8 -49.0677
-      vertex 3.61308 52.8 -49.4813
+      vertex 4.00153 52 -46.459
+      vertex 3.56808 52.8 -46.1373
+      vertex 3.56808 52 -46.1373
     endloop
   endfacet
-  facet normal -0.956604 0 0.291392
+  facet normal 0.782606 -0 0.622517
     outer loop
-      vertex 3.73909 52.8 -49.0677
-      vertex 3.61308 52 -49.4813
-      vertex 3.73909 52 -49.0677
+      vertex 4.00153 52 -46.459
+      vertex 4.42375 52.8 -46.9898
+      vertex 4.00153 52.8 -46.459
     endloop
   endfacet
-  facet normal -0.996313 0 0.0857902
+  facet normal 0.782606 0 0.622517
     outer loop
-      vertex 3.73909 52 -49.0677
-      vertex 3.78108 52.8 -48.58
-      vertex 3.73909 52.8 -49.0677
+      vertex 4.42375 52.8 -46.9898
+      vertex 4.00153 52 -46.459
+      vertex 4.42375 52 -46.9898
     endloop
   endfacet
-  facet normal -0.996313 0 0.0857902
+  facet normal 0.937352 -0 0.348385
     outer loop
-      vertex 3.78108 52.8 -48.58
-      vertex 3.73909 52 -49.0677
-      vertex 3.78108 52 -48.58
+      vertex 4.42375 52 -46.9898
+      vertex 4.67708 52.8 -47.6714
+      vertex 4.42375 52.8 -46.9898
     endloop
   endfacet
-  facet normal -0.996407 0 -0.0846993
+  facet normal 0.937352 0 0.348385
     outer loop
-      vertex 3.78108 52 -48.58
-      vertex 3.74008 52.8 -48.0977
-      vertex 3.78108 52.8 -48.58
+      vertex 4.67708 52.8 -47.6714
+      vertex 4.42375 52 -46.9898
+      vertex 4.67708 52 -47.6714
     endloop
   endfacet
-  facet normal -0.996407 -0 -0.0846993
+  facet normal 0.994897 -0 0.1009
     outer loop
-      vertex 3.74008 52.8 -48.0977
-      vertex 3.78108 52 -48.58
-      vertex 3.74008 52 -48.0977
+      vertex 4.67708 52 -47.6714
+      vertex 4.76152 52.8 -48.504
+      vertex 4.67708 52.8 -47.6714
     endloop
   endfacet
-  facet normal -0.956978 0 -0.29016
+  facet normal 0.994897 0 0.1009
     outer loop
-      vertex 3.74008 52 -48.0977
-      vertex 3.61708 52.8 -47.692
-      vertex 3.74008 52.8 -48.0977
+      vertex 4.76152 52.8 -48.504
+      vertex 4.67708 52 -47.6714
+      vertex 4.76152 52 -48.504
     endloop
   endfacet
-  facet normal -0.956978 -0 -0.29016
+  facet normal 0.994753 0 -0.10231
     outer loop
-      vertex 3.61708 52.8 -47.692
-      vertex 3.74008 52 -48.0977
-      vertex 3.61708 52 -47.692
+      vertex 4.76152 52 -48.504
+      vertex 4.67708 52.8 -49.325
+      vertex 4.76152 52.8 -48.504
     endloop
   endfacet
-  facet normal -0.84872 0 -0.528843
+  facet normal 0.994753 0 -0.10231
     outer loop
-      vertex 3.47219 50.8 -47.4595
-      vertex 3.41208 50.8 -47.363
-      vertex 3.41208 50.8313 -47.363
+      vertex 4.67708 52.8 -49.325
+      vertex 4.76152 52 -48.504
+      vertex 4.67708 52 -49.325
     endloop
   endfacet
-  facet normal -0.848716 0 -0.528849
+  facet normal 0.937368 0 -0.34834
     outer loop
-      vertex 3.61708 52 -47.692
-      vertex 3.41208 52.8 -47.363
-      vertex 3.61708 52.8 -47.692
+      vertex 4.67708 52 -49.325
+      vertex 4.42375 52.8 -50.0067
+      vertex 4.67708 52.8 -49.325
     endloop
   endfacet
-  facet normal -0.848716 -0 -0.528849
+  facet normal 0.937368 0 -0.34834
     outer loop
-      vertex 3.41208 52.8 -47.363
-      vertex 3.61708 52 -47.692
-      vertex 3.41208 52 -47.363
+      vertex 4.42375 52.8 -50.0067
+      vertex 4.67708 52 -49.325
+      vertex 4.42375 52 -50.0067
     endloop
   endfacet
-  facet normal -0.654069 0 -0.756434
+  facet normal 0.789048 0 -0.614331
     outer loop
-      vertex 3.41208 50.8 -47.363
-      vertex 3.27846 50.8689 -47.2475
-      vertex 3.41208 50.8313 -47.363
+      vertex 4.42375 52 -50.0067
+      vertex 4.00153 52.8 -50.549
+      vertex 4.42375 52.8 -50.0067
     endloop
   endfacet
-  facet normal -0.654072 -1.02541e-005 -0.756432
+  facet normal 0.789048 0 -0.614331
     outer loop
-      vertex 3.1313 50.8 -47.1202
-      vertex 3.27846 50.8689 -47.2475
-      vertex 3.41208 50.8 -47.363
+      vertex 4.00153 52.8 -50.549
+      vertex 4.42375 52 -50.0067
+      vertex 4.00153 52 -50.549
     endloop
   endfacet
-  facet normal -0.654075 0 -0.75643
+  facet normal 0.595976 0 -0.803002
     outer loop
-      vertex 3.27846 50.8689 -47.2475
-      vertex 3.1313 50.8 -47.1202
-      vertex 3.1313 50.8823 -47.1202
+      vertex 3.56808 52 -50.8707
+      vertex 4.00153 52.8 -50.549
+      vertex 4.00153 52 -50.549
     endloop
   endfacet
-  facet normal -0.654072 0 -0.756432
+  facet normal 0.595976 0 -0.803002
     outer loop
-      vertex 3.1313 52 -47.1202
-      vertex 3.41208 52.8 -47.363
-      vertex 3.41208 52 -47.363
+      vertex 4.00153 52.8 -50.549
+      vertex 3.56808 52 -50.8707
+      vertex 3.56808 52.8 -50.8707
     endloop
   endfacet
-  facet normal -0.654072 0 -0.756432
+  facet normal 0.333456 0 -0.942766
     outer loop
-      vertex 3.41208 52.8 -47.363
-      vertex 3.1313 52 -47.1202
-      vertex 3.1313 52.8 -47.1202
+      vertex 3.02242 52 -51.0637
+      vertex 3.56808 52.8 -50.8707
+      vertex 3.56808 52 -50.8707
     endloop
   endfacet
-  facet normal -0.385165 0 -0.922848
+  facet normal 0.333456 0 -0.942766
     outer loop
-      vertex 2.7823 50.8 -46.9746
-      vertex 3.1313 50.8823 -47.1202
-      vertex 3.1313 50.8 -47.1202
+      vertex 3.56808 52.8 -50.8707
+      vertex 3.02242 52 -51.0637
+      vertex 3.02242 52.8 -51.0637
     endloop
   endfacet
-  facet normal -0.385165 0 -0.922848
+  facet normal 0.0972717 0 -0.995258
     outer loop
-      vertex 3.1313 50.8823 -47.1202
-      vertex 2.7823 50.8 -46.9746
-      vertex 2.7823 50.8976 -46.9746
+      vertex 2.36452 52 -51.128
+      vertex 3.02242 52.8 -51.0637
+      vertex 3.02242 52 -51.0637
     endloop
   endfacet
-  facet normal -0.385165 0 -0.922848
+  facet normal 0.0972717 0 -0.995258
     outer loop
-      vertex 2.7823 52 -46.9746
-      vertex 3.1313 52.8 -47.1202
-      vertex 3.1313 52 -47.1202
+      vertex 3.02242 52.8 -51.0637
+      vertex 2.36452 52 -51.128
+      vertex 2.36452 52.8 -51.128
     endloop
   endfacet
-  facet normal -0.385165 0 -0.922848
+  facet normal -0.0971942 0 -0.995265
     outer loop
-      vertex 3.1313 52.8 -47.1202
-      vertex 2.7823 52 -46.9746
-      vertex 2.7823 52.8 -46.9746
+      vertex 1.70609 52 -51.0637
+      vertex 2.36452 52.8 -51.128
+      vertex 2.36452 52 -51.128
     endloop
   endfacet
-  facet normal -0.115593 0 -0.993297
+  facet normal -0.0971942 0 -0.995265
     outer loop
-      vertex 2.36508 50.8 -46.926
-      vertex 2.7823 50.8976 -46.9746
-      vertex 2.7823 50.8 -46.9746
+      vertex 2.36452 52.8 -51.128
+      vertex 1.70609 52 -51.0637
+      vertex 1.70609 52.8 -51.0637
     endloop
   endfacet
-  facet normal -0.115593 0 -0.993297
+  facet normal -0.412535 0 0.910942
     outer loop
-      vertex 2.7823 50.8976 -46.9746
-      vertex 2.36508 50.8 -46.926
-      vertex 2.36508 50.9027 -46.926
+      vertex 2.74963 52.8 -50.1821
+      vertex 3.07997 52 -50.0325
+      vertex 3.07997 52.8 -50.0325
     endloop
   endfacet
-  facet normal -0.115593 0 -0.993297
+  facet normal -0.412535 0 0.910942
     outer loop
-      vertex 2.36508 52 -46.926
-      vertex 2.7823 52.8 -46.9746
-      vertex 2.7823 52 -46.9746
+      vertex 3.07997 52 -50.0325
+      vertex 2.74963 52.8 -50.1821
+      vertex 2.74963 52 -50.1821
     endloop
   endfacet
-  facet normal -0.115593 0 -0.993297
+  facet normal -0.672539 0 0.740062
     outer loop
-      vertex 2.7823 52.8 -46.9746
-      vertex 2.36508 52 -46.926
-      vertex 2.36508 52.8 -46.926
+      vertex 3.07997 52.8 -50.0325
+      vertex 3.35452 52 -49.783
+      vertex 3.35452 52.8 -49.783
     endloop
   endfacet
-  facet normal 0.117965 0 -0.993018
+  facet normal -0.672539 0 0.740062
     outer loop
-      vertex 1.95354 50.8975 -46.9749
-      vertex 2.36508 50.8 -46.926
-      vertex 1.95354 50.8 -46.9749
+      vertex 3.35452 52 -49.783
+      vertex 3.07997 52.8 -50.0325
+      vertex 3.07997 52 -50.0325
     endloop
   endfacet
-  facet normal 0.117965 0 -0.993018
+  facet normal -0.85778 0 0.514016
     outer loop
-      vertex 2.36508 50.8 -46.926
-      vertex 1.95354 50.8975 -46.9749
-      vertex 2.36508 50.9027 -46.926
+      vertex 3.35452 52 -49.783
+      vertex 3.55952 52.8 -49.4409
+      vertex 3.35452 52.8 -49.783
     endloop
   endfacet
-  facet normal 0.117965 0 -0.993018
+  facet normal -0.85778 0 0.514016
     outer loop
-      vertex 1.95354 52 -46.9749
-      vertex 2.36508 52.8 -46.926
-      vertex 2.36508 52 -46.926
+      vertex 3.55952 52.8 -49.4409
+      vertex 3.35452 52 -49.783
+      vertex 3.55952 52 -49.4409
     endloop
   endfacet
-  facet normal 0.117965 0 -0.993018
+  facet normal -0.9608 0 0.277241
     outer loop
-      vertex 2.36508 52.8 -46.926
-      vertex 1.95354 52 -46.9749
-      vertex 1.95354 52.8 -46.9749
+      vertex 3.55952 52 -49.4409
+      vertex 3.68253 52.8 -49.0146
+      vertex 3.55952 52.8 -49.4409
     endloop
   endfacet
-  facet normal 0.390913 0 -0.920428
+  facet normal -0.9608 0 0.277241
     outer loop
-      vertex 1.6082 50.8821 -47.1216
-      vertex 1.95354 50.8 -46.9749
-      vertex 1.6082 50.8 -47.1216
+      vertex 3.68253 52.8 -49.0146
+      vertex 3.55952 52 -49.4409
+      vertex 3.68253 52 -49.0146
     endloop
   endfacet
-  facet normal 0.390913 0 -0.920428
+  facet normal -0.996792 0 0.0800401
     outer loop
-      vertex 1.95354 50.8 -46.9749
-      vertex 1.6082 50.8821 -47.1216
-      vertex 1.95354 50.8975 -46.9749
+      vertex 3.68253 52 -49.0146
+      vertex 3.72353 52.8 -48.504
+      vertex 3.68253 52.8 -49.0146
     endloop
   endfacet
-  facet normal 0.390913 0 -0.920428
+  facet normal -0.996792 0 0.0800401
     outer loop
-      vertex 1.6082 52 -47.1216
-      vertex 1.95354 52.8 -46.9749
-      vertex 1.95354 52 -46.9749
+      vertex 3.72353 52.8 -48.504
+      vertex 3.68253 52 -49.0146
+      vertex 3.72353 52 -48.504
     endloop
   endfacet
-  facet normal 0.390913 0 -0.920428
+  facet normal -0.996789 0 -0.0800712
     outer loop
-      vertex 1.95354 52.8 -46.9749
-      vertex 1.6082 52 -47.1216
-      vertex 1.6082 52.8 -47.1216
+      vertex 3.72353 52 -48.504
+      vertex 3.68253 52.8 -47.9936
+      vertex 3.72353 52.8 -48.504
     endloop
   endfacet
-  facet normal 0.658845 0 -0.752279
+  facet normal -0.996789 -0 -0.0800712
     outer loop
-      vertex 1.6082 50.8 -47.1216
-      vertex 1.46444 50.8689 -47.2475
-      vertex 1.6082 50.8821 -47.1216
+      vertex 3.68253 52.8 -47.9936
+      vertex 3.72353 52 -48.504
+      vertex 3.68253 52 -47.9936
     endloop
   endfacet
-  facet normal 0.658842 -1.08151e-005 -0.752281
+  facet normal -0.960748 0 -0.277422
     outer loop
-      vertex 1.32909 50.8 -47.366
-      vertex 1.46444 50.8689 -47.2475
-      vertex 1.6082 50.8 -47.1216
+      vertex 3.68253 52 -47.9936
+      vertex 3.55952 52.8 -47.5676
+      vertex 3.68253 52.8 -47.9936
     endloop
   endfacet
-  facet normal 0.658839 0 -0.752284
+  facet normal -0.960748 -0 -0.277422
     outer loop
-      vertex 1.46444 50.8689 -47.2475
-      vertex 1.32909 50.8 -47.366
-      vertex 1.32909 50.8304 -47.366
+      vertex 3.55952 52.8 -47.5676
+      vertex 3.68253 52 -47.9936
+      vertex 3.55952 52 -47.5676
     endloop
   endfacet
-  facet normal 0.658842 0 -0.752281
+  facet normal -0.857449 0 -0.51457
     outer loop
-      vertex 1.32909 52 -47.366
-      vertex 1.6082 52.8 -47.1216
-      vertex 1.6082 52 -47.1216
+      vertex 3.55952 52 -47.5676
+      vertex 3.35452 52.8 -47.226
+      vertex 3.55952 52.8 -47.5676
     endloop
   endfacet
-  facet normal 0.658842 0 -0.752281
+  facet normal -0.857449 -0 -0.51457
     outer loop
-      vertex 1.6082 52.8 -47.1216
-      vertex 1.32909 52 -47.366
-      vertex 1.32909 52.8 -47.366
+      vertex 3.35452 52.8 -47.226
+      vertex 3.55952 52 -47.5676
+      vertex 3.35452 52 -47.226
     endloop
   endfacet
-  facet normal 0.84881 0 -0.528697
+  facet normal -0.673276 0 -0.739391
     outer loop
-      vertex 1.32909 50.8304 -47.366
-      vertex 1.32909 50.8 -47.366
-      vertex 1.27087 50.8 -47.4595
+      vertex 3.07997 52 -46.976
+      vertex 3.35452 52.8 -47.226
+      vertex 3.35452 52 -47.226
     endloop
   endfacet
-  facet normal 0.848807 0 -0.528704
+  facet normal -0.673276 0 -0.739391
     outer loop
-      vertex 1.32909 52 -47.366
-      vertex 1.12354 52.8 -47.696
-      vertex 1.32909 52.8 -47.366
+      vertex 3.35452 52.8 -47.226
+      vertex 3.07997 52 -46.976
+      vertex 3.07997 52.8 -46.976
     endloop
   endfacet
-  facet normal 0.848807 0 -0.528704
+  facet normal -0.41345 0 -0.910527
     outer loop
-      vertex 1.12354 52.8 -47.696
-      vertex 1.32909 52 -47.366
-      vertex 1.12354 52 -47.696
+      vertex 2.74963 52 -46.826
+      vertex 3.07997 52.8 -46.976
+      vertex 3.07997 52 -46.976
     endloop
   endfacet
-  facet normal 0.956556 0 -0.291548
+  facet normal -0.41345 0 -0.910527
     outer loop
-      vertex 1.12354 52 -47.696
-      vertex 1.0002 52.8 -48.1007
-      vertex 1.12354 52.8 -47.696
+      vertex 3.07997 52.8 -46.976
+      vertex 2.74963 52 -46.826
+      vertex 2.74963 52.8 -46.826
     endloop
   endfacet
-  facet normal 0.956556 0 -0.291548
+  facet normal -0.128428 0 -0.991719
     outer loop
-      vertex 1.0002 52.8 -48.1007
-      vertex 1.12354 52 -47.696
-      vertex 1.0002 52 -48.1007
+      vertex 2.36353 52 -46.776
+      vertex 2.74963 52.8 -46.826
+      vertex 2.74963 52 -46.826
     endloop
   endfacet
-  facet normal 0.996343 0 -0.085447
+  facet normal -0.128428 0 -0.991719
     outer loop
-      vertex 1.0002 52 -48.1007
-      vertex 0.959091 52.8 -48.58
-      vertex 1.0002 52.8 -48.1007
+      vertex 2.74963 52.8 -46.826
+      vertex 2.36353 52 -46.776
+      vertex 2.36353 52.8 -46.776
     endloop
   endfacet
-  facet normal 0.996343 0 -0.085447
+  facet normal 0.129078 0 -0.991634
     outer loop
-      vertex 0.959091 52.8 -48.58
-      vertex 1.0002 52 -48.1007
-      vertex 0.959091 52 -48.58
+      vertex 1.97864 52 -46.8261
+      vertex 2.36353 52.8 -46.776
+      vertex 2.36353 52 -46.776
     endloop
   endfacet
-  facet normal 0.99667 -0 0.0815366
+  facet normal 0.129078 0 -0.991634
     outer loop
-      vertex 0.959091 52 -48.58
-      vertex 0.999969 52.8 -49.0797
-      vertex 0.959091 52.8 -48.58
+      vertex 2.36353 52.8 -46.776
+      vertex 1.97864 52 -46.8261
+      vertex 1.97864 52.8 -46.8261
     endloop
   endfacet
-  facet normal 0.99667 0 0.0815366
+  facet normal 0.416797 0 -0.909
     outer loop
-      vertex 0.999969 52.8 -49.0797
-      vertex 0.959091 52 -48.58
-      vertex 0.999969 52 -49.0797
+      vertex 1.65063 52 -46.9765
+      vertex 1.97864 52.8 -46.8261
+      vertex 1.97864 52 -46.8261
     endloop
   endfacet
-  facet normal 0.959475 -0 0.281792
+  facet normal 0.416797 0 -0.909
     outer loop
-      vertex 0.999969 52 -49.0797
-      vertex 1.12263 52.8 -49.4973
-      vertex 0.999969 52.8 -49.0797
+      vertex 1.97864 52.8 -46.8261
+      vertex 1.65063 52 -46.9765
+      vertex 1.65063 52.8 -46.9765
     endloop
   endfacet
-  facet normal 0.959475 0 0.281792
+  facet normal 0.678638 0 -0.734473
     outer loop
-      vertex 1.12263 52.8 -49.4973
-      vertex 0.999969 52 -49.0797
-      vertex 1.12263 52 -49.4973
+      vertex 1.37952 52 -47.227
+      vertex 1.65063 52.8 -46.9765
+      vertex 1.65063 52 -46.9765
     endloop
   endfacet
-  facet normal 0.854045 -0 0.520199
+  facet normal 0.678638 0 -0.734473
     outer loop
-      vertex 1.12263 52 -49.4973
-      vertex 1.32709 52.8 -49.833
-      vertex 1.12263 52.8 -49.4973
+      vertex 1.65063 52.8 -46.9765
+      vertex 1.37952 52 -47.227
+      vertex 1.37952 52.8 -47.227
     endloop
   endfacet
-  facet normal 0.854045 0 0.520199
+  facet normal 0.860363 0 -0.509683
     outer loop
-      vertex 1.32709 52.8 -49.833
-      vertex 1.12263 52 -49.4973
-      vertex 1.32709 52 -49.833
+      vertex 1.37952 52 -47.227
+      vertex 1.17674 52.8 -47.5693
+      vertex 1.37952 52.8 -47.227
     endloop
   endfacet
-  facet normal 0.659536 0 0.751673
+  facet normal 0.860363 0 -0.509683
     outer loop
-      vertex 1.32709 52.8 -49.833
-      vertex 1.60631 52 -50.078
-      vertex 1.60631 52.8 -50.078
+      vertex 1.17674 52.8 -47.5693
+      vertex 1.37952 52 -47.227
+      vertex 1.17674 52 -47.5693
     endloop
   endfacet
-  facet normal 0.659536 0 0.751673
+  facet normal 0.961505 0 -0.274787
     outer loop
-      vertex 1.60631 52 -50.078
-      vertex 1.32709 52.8 -49.833
-      vertex 1.32709 52 -49.833
+      vertex 1.17674 52 -47.5693
+      vertex 1.05508 52.8 -47.995
+      vertex 1.17674 52.8 -47.5693
     endloop
   endfacet
-  facet normal 0.388818 0 0.921314
+  facet normal 0.961505 0 -0.274787
     outer loop
-      vertex 1.60631 52.8 -50.078
-      vertex 1.95464 52 -50.225
-      vertex 1.95464 52.8 -50.225
+      vertex 1.05508 52.8 -47.995
+      vertex 1.17674 52 -47.5693
+      vertex 1.05508 52 -47.995
     endloop
   endfacet
-  facet normal 0.388818 0 0.921314
+  facet normal 0.996842 0 -0.0794144
     outer loop
-      vertex 1.95464 52 -50.225
-      vertex 1.60631 52.8 -50.078
-      vertex 1.60631 52 -50.078
+      vertex 1.05508 52 -47.995
+      vertex 1.01453 52.8 -48.504
+      vertex 1.05508 52.8 -47.995
     endloop
   endfacet
-  facet normal 0.11657 0 0.993183
+  facet normal 0.996842 0 -0.0794144
     outer loop
-      vertex 1.95464 52.8 -50.225
-      vertex 2.37209 52 -50.274
-      vertex 2.37209 52.8 -50.274
+      vertex 1.01453 52.8 -48.504
+      vertex 1.05508 52 -47.995
+      vertex 1.01453 52 -48.504
     endloop
   endfacet
-  facet normal 0.11657 0 0.993183
+  facet normal 0.996861 -0 0.0791671
     outer loop
-      vertex 2.37209 52 -50.274
-      vertex 1.95464 52.8 -50.225
-      vertex 1.95464 52 -50.225
+      vertex 1.01453 52 -48.504
+      vertex 1.05508 52.8 -49.0146
+      vertex 1.01453 52.8 -48.504
     endloop
   endfacet
-  facet normal -0.123372 0 0.992361
+  facet normal 0.996861 0 0.0791671
     outer loop
-      vertex 2.37209 52.8 -50.274
-      vertex 2.77687 52 -50.2237
-      vertex 2.77687 52.8 -50.2237
+      vertex 1.05508 52.8 -49.0146
+      vertex 1.01453 52 -48.504
+      vertex 1.05508 52 -49.0146
     endloop
   endfacet
-  facet normal -0.123372 0 0.992361
+  facet normal 0.961607 -0 0.274429
     outer loop
-      vertex 2.77687 52 -50.2237
-      vertex 2.37209 52.8 -50.274
-      vertex 2.37209 52 -50.274
+      vertex 1.05508 52 -49.0146
+      vertex 1.17674 52.8 -49.4409
+      vertex 1.05508 52.8 -49.0146
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.961607 0 0.274429
     outer loop
-      vertex -10.2714 52.8 -50.213
-      vertex -8.02243 52 -50.213
-      vertex -8.02243 52.8 -50.213
+      vertex 1.17674 52.8 -49.4409
+      vertex 1.05508 52 -49.0146
+      vertex 1.17674 52 -49.4409
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.860232 -0 0.509903
     outer loop
-      vertex -8.02243 52 -50.213
-      vertex -10.2714 52.8 -50.213
-      vertex -10.2714 52 -50.213
+      vertex 1.17674 52 -49.4409
+      vertex 1.37952 52.8 -49.783
+      vertex 1.17674 52.8 -49.4409
     endloop
   endfacet
-  facet normal -0.886513 0 -0.462704
+  facet normal 0.860232 0 0.509903
     outer loop
-      vertex -8.02243 52 -50.213
-      vertex -8.09776 52.8 -50.0687
-      vertex -8.02243 52.8 -50.213
+      vertex 1.37952 52.8 -49.783
+      vertex 1.17674 52 -49.4409
+      vertex 1.37952 52 -49.783
     endloop
   endfacet
-  facet normal -0.886513 -0 -0.462704
+  facet normal 0.677172 0 0.735824
     outer loop
-      vertex -8.09776 52.8 -50.0687
-      vertex -8.02243 52 -50.213
-      vertex -8.09776 52 -50.0687
+      vertex 1.37952 52.8 -49.783
+      vertex 1.65063 52 -50.0325
+      vertex 1.65063 52.8 -50.0325
     endloop
   endfacet
-  facet normal -0.815971 0 -0.578092
+  facet normal 0.677172 0 0.735824
     outer loop
-      vertex -8.09776 52 -50.0687
-      vertex -8.19577 52.8 -49.9303
-      vertex -8.09776 52.8 -50.0687
+      vertex 1.65063 52 -50.0325
+      vertex 1.37952 52.8 -49.783
+      vertex 1.37952 52 -49.783
     endloop
   endfacet
-  facet normal -0.815971 -0 -0.578092
+  facet normal 0.414962 0 0.909839
     outer loop
-      vertex -8.19577 52.8 -49.9303
-      vertex -8.09776 52 -50.0687
-      vertex -8.19577 52 -49.9303
+      vertex 1.65063 52.8 -50.0325
+      vertex 1.97864 52 -50.1821
+      vertex 1.97864 52.8 -50.1821
     endloop
   endfacet
-  facet normal -0.738945 0 -0.673766
+  facet normal 0.414962 0 0.909839
     outer loop
-      vertex -8.19577 52 -49.9303
-      vertex -8.31644 52.8 -49.798
-      vertex -8.19577 52.8 -49.9303
+      vertex 1.97864 52 -50.1821
+      vertex 1.65063 52.8 -50.0325
+      vertex 1.65063 52 -50.0325
     endloop
   endfacet
-  facet normal -0.738945 -0 -0.673766
+  facet normal 0.128571 0 0.9917
     outer loop
-      vertex -8.31644 52.8 -49.798
-      vertex -8.19577 52 -49.9303
-      vertex -8.31644 52 -49.798
+      vertex 1.97864 52.8 -50.1821
+      vertex 2.36353 52 -50.232
+      vertex 2.36353 52.8 -50.232
     endloop
   endfacet
-  facet normal -0.686132 0 -0.727477
+  facet normal 0.128571 0 0.9917
     outer loop
-      vertex -8.45309 52 -49.6691
-      vertex -8.31644 52.8 -49.798
-      vertex -8.31644 52 -49.798
+      vertex 2.36353 52 -50.232
+      vertex 1.97864 52.8 -50.1821
+      vertex 1.97864 52 -50.1821
     endloop
   endfacet
-  facet normal -0.686132 0 -0.727477
+  facet normal -0.128175 0 0.991752
     outer loop
-      vertex -8.31644 52.8 -49.798
-      vertex -8.45309 52 -49.6691
-      vertex -8.45309 52.8 -49.6691
+      vertex 2.36353 52.8 -50.232
+      vertex 2.74963 52 -50.1821
+      vertex 2.74963 52.8 -50.1821
     endloop
   endfacet
-  facet normal -0.659216 0 -0.751953
+  facet normal -0.128175 0 0.991752
     outer loop
-      vertex -8.59909 52 -49.5411
-      vertex -8.45309 52.8 -49.6691
-      vertex -8.45309 52 -49.6691
-    endloop
-  endfacet
-  facet normal -0.659216 0 -0.751953
-    outer loop
-      vertex -8.45309 52.8 -49.6691
-      vertex -8.59909 52 -49.5411
-      vertex -8.59909 52.8 -49.5411
-    endloop
-  endfacet
-  facet normal -0.633325 0 -0.773886
-    outer loop
-      vertex -8.75443 52 -49.414
-      vertex -8.59909 52.8 -49.5411
-      vertex -8.59909 52 -49.5411
-    endloop
-  endfacet
-  facet normal -0.633325 0 -0.773886
-    outer loop
-      vertex -8.59909 52.8 -49.5411
-      vertex -8.75443 52 -49.414
-      vertex -8.75443 52.8 -49.414
-    endloop
-  endfacet
-  facet normal -0.618295 0 -0.785946
-    outer loop
-      vertex -9.25143 52 -49.023
-      vertex -8.75443 52.8 -49.414
-      vertex -8.75443 52 -49.414
-    endloop
-  endfacet
-  facet normal -0.618295 0 -0.785946
-    outer loop
-      vertex -8.75443 52.8 -49.414
-      vertex -9.25143 52 -49.023
-      vertex -9.25143 52.8 -49.023
-    endloop
-  endfacet
-  facet normal -0.636596 0 -0.771198
-    outer loop
-      vertex -9.41754 52 -48.8859
-      vertex -9.25143 52.8 -49.023
-      vertex -9.25143 52 -49.023
-    endloop
-  endfacet
-  facet normal -0.636596 0 -0.771198
-    outer loop
-      vertex -9.25143 52.8 -49.023
-      vertex -9.41754 52 -48.8859
-      vertex -9.41754 52.8 -48.8859
-    endloop
-  endfacet
-  facet normal -0.677336 0 -0.735674
-    outer loop
-      vertex -9.57321 52 -48.7426
-      vertex -9.41754 52.8 -48.8859
-      vertex -9.41754 52 -48.8859
-    endloop
-  endfacet
-  facet normal -0.677336 0 -0.735674
-    outer loop
-      vertex -9.41754 52.8 -48.8859
-      vertex -9.57321 52 -48.7426
-      vertex -9.57321 52.8 -48.7426
-    endloop
-  endfacet
-  facet normal -0.71746 0 -0.6966
-    outer loop
-      vertex -9.57321 52 -48.7426
-      vertex -9.71843 52.8 -48.593
-      vertex -9.57321 52.8 -48.7426
-    endloop
-  endfacet
-  facet normal -0.71746 -0 -0.6966
-    outer loop
-      vertex -9.71843 52.8 -48.593
-      vertex -9.57321 52 -48.7426
-      vertex -9.71843 52 -48.593
-    endloop
-  endfacet
-  facet normal -0.768452 0 -0.639907
-    outer loop
-      vertex -9.71843 52 -48.593
-      vertex -9.84999 52.8 -48.435
-      vertex -9.71843 52.8 -48.593
-    endloop
-  endfacet
-  facet normal -0.768452 -0 -0.639907
-    outer loop
-      vertex -9.84999 52.8 -48.435
-      vertex -9.71843 52 -48.593
-      vertex -9.84999 52 -48.435
-    endloop
-  endfacet
-  facet normal -0.824947 0 -0.56521
-    outer loop
-      vertex -9.84999 52 -48.435
-      vertex -9.96465 52.8 -48.2677
-      vertex -9.84999 52.8 -48.435
-    endloop
-  endfacet
-  facet normal -0.824947 -0 -0.56521
-    outer loop
-      vertex -9.96465 52.8 -48.2677
-      vertex -9.84999 52 -48.435
-      vertex -9.96465 52 -48.2677
-    endloop
-  endfacet
-  facet normal -0.874933 0 -0.484244
-    outer loop
-      vertex -9.96465 52 -48.2677
-      vertex -10.0624 52.8 -48.091
-      vertex -9.96465 52.8 -48.2677
-    endloop
-  endfacet
-  facet normal -0.874933 -0 -0.484244
-    outer loop
-      vertex -10.0624 52.8 -48.091
-      vertex -9.96465 52 -48.2677
-      vertex -10.0624 52 -48.091
-    endloop
-  endfacet
-  facet normal -0.930052 0 -0.367427
-    outer loop
-      vertex -10.0624 52 -48.091
-      vertex -10.1369 52.8 -47.9026
-      vertex -10.0624 52.8 -48.091
-    endloop
-  endfacet
-  facet normal -0.930052 -0 -0.367427
-    outer loop
-      vertex -10.1369 52.8 -47.9026
-      vertex -10.0624 52 -48.091
-      vertex -10.1369 52 -47.9026
-    endloop
-  endfacet
-  facet normal -0.976568 0 -0.21521
-    outer loop
-      vertex -10.1369 52 -47.9026
-      vertex -10.1815 52.8 -47.6999
-      vertex -10.1369 52.8 -47.9026
-    endloop
-  endfacet
-  facet normal -0.976568 -0 -0.21521
-    outer loop
-      vertex -10.1815 52.8 -47.6999
-      vertex -10.1369 52 -47.9026
-      vertex -10.1815 52 -47.6999
-    endloop
-  endfacet
-  facet normal -0.997651 0 -0.0685034
-    outer loop
-      vertex -10.1815 52 -47.6999
-      vertex -10.1964 52.8 -47.483
-      vertex -10.1815 52.8 -47.6999
-    endloop
-  endfacet
-  facet normal -0.997651 -0 -0.0685034
-    outer loop
-      vertex -10.1964 52.8 -47.483
-      vertex -10.1815 52 -47.6999
-      vertex -10.1964 52 -47.483
-    endloop
-  endfacet
-  facet normal -0.993118 2.85556e-006 0.117114
-    outer loop
-      vertex -10.1499 50.8 -47.0882
-      vertex -10.1687 50.8689 -47.2475
-      vertex -10.1937 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal -0.993119 0 0.117113
-    outer loop
-      vertex -10.1687 50.8689 -47.2475
-      vertex -10.1499 50.8 -47.0882
-      vertex -10.1499 50.8856 -47.0882
-    endloop
-  endfacet
-  facet normal -0.993118 0 0.117115
-    outer loop
-      vertex -10.1964 52 -47.483
-      vertex -10.1499 52.8 -47.0882
-      vertex -10.1964 52.8 -47.483
-    endloop
-  endfacet
-  facet normal -0.993118 0 0.117115
-    outer loop
-      vertex -10.1499 52.8 -47.0882
-      vertex -10.1964 52 -47.483
-      vertex -10.1499 52 -47.0882
-    endloop
-  endfacet
-  facet normal -0.921338 0 0.388761
-    outer loop
-      vertex -10.0102 50.8 -46.7572
-      vertex -10.1499 50.8856 -47.0882
-      vertex -10.1499 50.8 -47.0882
-    endloop
-  endfacet
-  facet normal -0.921338 0 0.388761
-    outer loop
-      vertex -10.1499 50.8856 -47.0882
-      vertex -10.0102 50.8 -46.7572
-      vertex -10.0102 50.9204 -46.7572
-    endloop
-  endfacet
-  facet normal -0.921338 0 0.388761
-    outer loop
-      vertex -10.1499 52 -47.0882
-      vertex -10.0102 52.8 -46.7572
-      vertex -10.1499 52.8 -47.0882
-    endloop
-  endfacet
-  facet normal -0.921338 0 0.388761
-    outer loop
-      vertex -10.0102 52.8 -46.7572
-      vertex -10.1499 52 -47.0882
-      vertex -10.0102 52 -46.7572
-    endloop
-  endfacet
-  facet normal -0.754044 0 0.656823
-    outer loop
-      vertex -9.77744 50.8 -46.49
-      vertex -10.0102 50.9204 -46.7572
-      vertex -10.0102 50.8 -46.7572
-    endloop
-  endfacet
-  facet normal -0.754044 0 0.656823
-    outer loop
-      vertex -10.0102 50.9204 -46.7572
-      vertex -9.77744 50.8 -46.49
-      vertex -9.77744 50.9485 -46.49
-    endloop
-  endfacet
-  facet normal -0.754044 0 0.656823
-    outer loop
-      vertex -10.0102 52 -46.7572
-      vertex -9.77744 52.8 -46.49
-      vertex -10.0102 52.8 -46.7572
-    endloop
-  endfacet
-  facet normal -0.754044 0 0.656823
-    outer loop
-      vertex -9.77744 52.8 -46.49
-      vertex -10.0102 52 -46.7572
-      vertex -9.77744 52 -46.49
-    endloop
-  endfacet
-  facet normal -0.524794 0 0.851229
-    outer loop
-      vertex -9.6683 50.9556 -46.4227
-      vertex -9.45844 50.8 -46.2933
-      vertex -9.45844 50.9692 -46.2933
-    endloop
-  endfacet
-  facet normal -0.524809 0 0.85122
-    outer loop
-      vertex -9.77744 50.8 -46.49
-      vertex -9.6683 50.9556 -46.4227
-      vertex -9.77744 50.9485 -46.49
-    endloop
-  endfacet
-  facet normal -0.524799 -9.85048e-006 0.851226
-    outer loop
-      vertex -9.6683 50.9556 -46.4227
-      vertex -9.77744 50.8 -46.49
-      vertex -9.45844 50.8 -46.2933
-    endloop
-  endfacet
-  facet normal -0.524799 0 0.851226
-    outer loop
-      vertex -9.77744 52.8 -46.49
-      vertex -9.45844 52 -46.2933
-      vertex -9.45844 52.8 -46.2933
-    endloop
-  endfacet
-  facet normal -0.524799 0 0.851226
-    outer loop
-      vertex -9.45844 52 -46.2933
-      vertex -9.77744 52.8 -46.49
-      vertex -9.77744 52 -46.49
-    endloop
-  endfacet
-  facet normal -0.283149 0 0.959076
-    outer loop
-      vertex -9.45844 50.9692 -46.2933
-      vertex -9.05876 50.8 -46.1753
-      vertex -9.05876 50.9816 -46.1753
-    endloop
-  endfacet
-  facet normal -0.283149 0 0.959076
-    outer loop
-      vertex -9.05876 50.8 -46.1753
-      vertex -9.45844 50.9692 -46.2933
-      vertex -9.45844 50.8 -46.2933
-    endloop
-  endfacet
-  facet normal -0.283149 0 0.959076
-    outer loop
-      vertex -9.45844 52.8 -46.2933
-      vertex -9.05876 52 -46.1753
-      vertex -9.05876 52.8 -46.1753
-    endloop
-  endfacet
-  facet normal -0.283149 0 0.959076
-    outer loop
-      vertex -9.05876 52 -46.1753
-      vertex -9.45844 52.8 -46.2933
-      vertex -9.45844 52 -46.2933
-    endloop
-  endfacet
-  facet normal -0.0816226 0 0.996663
-    outer loop
-      vertex -9.05876 50.9816 -46.1753
-      vertex -8.57843 50.8 -46.136
-      vertex -8.57843 50.9857 -46.136
-    endloop
-  endfacet
-  facet normal -0.0816226 0 0.996663
-    outer loop
-      vertex -8.57843 50.8 -46.136
-      vertex -9.05876 50.9816 -46.1753
-      vertex -9.05876 50.8 -46.1753
-    endloop
-  endfacet
-  facet normal -0.0816226 0 0.996663
-    outer loop
-      vertex -9.05876 52.8 -46.1753
-      vertex -8.57843 52 -46.136
-      vertex -8.57843 52.8 -46.136
-    endloop
-  endfacet
-  facet normal -0.0816226 0 0.996663
-    outer loop
-      vertex -8.57843 52 -46.136
-      vertex -9.05876 52.8 -46.1753
-      vertex -9.05876 52 -46.1753
-    endloop
-  endfacet
-  facet normal 0.0855846 0 0.996331
-    outer loop
-      vertex -8.57843 50.9857 -46.136
-      vertex -8.12955 50.8 -46.1746
-      vertex -8.12955 50.9817 -46.1746
-    endloop
-  endfacet
-  facet normal 0.0855846 0 0.996331
-    outer loop
-      vertex -8.12955 50.8 -46.1746
-      vertex -8.57843 50.9857 -46.136
-      vertex -8.57843 50.8 -46.136
-    endloop
-  endfacet
-  facet normal 0.0855846 0 0.996331
-    outer loop
-      vertex -8.57843 52.8 -46.136
-      vertex -8.12955 52 -46.1746
-      vertex -8.12955 52.8 -46.1746
-    endloop
-  endfacet
-  facet normal 0.0855846 0 0.996331
-    outer loop
-      vertex -8.12955 52 -46.1746
-      vertex -8.57843 52.8 -46.136
-      vertex -8.57843 52 -46.136
-    endloop
-  endfacet
-  facet normal 0.290287 -0 0.95694
-    outer loop
-      vertex -8.12955 50.8 -46.1746
-      vertex -7.74821 50.9695 -46.2902
-      vertex -8.12955 50.9817 -46.1746
-    endloop
-  endfacet
-  facet normal 0.290287 0 0.95694
-    outer loop
-      vertex -7.74821 50.9695 -46.2902
-      vertex -8.12955 50.8 -46.1746
-      vertex -7.74821 50.8 -46.2902
-    endloop
-  endfacet
-  facet normal 0.290287 0 0.95694
-    outer loop
-      vertex -8.12955 52.8 -46.1746
-      vertex -7.74821 52 -46.2902
-      vertex -7.74821 52.8 -46.2902
-    endloop
-  endfacet
-  facet normal 0.290287 0 0.95694
-    outer loop
-      vertex -7.74821 52 -46.2902
-      vertex -8.12955 52.8 -46.1746
-      vertex -8.12955 52 -46.1746
-    endloop
-  endfacet
-  facet normal 0.523397 0 0.852089
-    outer loop
-      vertex -7.45775 50.9507 -46.4687
-      vertex -7.43443 50.8 -46.483
-      vertex -7.43443 50.9492 -46.483
-    endloop
-  endfacet
-  facet normal 0.523447 -0 0.852058
-    outer loop
-      vertex -7.74821 50.8 -46.2902
-      vertex -7.45775 50.9507 -46.4687
-      vertex -7.74821 50.9695 -46.2902
-    endloop
-  endfacet
-  facet normal 0.523443 9.77617e-006 0.852061
-    outer loop
-      vertex -7.45775 50.9507 -46.4687
-      vertex -7.74821 50.8 -46.2902
-      vertex -7.43443 50.8 -46.483
-    endloop
-  endfacet
-  facet normal 0.523443 0 0.852061
-    outer loop
-      vertex -7.74821 52.8 -46.2902
-      vertex -7.43443 52 -46.483
-      vertex -7.43443 52.8 -46.483
-    endloop
-  endfacet
-  facet normal 0.523443 0 0.852061
-    outer loop
-      vertex -7.43443 52 -46.483
-      vertex -7.74821 52.8 -46.2902
-      vertex -7.74821 52 -46.2902
-    endloop
-  endfacet
-  facet normal 0.739213 -0 0.673472
-    outer loop
-      vertex -7.43443 50.8 -46.483
-      vertex -7.19199 50.9213 -46.7491
-      vertex -7.43443 50.9492 -46.483
-    endloop
-  endfacet
-  facet normal 0.739213 0 0.673472
-    outer loop
-      vertex -7.19199 50.9213 -46.7491
-      vertex -7.43443 50.8 -46.483
-      vertex -7.19199 50.8 -46.7491
-    endloop
-  endfacet
-  facet normal 0.739213 -0 0.673472
-    outer loop
-      vertex -7.43443 52 -46.483
-      vertex -7.19199 52.8 -46.7491
-      vertex -7.43443 52.8 -46.483
-    endloop
-  endfacet
-  facet normal 0.739213 0 0.673472
-    outer loop
-      vertex -7.19199 52.8 -46.7491
-      vertex -7.43443 52 -46.483
-      vertex -7.19199 52 -46.7491
-    endloop
-  endfacet
-  facet normal 0.894964 -0 0.446139
-    outer loop
-      vertex -7.19199 50.8 -46.7491
-      vertex -7.02466 50.886 -47.0848
-      vertex -7.19199 50.9213 -46.7491
-    endloop
-  endfacet
-  facet normal 0.894964 0 0.446139
-    outer loop
-      vertex -7.02466 50.886 -47.0848
-      vertex -7.19199 50.8 -46.7491
-      vertex -7.02466 50.8 -47.0848
-    endloop
-  endfacet
-  facet normal 0.894964 -0 0.446139
-    outer loop
-      vertex -7.19199 52 -46.7491
-      vertex -7.02466 52.8 -47.0848
-      vertex -7.19199 52.8 -46.7491
-    endloop
-  endfacet
-  facet normal 0.894964 0 0.446139
-    outer loop
-      vertex -7.02466 52.8 -47.0848
-      vertex -7.19199 52 -46.7491
-      vertex -7.02466 52 -47.0848
-    endloop
-  endfacet
-  facet normal 0.975067 -0 0.22191
-    outer loop
-      vertex -7.02466 50.8 -47.0848
-      vertex -6.98763 50.8689 -47.2475
-      vertex -7.02466 50.886 -47.0848
-    endloop
-  endfacet
-  facet normal 0.975067 8.90677e-007 0.22191
-    outer loop
-      vertex -6.98763 50.8689 -47.2475
-      vertex -7.02466 50.8 -47.0848
-      vertex -6.93938 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0.975067 -0 0.221912
-    outer loop
-      vertex -7.02466 52 -47.0848
-      vertex -6.93243 52.8 -47.49
-      vertex -7.02466 52.8 -47.0848
-    endloop
-  endfacet
-  facet normal 0.975067 0 0.221912
-    outer loop
-      vertex -6.93243 52.8 -47.49
-      vertex -7.02466 52 -47.0848
-      vertex -6.93243 52 -47.49
-    endloop
-  endfacet
-  facet normal 0.0559304 0 -0.998435
-    outer loop
-      vertex -7.89642 52 -47.544
-      vertex -6.93243 52.8 -47.49
-      vertex -6.93243 52 -47.49
-    endloop
-  endfacet
-  facet normal 0.0559304 0 -0.998435
-    outer loop
-      vertex -6.93243 52.8 -47.49
-      vertex -7.89642 52 -47.544
-      vertex -7.89642 52.8 -47.544
-    endloop
-  endfacet
-  facet normal -0.97482 0 -0.222992
-    outer loop
-      vertex -7.91576 50.8 -47.4595
-      vertex -7.94144 50.8 -47.3472
-      vertex -7.94144 50.8365 -47.3472
-    endloop
-  endfacet
-  facet normal -0.97482 0 -0.222993
-    outer loop
-      vertex -7.89642 52 -47.544
-      vertex -7.94144 52.8 -47.3472
-      vertex -7.89642 52.8 -47.544
-    endloop
-  endfacet
-  facet normal -0.97482 -0 -0.222993
-    outer loop
-      vertex -7.94144 52.8 -47.3472
-      vertex -7.89642 52 -47.544
-      vertex -7.94144 52 -47.3472
-    endloop
-  endfacet
-  facet normal -0.914975 0 -0.40351
-    outer loop
-      vertex -7.94144 50.8 -47.3472
-      vertex -7.98543 50.8689 -47.2475
-      vertex -7.94144 50.8365 -47.3472
-    endloop
-  endfacet
-  facet normal -0.914977 -6.92608e-006 -0.403506
-    outer loop
-      vertex -7.98543 50.8689 -47.2475
-      vertex -7.94144 50.8 -47.3472
-      vertex -8.01244 50.8 -47.1862
-    endloop
-  endfacet
-  facet normal -0.91498 0 -0.403499
-    outer loop
-      vertex -7.98543 50.8689 -47.2475
-      vertex -8.01244 50.8 -47.1862
-      vertex -8.01244 50.8753 -47.1862
-    endloop
-  endfacet
-  facet normal -0.914977 0 -0.403506
-    outer loop
-      vertex -7.94144 52 -47.3472
-      vertex -8.01244 52.8 -47.1862
-      vertex -7.94144 52.8 -47.3472
-    endloop
-  endfacet
-  facet normal -0.914977 -0 -0.403506
-    outer loop
-      vertex -8.01244 52.8 -47.1862
-      vertex -7.94144 52 -47.3472
-      vertex -8.01244 52 -47.1862
-    endloop
-  endfacet
-  facet normal -0.790575 0 -0.612366
-    outer loop
-      vertex -8.10944 50.8 -47.061
-      vertex -8.01244 50.8753 -47.1862
-      vertex -8.01244 50.8 -47.1862
-    endloop
-  endfacet
-  facet normal -0.790575 0 -0.612366
-    outer loop
-      vertex -8.01244 50.8753 -47.1862
-      vertex -8.10944 50.8 -47.061
-      vertex -8.10944 50.8885 -47.061
-    endloop
-  endfacet
-  facet normal -0.790575 0 -0.612366
-    outer loop
-      vertex -8.01244 52 -47.1862
-      vertex -8.10944 52.8 -47.061
-      vertex -8.01244 52.8 -47.1862
-    endloop
-  endfacet
-  facet normal -0.790575 -0 -0.612366
-    outer loop
-      vertex -8.10944 52.8 -47.061
-      vertex -8.01244 52 -47.1862
-      vertex -8.10944 52 -47.061
-    endloop
-  endfacet
-  facet normal -0.580549 0 -0.814225
-    outer loop
-      vertex -8.23566 50.8 -46.971
-      vertex -8.10944 50.8885 -47.061
-      vertex -8.10944 50.8 -47.061
-    endloop
-  endfacet
-  facet normal -0.580549 0 -0.814225
-    outer loop
-      vertex -8.10944 50.8885 -47.061
-      vertex -8.23566 50.8 -46.971
-      vertex -8.23566 50.8979 -46.971
-    endloop
-  endfacet
-  facet normal -0.580549 0 -0.814225
-    outer loop
-      vertex -8.23566 52 -46.971
-      vertex -8.10944 52.8 -47.061
-      vertex -8.10944 52 -47.061
-    endloop
-  endfacet
-  facet normal -0.580549 0 -0.814225
-    outer loop
-      vertex -8.10944 52.8 -47.061
-      vertex -8.23566 52 -46.971
-      vertex -8.23566 52.8 -46.971
-    endloop
-  endfacet
-  facet normal -0.322203 0 -0.946671
-    outer loop
-      vertex -8.39432 50.8 -46.917
-      vertex -8.23566 50.8979 -46.971
-      vertex -8.23566 50.8 -46.971
-    endloop
-  endfacet
-  facet normal -0.322203 0 -0.946671
-    outer loop
-      vertex -8.23566 50.8979 -46.971
-      vertex -8.39432 50.8 -46.917
-      vertex -8.39432 50.9036 -46.917
-    endloop
-  endfacet
-  facet normal -0.322203 0 -0.946671
-    outer loop
-      vertex -8.39432 52 -46.917
-      vertex -8.23566 52.8 -46.971
-      vertex -8.23566 52 -46.971
-    endloop
-  endfacet
-  facet normal -0.322203 0 -0.946671
-    outer loop
-      vertex -8.23566 52.8 -46.971
-      vertex -8.39432 52 -46.917
-      vertex -8.39432 52.8 -46.917
-    endloop
-  endfacet
-  facet normal -0.0937962 0 -0.995591
-    outer loop
-      vertex -8.58543 50.8 -46.899
-      vertex -8.39432 50.9036 -46.917
-      vertex -8.39432 50.8 -46.917
-    endloop
-  endfacet
-  facet normal -0.0937962 0 -0.995591
-    outer loop
-      vertex -8.39432 50.9036 -46.917
-      vertex -8.58543 50.8 -46.899
-      vertex -8.58543 50.9055 -46.899
-    endloop
-  endfacet
-  facet normal -0.0937962 0 -0.995591
-    outer loop
-      vertex -8.58543 52 -46.899
-      vertex -8.39432 52.8 -46.917
-      vertex -8.39432 52 -46.917
-    endloop
-  endfacet
-  facet normal -0.0937962 0 -0.995591
-    outer loop
-      vertex -8.39432 52.8 -46.917
-      vertex -8.58543 52 -46.899
-      vertex -8.58543 52.8 -46.899
-    endloop
-  endfacet
-  facet normal 0.191399 0 -0.981512
-    outer loop
-      vertex -8.94154 50.8982 -46.9684
-      vertex -8.58543 50.8 -46.899
-      vertex -8.94154 50.8 -46.9684
-    endloop
-  endfacet
-  facet normal 0.191399 0 -0.981512
-    outer loop
-      vertex -8.58543 50.8 -46.899
-      vertex -8.94154 50.8982 -46.9684
-      vertex -8.58543 50.9055 -46.899
-    endloop
-  endfacet
-  facet normal 0.191399 0 -0.981512
-    outer loop
-      vertex -8.94154 52 -46.9684
-      vertex -8.58543 52.8 -46.899
-      vertex -8.58543 52 -46.899
-    endloop
-  endfacet
-  facet normal 0.191399 0 -0.981512
-    outer loop
-      vertex -8.58543 52.8 -46.899
-      vertex -8.94154 52 -46.9684
-      vertex -8.94154 52.8 -46.9684
-    endloop
-  endfacet
-  facet normal 0.698128 0 -0.715973
-    outer loop
-      vertex -9.15521 50.8763 -47.1768
-      vertex -8.94154 50.8 -46.9684
-      vertex -9.15521 50.8 -47.1768
-    endloop
-  endfacet
-  facet normal 0.698128 0 -0.715973
-    outer loop
-      vertex -8.94154 50.8 -46.9684
-      vertex -9.15521 50.8763 -47.1768
-      vertex -8.94154 50.8982 -46.9684
-    endloop
-  endfacet
-  facet normal 0.698128 0 -0.715973
-    outer loop
-      vertex -9.15521 52 -47.1768
-      vertex -8.94154 52.8 -46.9684
-      vertex -8.94154 52 -46.9684
-    endloop
-  endfacet
-  facet normal 0.698128 0 -0.715973
-    outer loop
-      vertex -8.94154 52.8 -46.9684
-      vertex -9.15521 52 -47.1768
-      vertex -9.15521 52.8 -47.1768
-    endloop
-  endfacet
-  facet normal 0.979609 0 -0.200915
-    outer loop
-      vertex -9.15521 50.8 -47.1768
-      vertex -9.16971 50.8689 -47.2475
-      vertex -9.15521 50.8763 -47.1768
-    endloop
-  endfacet
-  facet normal 0.979609 -6.91403e-007 -0.200916
-    outer loop
-      vertex -9.16971 50.8689 -47.2475
-      vertex -9.15521 50.8 -47.1768
-      vertex -9.21319 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0.979609 0 -0.200916
-    outer loop
-      vertex -9.15521 52 -47.1768
-      vertex -9.22643 52.8 -47.524
-      vertex -9.15521 52.8 -47.1768
-    endloop
-  endfacet
-  facet normal 0.979609 0 -0.200916
-    outer loop
-      vertex -9.22643 52.8 -47.524
-      vertex -9.15521 52 -47.1768
-      vertex -9.22643 52 -47.524
-    endloop
-  endfacet
-  facet normal 0.991277 -0 0.131793
-    outer loop
-      vertex -9.22643 52 -47.524
-      vertex -9.20366 52.8 -47.6952
-      vertex -9.22643 52.8 -47.524
-    endloop
-  endfacet
-  facet normal 0.991277 0 0.131793
-    outer loop
-      vertex -9.20366 52.8 -47.6952
-      vertex -9.22643 52 -47.524
-      vertex -9.20366 52 -47.6952
-    endloop
-  endfacet
-  facet normal 0.930532 -0 0.366211
-    outer loop
-      vertex -9.20366 52 -47.6952
-      vertex -9.13531 52.8 -47.8689
-      vertex -9.20366 52.8 -47.6952
-    endloop
-  endfacet
-  facet normal 0.930532 0 0.366211
-    outer loop
-      vertex -9.13531 52.8 -47.8689
-      vertex -9.20366 52 -47.6952
-      vertex -9.13531 52 -47.8689
-    endloop
-  endfacet
-  facet normal 0.839715 -0 0.543028
-    outer loop
-      vertex -9.13531 52 -47.8689
-      vertex -9.02142 52.8 -48.045
-      vertex -9.13531 52.8 -47.8689
-    endloop
-  endfacet
-  facet normal 0.839715 0 0.543028
-    outer loop
-      vertex -9.02142 52.8 -48.045
-      vertex -9.13531 52 -47.8689
-      vertex -9.02142 52 -48.045
-    endloop
-  endfacet
-  facet normal 0.749879 -0 0.661574
-    outer loop
-      vertex -9.02142 52 -48.045
-      vertex -8.85155 52.8 -48.2376
-      vertex -9.02142 52.8 -48.045
-    endloop
-  endfacet
-  facet normal 0.749879 0 0.661574
-    outer loop
-      vertex -8.85155 52.8 -48.2376
-      vertex -9.02142 52 -48.045
-      vertex -8.85155 52 -48.2376
-    endloop
-  endfacet
-  facet normal 0.68641 0 0.727215
-    outer loop
-      vertex -8.85155 52.8 -48.2376
-      vertex -8.61388 52 -48.4619
-      vertex -8.61388 52.8 -48.4619
-    endloop
-  endfacet
-  facet normal 0.68641 0 0.727215
-    outer loop
-      vertex -8.61388 52 -48.4619
-      vertex -8.85155 52.8 -48.2376
-      vertex -8.85155 52 -48.2376
-    endloop
-  endfacet
-  facet normal 0.642612 0 0.766192
-    outer loop
-      vertex -8.61388 52.8 -48.4619
-      vertex -7.9752 52 -48.9976
-      vertex -7.9752 52.8 -48.9976
-    endloop
-  endfacet
-  facet normal 0.642612 0 0.766192
-    outer loop
-      vertex -7.9752 52 -48.9976
-      vertex -8.61388 52.8 -48.4619
-      vertex -8.61388 52 -48.4619
-    endloop
-  endfacet
-  facet normal 0.68036 0 0.732878
-    outer loop
-      vertex -7.9752 52.8 -48.9976
-      vertex -7.68221 52 -49.2696
-      vertex -7.68221 52.8 -49.2696
-    endloop
-  endfacet
-  facet normal 0.68036 0 0.732878
-    outer loop
-      vertex -7.68221 52 -49.2696
-      vertex -7.9752 52.8 -48.9976
-      vertex -7.9752 52 -48.9976
-    endloop
-  endfacet
-  facet normal 0.722881 -0 0.690973
-    outer loop
-      vertex -7.68221 52 -49.2696
-      vertex -7.42943 52.8 -49.534
-      vertex -7.68221 52.8 -49.2696
-    endloop
-  endfacet
-  facet normal 0.722881 0 0.690973
-    outer loop
-      vertex -7.42943 52.8 -49.534
-      vertex -7.68221 52 -49.2696
-      vertex -7.42943 52 -49.534
-    endloop
-  endfacet
-  facet normal 0.774379 -0 0.632721
-    outer loop
-      vertex -7.42943 52 -49.534
-      vertex -7.21454 52.8 -49.797
-      vertex -7.42943 52.8 -49.534
-    endloop
-  endfacet
-  facet normal 0.774379 0 0.632721
-    outer loop
-      vertex -7.21454 52.8 -49.797
-      vertex -7.42943 52 -49.534
-      vertex -7.21454 52 -49.797
-    endloop
-  endfacet
-  facet normal 0.830758 -0 0.556633
-    outer loop
-      vertex -7.21454 52 -49.797
-      vertex -7.0352 52.8 -50.0647
-      vertex -7.21454 52.8 -49.797
-    endloop
-  endfacet
-  facet normal 0.830758 0 0.556633
-    outer loop
-      vertex -7.0352 52.8 -50.0647
-      vertex -7.21454 52 -49.797
-      vertex -7.0352 52 -50.0647
-    endloop
-  endfacet
-  facet normal 0.884339 -0 0.466845
-    outer loop
-      vertex -7.0352 52 -50.0647
-      vertex -6.89143 52.8 -50.337
-      vertex -7.0352 52.8 -50.0647
-    endloop
-  endfacet
-  facet normal 0.884339 0 0.466845
-    outer loop
-      vertex -6.89143 52.8 -50.337
-      vertex -7.0352 52 -50.0647
-      vertex -6.89143 52 -50.337
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -6.89143 52 -50.337
-      vertex -6.89143 52.8 -51
-      vertex -6.89143 52.8 -50.337
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -6.89143 52.8 -51
-      vertex -6.89143 52 -50.337
-      vertex -6.89143 52 -51
+      vertex 2.74963 52 -50.1821
+      vertex 2.36353 52.8 -50.232
+      vertex 2.36353 52 -50.232
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -10.2714 52 -51
-      vertex -6.89143 52.8 -51
-      vertex -6.89143 52 -51
+      vertex 6.49101 52 -48.824
+      vertex 8.444 52.8 -48.824
+      vertex 8.444 52 -48.824
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -6.89143 52.8 -51
-      vertex -10.2714 52 -51
-      vertex -10.2714 52.8 -51
+      vertex 8.444 52.8 -48.824
+      vertex 6.49101 52 -48.824
+      vertex 6.49101 52.8 -48.824
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 6.49101 52 -48.824
+      vertex 6.49101 52.8 -51
+      vertex 6.49101 52.8 -48.824
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6.49101 52.8 -51
+      vertex 6.49101 52 -48.824
+      vertex 6.49101 52 -51
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.453 52 -51
+      vertex 6.49101 52.8 -51
+      vertex 6.49101 52 -51
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.49101 52.8 -51
+      vertex 5.453 52 -51
+      vertex 5.453 52.8 -51
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -10.2714 52 -51
-      vertex -10.2714 52.8 -50.213
-      vertex -10.2714 52.8 -51
+      vertex 5.453 52 -51
+      vertex 5.453 52.8 -46.008
+      vertex 5.453 52.8 -51
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex -10.2714 52.8 -50.213
-      vertex -10.2714 52 -51
-      vertex -10.2714 52 -50.213
+      vertex 5.453 52.8 -46.008
+      vertex 5.453 52 -51
+      vertex 5.453 52 -46.008
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0 0 1
     outer loop
-      vertex 6.42101 52 -48.951
-      vertex 8.52701 52.8 -48.951
-      vertex 8.52701 52 -48.951
+      vertex 5.453 52.8 -46.008
+      vertex 6.49101 52 -46.008
+      vertex 6.49101 52.8 -46.008
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 1
     outer loop
-      vertex 8.52701 52.8 -48.951
-      vertex 6.42101 52 -48.951
-      vertex 6.42101 52.8 -48.951
+      vertex 6.49101 52 -46.008
+      vertex 5.453 52.8 -46.008
+      vertex 5.453 52 -46.008
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 6.42101 52 -48.951
-      vertex 6.42101 52.8 -51
-      vertex 6.42101 52.8 -48.951
+      vertex 6.49101 52 -46.008
+      vertex 6.49101 52.8 -47.928
+      vertex 6.49101 52.8 -46.008
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 6.42101 52.8 -51
-      vertex 6.42101 52 -48.951
-      vertex 6.42101 52 -51
+      vertex 6.49101 52.8 -47.928
+      vertex 6.49101 52 -46.008
+      vertex 6.49101 52 -47.928
     endloop
   endfacet
-  facet normal 0 0 -1
+  facet normal -0 0 1
     outer loop
-      vertex 5.416 52 -51
-      vertex 6.42101 52.8 -51
-      vertex 6.42101 52 -51
+      vertex 6.49101 52.8 -47.928
+      vertex 8.444 52 -47.928
+      vertex 8.444 52.8 -47.928
     endloop
   endfacet
-  facet normal -0 0 -1
+  facet normal 0 0 1
     outer loop
-      vertex 6.42101 52.8 -51
-      vertex 5.416 52 -51
-      vertex 5.416 52.8 -51
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 5.416 50.8 -46.2
-      vertex 5.416 50.9226 -46.7363
-      vertex 5.416 50.8689 -47.2475
+      vertex 8.444 52 -47.928
+      vertex 6.49101 52.8 -47.928
+      vertex 6.49101 52 -47.928
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 5.416 50.8 -46.2
-      vertex 5.416 50.8689 -47.2475
-      vertex 5.416 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 5.416 50.9226 -46.7363
-      vertex 5.416 50.8 -46.2
-      vertex 5.416 50.979 -46.2
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 5.416 52 -51
-      vertex 5.416 52.8 -46.2
-      vertex 5.416 52.8 -51
+      vertex 8.444 52 -47.928
+      vertex 8.444 52.8 -46.008
+      vertex 8.444 52.8 -47.928
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 5.416 52.8 -46.2
-      vertex 5.416 52 -51
-      vertex 5.416 52 -46.2
+      vertex 8.444 52.8 -46.008
+      vertex 8.444 52 -47.928
+      vertex 8.444 52 -46.008
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 5.416 50.979 -46.2
-      vertex 6.42101 50.8 -46.2
-      vertex 6.42101 50.979 -46.2
+      vertex 8.444 52.8 -46.008
+      vertex 9.47801 52 -46.008
+      vertex 9.47801 52.8 -46.008
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 6.42101 50.8 -46.2
-      vertex 5.416 50.979 -46.2
-      vertex 5.416 50.8 -46.2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 5.416 52.8 -46.2
-      vertex 6.42101 52 -46.2
-      vertex 6.42101 52.8 -46.2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.42101 52 -46.2
-      vertex 5.416 52.8 -46.2
-      vertex 5.416 52 -46.2
+      vertex 9.47801 52 -46.008
+      vertex 8.444 52.8 -46.008
+      vertex 8.444 52 -46.008
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 6.42101 50.8 -46.2
-      vertex 6.42101 50.9204 -46.7572
-      vertex 6.42101 50.979 -46.2
+      vertex 9.47801 52 -46.008
+      vertex 9.47801 52.8 -51
+      vertex 9.47801 52.8 -46.008
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 6.42101 50.8 -46.2
-      vertex 6.42101 50.8689 -47.2475
-      vertex 6.42101 50.9204 -46.7572
+      vertex 9.47801 52.8 -51
+      vertex 9.47801 52 -46.008
+      vertex 9.47801 52 -51
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal 0 0 -1
     outer loop
-      vertex 6.42101 50.8689 -47.2475
-      vertex 6.42101 50.8 -46.2
-      vertex 6.42101 50.8 -47.4595
+      vertex 8.444 52 -51
+      vertex 9.47801 52.8 -51
+      vertex 9.47801 52 -51
     endloop
   endfacet
-  facet normal 1 -0 0
+  facet normal -0 0 -1
     outer loop
-      vertex 6.42101 52 -46.2
-      vertex 6.42101 52.8 -48.12
-      vertex 6.42101 52.8 -46.2
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 6.42101 52.8 -48.12
-      vertex 6.42101 52 -46.2
-      vertex 6.42101 52 -48.12
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 6.42101 52.8 -48.12
-      vertex 8.52701 52 -48.12
-      vertex 8.52701 52.8 -48.12
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 8.52701 52 -48.12
-      vertex 6.42101 52.8 -48.12
-      vertex 6.42101 52 -48.12
+      vertex 9.47801 52.8 -51
+      vertex 8.444 52 -51
+      vertex 8.444 52.8 -51
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 8.52701 50.8 -47.4595
-      vertex 8.52701 50.9158 -46.801
-      vertex 8.52701 50.8689 -47.2475
+      vertex 8.444 52 -51
+      vertex 8.444 52.8 -48.824
+      vertex 8.444 52.8 -51
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 8.52701 50.9158 -46.801
-      vertex 8.52701 50.8 -47.4595
-      vertex 8.52701 50.8 -46.2
+      vertex 8.444 52.8 -48.824
+      vertex 8.444 52 -51
+      vertex 8.444 52 -48.824
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.33089 52 -46.904
+      vertex -2.83589 52.8 -46.904
+      vertex -2.83589 52 -46.904
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -2.83589 52.8 -46.904
+      vertex -4.33089 52 -46.904
+      vertex -4.33089 52.8 -46.904
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 8.52701 50.9158 -46.801
-      vertex 8.52701 50.8 -46.2
-      vertex 8.52701 50.979 -46.2
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 8.52701 52 -48.12
-      vertex 8.52701 52.8 -46.2
-      vertex 8.52701 52.8 -48.12
+      vertex -4.33089 52 -46.904
+      vertex -4.33089 52.8 -46.008
+      vertex -4.33089 52.8 -46.904
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 8.52701 52.8 -46.2
-      vertex 8.52701 52 -48.12
-      vertex 8.52701 52 -46.2
+      vertex -4.33089 52.8 -46.008
+      vertex -4.33089 52 -46.904
+      vertex -4.33089 52 -46.008
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 8.52701 50.979 -46.2
-      vertex 9.53201 50.8 -46.2
-      vertex 9.53201 50.979 -46.2
+      vertex -4.33089 52.8 -46.008
+      vertex -0.282898 52 -46.008
+      vertex -0.282898 52.8 -46.008
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.53201 50.8 -46.2
-      vertex 8.52701 50.979 -46.2
-      vertex 8.52701 50.8 -46.2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 8.52701 52.8 -46.2
-      vertex 9.53201 52 -46.2
-      vertex 9.53201 52.8 -46.2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.53201 52 -46.2
-      vertex 8.52701 52.8 -46.2
-      vertex 8.52701 52 -46.2
+      vertex -0.282898 52 -46.008
+      vertex -4.33089 52.8 -46.008
+      vertex -4.33089 52 -46.008
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 9.53201 50.8 -46.2
-      vertex 9.53201 50.9136 -46.8219
-      vertex 9.53201 50.979 -46.2
+      vertex -0.282898 52 -46.008
+      vertex -0.282898 52.8 -46.904
+      vertex -0.282898 52.8 -46.008
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 9.53201 50.8 -47.4595
-      vertex 9.53201 50.9136 -46.8219
-      vertex 9.53201 50.8 -46.2
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 9.53201 50.9136 -46.8219
-      vertex 9.53201 50.8 -47.4595
-      vertex 9.53201 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 9.53201 52 -46.2
-      vertex 9.53201 52.8 -51
-      vertex 9.53201 52.8 -46.2
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 9.53201 52.8 -51
-      vertex 9.53201 52 -46.2
-      vertex 9.53201 52 -51
+      vertex -0.282898 52.8 -46.904
+      vertex -0.282898 52 -46.008
+      vertex -0.282898 52 -46.904
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 8.52701 52 -51
-      vertex 9.53201 52.8 -51
-      vertex 9.53201 52 -51
+      vertex -1.7849 52 -46.904
+      vertex -0.282898 52.8 -46.904
+      vertex -0.282898 52 -46.904
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 9.53201 52.8 -51
-      vertex 8.52701 52 -51
-      vertex 8.52701 52.8 -51
+      vertex -0.282898 52.8 -46.904
+      vertex -1.7849 52 -46.904
+      vertex -1.7849 52.8 -46.904
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -1.7849 52 -46.904
+      vertex -1.7849 52.8 -51
+      vertex -1.7849 52.8 -46.904
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -1.7849 52.8 -51
+      vertex -1.7849 52 -46.904
+      vertex -1.7849 52 -51
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.83589 52 -51
+      vertex -1.7849 52.8 -51
+      vertex -1.7849 52 -51
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.7849 52.8 -51
+      vertex -2.83589 52 -51
+      vertex -2.83589 52.8 -51
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 8.52701 52 -51
-      vertex 8.52701 52.8 -48.951
-      vertex 8.52701 52.8 -51
+      vertex -2.83589 52 -51
+      vertex -2.83589 52.8 -46.904
+      vertex -2.83589 52.8 -51
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 8.52701 52.8 -48.951
-      vertex 8.52701 52 -51
-      vertex 8.52701 52 -48.951
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -4.36874 50.8 -46.977
-      vertex -2.83774 50.8973 -46.977
-      vertex -2.83774 50.8 -46.977
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.83774 50.8973 -46.977
-      vertex -4.36874 50.8 -46.977
-      vertex -4.36874 50.8973 -46.977
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -4.36874 52 -46.977
-      vertex -2.83774 52.8 -46.977
-      vertex -2.83774 52 -46.977
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.83774 52.8 -46.977
-      vertex -4.36874 52 -46.977
-      vertex -4.36874 52.8 -46.977
+      vertex -2.83589 52.8 -46.904
+      vertex -2.83589 52 -51
+      vertex -2.83589 52 -46.904
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -4.36874 50.8 -46.977
-      vertex -4.36874 50.944 -46.5329
-      vertex -4.36874 50.8973 -46.977
+      vertex -6.13649 52 -47.27
+      vertex -6.13649 52.8 -46.008
+      vertex -6.13649 52.8 -47.27
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex -4.36874 50.944 -46.5329
-      vertex -4.36874 50.8 -46.977
-      vertex -4.36874 50.8 -46.2
+      vertex -6.13649 52.8 -46.008
+      vertex -6.13649 52 -47.27
+      vertex -6.13649 52 -46.008
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -6.13649 52.8 -46.008
+      vertex -5.07549 52 -46.008
+      vertex -5.07549 52.8 -46.008
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.07549 52 -46.008
+      vertex -6.13649 52.8 -46.008
+      vertex -6.13649 52 -46.008
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -5.07549 52 -46.008
+      vertex -5.07549 52.8 -47.27
+      vertex -5.07549 52.8 -46.008
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -5.07549 52.8 -47.27
+      vertex -5.07549 52 -46.008
+      vertex -5.07549 52 -47.27
+    endloop
+  endfacet
+  facet normal 0.992757 0 -0.12014
+    outer loop
+      vertex -5.07549 52 -47.27
+      vertex -5.35649 52.8 -49.592
+      vertex -5.07549 52.8 -47.27
+    endloop
+  endfacet
+  facet normal 0.992757 0 -0.12014
+    outer loop
+      vertex -5.35649 52.8 -49.592
+      vertex -5.07549 52 -47.27
+      vertex -5.35649 52 -49.592
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.86249 52 -49.592
+      vertex -5.35649 52.8 -49.592
+      vertex -5.35649 52 -49.592
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -5.35649 52.8 -49.592
+      vertex -5.86249 52 -49.592
+      vertex -5.86249 52.8 -49.592
+    endloop
+  endfacet
+  facet normal -0.99311 0 -0.117189
+    outer loop
+      vertex -5.86249 52 -49.592
+      vertex -6.13649 52.8 -47.27
+      vertex -5.86249 52.8 -49.592
+    endloop
+  endfacet
+  facet normal -0.99311 -0 -0.117189
+    outer loop
+      vertex -6.13649 52.8 -47.27
+      vertex -5.86249 52 -49.592
+      vertex -6.13649 52 -47.27
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -9.78029 52.8 -50.168
+      vertex -7.63428 52 -50.168
+      vertex -7.63428 52.8 -50.168
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.63428 52 -50.168
+      vertex -9.78029 52.8 -50.168
+      vertex -9.78029 52 -50.168
+    endloop
+  endfacet
+  facet normal -0.834222 0 -0.551429
+    outer loop
+      vertex -7.63428 52 -50.168
+      vertex -7.69972 52.8 -50.069
+      vertex -7.63428 52.8 -50.168
+    endloop
+  endfacet
+  facet normal -0.834222 -0 -0.551429
+    outer loop
+      vertex -7.69972 52.8 -50.069
+      vertex -7.63428 52 -50.168
+      vertex -7.69972 52 -50.069
+    endloop
+  endfacet
+  facet normal -0.769268 0 -0.638927
+    outer loop
+      vertex -7.69972 52 -50.069
+      vertex -7.77472 52.8 -49.9787
+      vertex -7.69972 52.8 -50.069
+    endloop
+  endfacet
+  facet normal -0.769268 -0 -0.638927
+    outer loop
+      vertex -7.77472 52.8 -49.9787
+      vertex -7.69972 52 -50.069
+      vertex -7.77472 52 -49.9787
+    endloop
+  endfacet
+  facet normal -0.69484 0 -0.719164
+    outer loop
+      vertex -7.85928 52 -49.897
+      vertex -7.77472 52.8 -49.9787
+      vertex -7.77472 52 -49.9787
+    endloop
+  endfacet
+  facet normal -0.69484 0 -0.719164
+    outer loop
+      vertex -7.77472 52.8 -49.9787
+      vertex -7.85928 52 -49.897
+      vertex -7.85928 52.8 -49.897
+    endloop
+  endfacet
+  facet normal -0.633597 0 -0.773663
+    outer loop
+      vertex -7.97406 52 -49.803
+      vertex -7.85928 52.8 -49.897
+      vertex -7.85928 52 -49.897
+    endloop
+  endfacet
+  facet normal -0.633597 0 -0.773663
+    outer loop
+      vertex -7.85928 52.8 -49.897
+      vertex -7.97406 52 -49.803
+      vertex -7.97406 52.8 -49.803
+    endloop
+  endfacet
+  facet normal -0.605383 0 -0.795934
+    outer loop
+      vertex -8.13972 52 -49.677
+      vertex -7.97406 52.8 -49.803
+      vertex -7.97406 52 -49.803
+    endloop
+  endfacet
+  facet normal -0.605383 0 -0.795934
+    outer loop
+      vertex -7.97406 52.8 -49.803
+      vertex -8.13972 52 -49.677
+      vertex -8.13972 52.8 -49.677
+    endloop
+  endfacet
+  facet normal -0.589395 0 -0.807845
+    outer loop
+      vertex -8.35628 52 -49.519
+      vertex -8.13972 52.8 -49.677
+      vertex -8.13972 52 -49.677
+    endloop
+  endfacet
+  facet normal -0.589395 0 -0.807845
+    outer loop
+      vertex -8.13972 52.8 -49.677
+      vertex -8.35628 52 -49.519
+      vertex -8.35628 52.8 -49.519
+    endloop
+  endfacet
+  facet normal -0.584415 0 -0.811455
+    outer loop
+      vertex -8.74228 52 -49.241
+      vertex -8.35628 52.8 -49.519
+      vertex -8.35628 52 -49.519
+    endloop
+  endfacet
+  facet normal -0.584415 0 -0.811455
+    outer loop
+      vertex -8.35628 52.8 -49.519
+      vertex -8.74228 52 -49.241
+      vertex -8.74228 52.8 -49.241
+    endloop
+  endfacet
+  facet normal -0.607211 0 -0.79454
+    outer loop
+      vertex -9.03761 52 -49.0153
+      vertex -8.74228 52.8 -49.241
+      vertex -8.74228 52 -49.241
+    endloop
+  endfacet
+  facet normal -0.607211 0 -0.79454
+    outer loop
+      vertex -8.74228 52.8 -49.241
+      vertex -9.03761 52 -49.0153
+      vertex -9.03761 52.8 -49.0153
+    endloop
+  endfacet
+  facet normal -0.668422 0 -0.743782
+    outer loop
+      vertex -9.27162 52 -48.805
+      vertex -9.03761 52.8 -49.0153
+      vertex -9.03761 52 -49.0153
+    endloop
+  endfacet
+  facet normal -0.668422 0 -0.743782
+    outer loop
+      vertex -9.03761 52.8 -49.0153
+      vertex -9.27162 52 -48.805
+      vertex -9.27162 52.8 -48.805
+    endloop
+  endfacet
+  facet normal -0.748711 0 -0.662897
+    outer loop
+      vertex -9.27162 52 -48.805
+      vertex -9.44427 52.8 -48.61
+      vertex -9.27162 52.8 -48.805
+    endloop
+  endfacet
+  facet normal -0.748711 -0 -0.662897
+    outer loop
+      vertex -9.44427 52.8 -48.61
+      vertex -9.27162 52 -48.805
+      vertex -9.44427 52 -48.61
+    endloop
+  endfacet
+  facet normal -0.852105 0 -0.52337
+    outer loop
+      vertex -9.44427 52 -48.61
+      vertex -9.6254 52.8 -48.3151
+      vertex -9.44427 52.8 -48.61
+    endloop
+  endfacet
+  facet normal -0.852105 -0 -0.52337
+    outer loop
+      vertex -9.6254 52.8 -48.3151
+      vertex -9.44427 52 -48.61
+      vertex -9.6254 52 -48.3151
+    endloop
+  endfacet
+  facet normal -0.947515 0 -0.319713
+    outer loop
+      vertex -9.6254 52 -48.3151
+      vertex -9.73405 52.8 -47.9931
+      vertex -9.6254 52.8 -48.3151
+    endloop
+  endfacet
+  facet normal -0.947515 -0 -0.319713
+    outer loop
+      vertex -9.73405 52.8 -47.9931
+      vertex -9.6254 52 -48.3151
+      vertex -9.73405 52 -47.9931
+    endloop
+  endfacet
+  facet normal -0.994658 0 -0.103227
+    outer loop
+      vertex -9.73405 52 -47.9931
+      vertex -9.77028 52.8 -47.644
+      vertex -9.73405 52.8 -47.9931
+    endloop
+  endfacet
+  facet normal -0.994658 -0 -0.103227
+    outer loop
+      vertex -9.77028 52.8 -47.644
+      vertex -9.73405 52 -47.9931
+      vertex -9.77028 52 -47.644
+    endloop
+  endfacet
+  facet normal -0.993361 0 0.115035
+    outer loop
+      vertex -9.77028 52 -47.644
+      vertex -9.71906 52.8 -47.2017
+      vertex -9.77028 52.8 -47.644
+    endloop
+  endfacet
+  facet normal -0.993361 0 0.115035
+    outer loop
+      vertex -9.71906 52.8 -47.2017
+      vertex -9.77028 52 -47.644
+      vertex -9.71906 52 -47.2017
+    endloop
+  endfacet
+  facet normal -0.927211 0 0.37454
+    outer loop
+      vertex -9.71906 52 -47.2017
+      vertex -9.5654 52.8 -46.8213
+      vertex -9.71906 52.8 -47.2017
+    endloop
+  endfacet
+  facet normal -0.927211 0 0.37454
+    outer loop
+      vertex -9.5654 52.8 -46.8213
+      vertex -9.71906 52 -47.2017
+      vertex -9.5654 52 -46.8213
+    endloop
+  endfacet
+  facet normal -0.779099 0 0.626901
+    outer loop
+      vertex -9.5654 52 -46.8213
+      vertex -9.30928 52.8 -46.503
+      vertex -9.5654 52.8 -46.8213
+    endloop
+  endfacet
+  facet normal -0.779099 0 0.626901
+    outer loop
+      vertex -9.30928 52.8 -46.503
+      vertex -9.5654 52 -46.8213
+      vertex -9.30928 52 -46.503
+    endloop
+  endfacet
+  facet normal -0.572597 0 0.819837
+    outer loop
+      vertex -9.30928 52.8 -46.503
+      vertex -8.96651 52 -46.2636
+      vertex -8.96651 52.8 -46.2636
+    endloop
+  endfacet
+  facet normal -0.572597 0 0.819837
+    outer loop
+      vertex -8.96651 52 -46.2636
+      vertex -9.30928 52.8 -46.503
+      vertex -9.30928 52 -46.503
+    endloop
+  endfacet
+  facet normal -0.328143 0 0.944628
+    outer loop
+      vertex -8.96651 52.8 -46.2636
+      vertex -8.55284 52 -46.1199
+      vertex -8.55284 52.8 -46.1199
+    endloop
+  endfacet
+  facet normal -0.328143 0 0.944628
+    outer loop
+      vertex -8.55284 52 -46.1199
+      vertex -8.96651 52.8 -46.2636
+      vertex -8.96651 52 -46.2636
+    endloop
+  endfacet
+  facet normal -0.0983731 0 0.99515
+    outer loop
+      vertex -8.55284 52.8 -46.1199
+      vertex -8.06828 52 -46.072
+      vertex -8.06828 52.8 -46.072
+    endloop
+  endfacet
+  facet normal -0.0983731 0 0.99515
+    outer loop
+      vertex -8.06828 52 -46.072
+      vertex -8.55284 52.8 -46.1199
+      vertex -8.55284 52 -46.1199
+    endloop
+  endfacet
+  facet normal 0.135381 0 0.990794
+    outer loop
+      vertex -8.06828 52.8 -46.072
+      vertex -7.47694 52 -46.1528
+      vertex -7.47694 52.8 -46.1528
+    endloop
+  endfacet
+  facet normal 0.135381 0 0.990794
+    outer loop
+      vertex -7.47694 52 -46.1528
+      vertex -8.06828 52.8 -46.072
+      vertex -8.06828 52 -46.072
+    endloop
+  endfacet
+  facet normal 0.467639 0 0.88392
+    outer loop
+      vertex -7.47694 52.8 -46.1528
+      vertex -7.01895 52 -46.3951
+      vertex -7.01895 52.8 -46.3951
+    endloop
+  endfacet
+  facet normal 0.467639 0 0.88392
+    outer loop
+      vertex -7.01895 52 -46.3951
+      vertex -7.47694 52.8 -46.1528
+      vertex -7.47694 52 -46.1528
+    endloop
+  endfacet
+  facet normal 0.779398 -0 0.626529
+    outer loop
+      vertex -7.01895 52 -46.3951
+      vertex -6.69427 52.8 -46.799
+      vertex -7.01895 52.8 -46.3951
+    endloop
+  endfacet
+  facet normal 0.779398 0 0.626529
+    outer loop
+      vertex -6.69427 52.8 -46.799
+      vertex -7.01895 52 -46.3951
+      vertex -6.69427 52 -46.799
+    endloop
+  endfacet
+  facet normal 0.924807 -0 0.380436
+    outer loop
+      vertex -6.69427 52 -46.799
+      vertex -6.57884 52.8 -47.0796
+      vertex -6.69427 52.8 -46.799
+    endloop
+  endfacet
+  facet normal 0.924807 0 0.380436
+    outer loop
+      vertex -6.57884 52.8 -47.0796
+      vertex -6.69427 52 -46.799
+      vertex -6.57884 52 -47.0796
+    endloop
+  endfacet
+  facet normal 0.975226 -0 0.221209
+    outer loop
+      vertex -6.57884 52 -47.0796
+      vertex -6.50317 52.8 -47.4132
+      vertex -6.57884 52.8 -47.0796
+    endloop
+  endfacet
+  facet normal 0.975226 0 0.221209
+    outer loop
+      vertex -6.50317 52.8 -47.4132
+      vertex -6.57884 52 -47.0796
+      vertex -6.50317 52 -47.4132
+    endloop
+  endfacet
+  facet normal 0.995725 -0 0.0923646
+    outer loop
+      vertex -6.50317 52 -47.4132
+      vertex -6.46729 52.8 -47.8
+      vertex -6.50317 52.8 -47.4132
+    endloop
+  endfacet
+  facet normal 0.995725 0 0.0923646
+    outer loop
+      vertex -6.46729 52.8 -47.8
+      vertex -6.50317 52 -47.4132
+      vertex -6.46729 52 -47.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.40628 52 -47.8
+      vertex -6.46729 52.8 -47.8
+      vertex -6.46729 52 -47.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.46729 52.8 -47.8
+      vertex -7.40628 52 -47.8
+      vertex -7.40628 52.8 -47.8
+    endloop
+  endfacet
+  facet normal -0.996683 0 -0.0813813
+    outer loop
+      vertex -7.40628 52 -47.8
+      vertex -7.42595 52.8 -47.5591
+      vertex -7.40628 52.8 -47.8
+    endloop
+  endfacet
+  facet normal -0.996683 -0 -0.0813813
+    outer loop
+      vertex -7.42595 52.8 -47.5591
+      vertex -7.40628 52 -47.8
+      vertex -7.42595 52 -47.5591
+    endloop
+  endfacet
+  facet normal -0.982793 0 -0.184712
+    outer loop
+      vertex -7.42595 52 -47.5591
+      vertex -7.46228 52.8 -47.3658
+      vertex -7.42595 52.8 -47.5591
+    endloop
+  endfacet
+  facet normal -0.982793 -0 -0.184712
+    outer loop
+      vertex -7.46228 52.8 -47.3658
+      vertex -7.42595 52 -47.5591
+      vertex -7.46228 52 -47.3658
+    endloop
+  endfacet
+  facet normal -0.939852 0 -0.341583
+    outer loop
+      vertex -7.46228 52 -47.3658
+      vertex -7.51527 52.8 -47.22
+      vertex -7.46228 52.8 -47.3658
+    endloop
+  endfacet
+  facet normal -0.939852 -0 -0.341583
+    outer loop
+      vertex -7.51527 52.8 -47.22
+      vertex -7.46228 52 -47.3658
+      vertex -7.51527 52 -47.22
+    endloop
+  endfacet
+  facet normal -0.787671 0 -0.616097
+    outer loop
+      vertex -7.51527 52 -47.22
+      vertex -7.65262 52.8 -47.0444
+      vertex -7.51527 52.8 -47.22
+    endloop
+  endfacet
+  facet normal -0.787671 -0 -0.616097
+    outer loop
+      vertex -7.65262 52.8 -47.0444
+      vertex -7.51527 52 -47.22
+      vertex -7.65262 52 -47.0444
+    endloop
+  endfacet
+  facet normal -0.465874 0 -0.884851
+    outer loop
+      vertex -7.85262 52 -46.9391
+      vertex -7.65262 52.8 -47.0444
+      vertex -7.65262 52 -47.0444
+    endloop
+  endfacet
+  facet normal -0.465874 0 -0.884851
+    outer loop
+      vertex -7.65262 52.8 -47.0444
+      vertex -7.85262 52 -46.9391
+      vertex -7.85262 52.8 -46.9391
+    endloop
+  endfacet
+  facet normal -0.132455 0 -0.991189
+    outer loop
+      vertex -8.11528 52 -46.904
+      vertex -7.85262 52.8 -46.9391
+      vertex -7.85262 52 -46.9391
+    endloop
+  endfacet
+  facet normal -0.132455 0 -0.991189
+    outer loop
+      vertex -7.85262 52.8 -46.9391
+      vertex -8.11528 52 -46.904
+      vertex -8.11528 52.8 -46.904
+    endloop
+  endfacet
+  facet normal 0.113838 0 -0.993499
+    outer loop
+      vertex -8.31339 52 -46.9267
+      vertex -8.11528 52.8 -46.904
+      vertex -8.11528 52 -46.904
+    endloop
+  endfacet
+  facet normal 0.113838 0 -0.993499
+    outer loop
+      vertex -8.11528 52.8 -46.904
+      vertex -8.31339 52 -46.9267
+      vertex -8.31339 52.8 -46.9267
+    endloop
+  endfacet
+  facet normal 0.381032 0 -0.924562
+    outer loop
+      vertex -8.47839 52 -46.9947
+      vertex -8.31339 52.8 -46.9267
+      vertex -8.31339 52 -46.9267
+    endloop
+  endfacet
+  facet normal 0.381032 0 -0.924562
+    outer loop
+      vertex -8.31339 52.8 -46.9267
+      vertex -8.47839 52 -46.9947
+      vertex -8.47839 52.8 -46.9947
+    endloop
+  endfacet
+  facet normal 0.651625 0 -0.758542
+    outer loop
+      vertex -8.61028 52 -47.108
+      vertex -8.47839 52.8 -46.9947
+      vertex -8.47839 52 -46.9947
+    endloop
+  endfacet
+  facet normal 0.651625 0 -0.758542
+    outer loop
+      vertex -8.47839 52.8 -46.9947
+      vertex -8.61028 52 -47.108
+      vertex -8.61028 52.8 -47.108
+    endloop
+  endfacet
+  facet normal 0.836642 0 -0.54775
+    outer loop
+      vertex -8.61028 52 -47.108
+      vertex -8.70639 52.8 -47.2548
+      vertex -8.61028 52.8 -47.108
+    endloop
+  endfacet
+  facet normal 0.836642 0 -0.54775
+    outer loop
+      vertex -8.70639 52.8 -47.2548
+      vertex -8.61028 52 -47.108
+      vertex -8.70639 52 -47.2548
+    endloop
+  endfacet
+  facet normal 0.946837 0 -0.321713
+    outer loop
+      vertex -8.70639 52 -47.2548
+      vertex -8.76405 52.8 -47.4245
+      vertex -8.70639 52.8 -47.2548
+    endloop
+  endfacet
+  facet normal 0.946837 0 -0.321713
+    outer loop
+      vertex -8.76405 52.8 -47.4245
+      vertex -8.70639 52 -47.2548
+      vertex -8.76405 52 -47.4245
+    endloop
+  endfacet
+  facet normal 0.995047 0 -0.0994014
+    outer loop
+      vertex -8.76405 52 -47.4245
+      vertex -8.78328 52.8 -47.617
+      vertex -8.76405 52.8 -47.4245
+    endloop
+  endfacet
+  facet normal 0.995047 0 -0.0994014
+    outer loop
+      vertex -8.78328 52.8 -47.617
+      vertex -8.76405 52 -47.4245
+      vertex -8.78328 52 -47.617
+    endloop
+  endfacet
+  facet normal 0.990731 -0 0.135836
+    outer loop
+      vertex -8.78328 52 -47.617
+      vertex -8.74973 52.8 -47.8617
+      vertex -8.78328 52.8 -47.617
+    endloop
+  endfacet
+  facet normal 0.990731 0 0.135836
+    outer loop
+      vertex -8.74973 52.8 -47.8617
+      vertex -8.78328 52 -47.617
+      vertex -8.74973 52 -47.8617
+    endloop
+  endfacet
+  facet normal 0.916918 -0 0.399075
+    outer loop
+      vertex -8.74973 52 -47.8617
+      vertex -8.64906 52.8 -48.093
+      vertex -8.74973 52.8 -47.8617
+    endloop
+  endfacet
+  facet normal 0.916918 0 0.399075
+    outer loop
+      vertex -8.64906 52.8 -48.093
+      vertex -8.74973 52 -47.8617
+      vertex -8.64906 52 -48.093
+    endloop
+  endfacet
+  facet normal 0.79247 -0 0.609911
+    outer loop
+      vertex -8.64906 52 -48.093
+      vertex -8.48128 52.8 -48.311
+      vertex -8.64906 52.8 -48.093
+    endloop
+  endfacet
+  facet normal 0.79247 0 0.609911
+    outer loop
+      vertex -8.48128 52.8 -48.311
+      vertex -8.64906 52 -48.093
+      vertex -8.48128 52 -48.311
+    endloop
+  endfacet
+  facet normal 0.672974 0 0.739666
+    outer loop
+      vertex -8.48128 52.8 -48.311
+      vertex -8.29817 52 -48.4776
+      vertex -8.29817 52.8 -48.4776
+    endloop
+  endfacet
+  facet normal 0.672974 0 0.739666
+    outer loop
+      vertex -8.29817 52 -48.4776
+      vertex -8.48128 52.8 -48.311
+      vertex -8.48128 52 -48.311
+    endloop
+  endfacet
+  facet normal 0.622385 0 0.782711
+    outer loop
+      vertex -8.29817 52.8 -48.4776
+      vertex -8.01018 52 -48.7066
+      vertex -8.01018 52.8 -48.7066
+    endloop
+  endfacet
+  facet normal 0.622385 0 0.782711
+    outer loop
+      vertex -8.01018 52 -48.7066
+      vertex -8.29817 52.8 -48.4776
+      vertex -8.29817 52 -48.4776
+    endloop
+  endfacet
+  facet normal 0.595707 0 0.803202
+    outer loop
+      vertex -8.01018 52.8 -48.7066
+      vertex -7.61728 52 -48.998
+      vertex -7.61728 52.8 -48.998
+    endloop
+  endfacet
+  facet normal 0.595707 0 0.803202
+    outer loop
+      vertex -7.61728 52 -48.998
+      vertex -8.01018 52.8 -48.7066
+      vertex -8.01018 52 -48.7066
+    endloop
+  endfacet
+  facet normal 0.6273 0 0.778778
+    outer loop
+      vertex -7.61728 52.8 -48.998
+      vertex -7.1665 52 -49.3611
+      vertex -7.1665 52.8 -49.3611
+    endloop
+  endfacet
+  facet normal 0.6273 0 0.778778
+    outer loop
+      vertex -7.1665 52 -49.3611
+      vertex -7.61728 52.8 -48.998
+      vertex -7.61728 52 -48.998
+    endloop
+  endfacet
+  facet normal 0.730155 -0 0.683282
+    outer loop
+      vertex -7.1665 52 -49.3611
+      vertex -6.84084 52.8 -49.7091
+      vertex -7.1665 52.8 -49.3611
+    endloop
+  endfacet
+  facet normal 0.730155 0 0.683282
+    outer loop
+      vertex -6.84084 52.8 -49.7091
+      vertex -7.1665 52 -49.3611
+      vertex -6.84084 52 -49.7091
+    endloop
+  endfacet
+  facet normal 0.856549 -0 0.516065
+    outer loop
+      vertex -6.84084 52 -49.7091
+      vertex -6.64027 52.8 -50.042
+      vertex -6.84084 52.8 -49.7091
+    endloop
+  endfacet
+  facet normal 0.856549 0 0.516065
+    outer loop
+      vertex -6.64027 52.8 -50.042
+      vertex -6.84084 52 -49.7091
+      vertex -6.64027 52 -50.042
+    endloop
+  endfacet
+  facet normal 0.928134 -0 0.372247
+    outer loop
+      vertex -6.64027 52 -50.042
+      vertex -6.52039 52.8 -50.3409
+      vertex -6.64027 52.8 -50.042
+    endloop
+  endfacet
+  facet normal 0.928134 0 0.372247
+    outer loop
+      vertex -6.52039 52.8 -50.3409
+      vertex -6.64027 52 -50.042
+      vertex -6.52039 52 -50.3409
+    endloop
+  endfacet
+  facet normal 0.973055 -0 0.230571
+    outer loop
+      vertex -6.52039 52 -50.3409
+      vertex -6.44473 52.8 -50.6602
+      vertex -6.52039 52.8 -50.3409
+    endloop
+  endfacet
+  facet normal 0.973055 0 0.230571
+    outer loop
+      vertex -6.44473 52.8 -50.6602
+      vertex -6.52039 52 -50.3409
+      vertex -6.44473 52 -50.6602
+    endloop
+  endfacet
+  facet normal 0.995744 -0 0.0921605
+    outer loop
+      vertex -6.44473 52 -50.6602
+      vertex -6.41328 52.8 -51
+      vertex -6.44473 52.8 -50.6602
+    endloop
+  endfacet
+  facet normal 0.995744 0 0.0921605
+    outer loop
+      vertex -6.41328 52.8 -51
+      vertex -6.44473 52 -50.6602
+      vertex -6.41328 52 -51
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.78029 52 -51
+      vertex -6.41328 52.8 -51
+      vertex -6.41328 52 -51
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.41328 52.8 -51
+      vertex -9.78029 52 -51
+      vertex -9.78029 52.8 -51
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -4.36874 50.944 -46.5329
-      vertex -4.36874 50.8 -46.2
-      vertex -4.36874 50.979 -46.2
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -4.36874 52 -46.977
-      vertex -4.36874 52.8 -46.2
-      vertex -4.36874 52.8 -46.977
+      vertex -9.78029 52 -51
+      vertex -9.78029 52.8 -50.168
+      vertex -9.78029 52.8 -51
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex -4.36874 52.8 -46.2
-      vertex -4.36874 52 -46.977
-      vertex -4.36874 52 -46.2
+      vertex -9.78029 52.8 -50.168
+      vertex -9.78029 52 -51
+      vertex -9.78029 52 -50.168
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -4.36874 50.979 -46.2
-      vertex -0.296738 50.8 -46.2
-      vertex -0.296738 50.979 -46.2
+      vertex -6.1095 52.8 -49.976
+      vertex -5.09949 52 -49.976
+      vertex -5.09949 52.8 -49.976
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.296738 50.8 -46.2
-      vertex -4.36874 50.979 -46.2
-      vertex -4.36874 50.8 -46.2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -4.36874 52.8 -46.2
-      vertex -0.296738 52 -46.2
-      vertex -0.296738 52.8 -46.2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.296738 52 -46.2
-      vertex -4.36874 52.8 -46.2
-      vertex -4.36874 52 -46.2
+      vertex -5.09949 52 -49.976
+      vertex -6.1095 52.8 -49.976
+      vertex -6.1095 52 -49.976
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex -0.296738 50.8 -46.2
-      vertex -0.296738 50.9351 -46.6176
-      vertex -0.296738 50.979 -46.2
+      vertex -5.09949 52 -49.976
+      vertex -5.09949 52.8 -51
+      vertex -5.09949 52.8 -49.976
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex -0.296738 50.8 -46.977
-      vertex -0.296738 50.9351 -46.6176
-      vertex -0.296738 50.8 -46.2
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -0.296738 50.9351 -46.6176
-      vertex -0.296738 50.8 -46.977
-      vertex -0.296738 50.8973 -46.977
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -0.296738 52 -46.2
-      vertex -0.296738 52.8 -46.977
-      vertex -0.296738 52.8 -46.2
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -0.296738 52.8 -46.977
-      vertex -0.296738 52 -46.2
-      vertex -0.296738 52 -46.977
+      vertex -5.09949 52.8 -51
+      vertex -5.09949 52 -49.976
+      vertex -5.09949 52 -51
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.83275 50.8 -46.977
-      vertex -0.296738 50.8973 -46.977
-      vertex -0.296738 50.8 -46.977
+      vertex -6.1095 52 -51
+      vertex -5.09949 52.8 -51
+      vertex -5.09949 52 -51
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -0.296738 50.8973 -46.977
-      vertex -1.83275 50.8 -46.977
-      vertex -1.83275 50.8973 -46.977
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.83275 52 -46.977
-      vertex -0.296738 52.8 -46.977
-      vertex -0.296738 52 -46.977
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.296738 52.8 -46.977
-      vertex -1.83275 52 -46.977
-      vertex -1.83275 52.8 -46.977
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -1.83275 50.8 -46.977
-      vertex -1.83275 50.8689 -47.2475
-      vertex -1.83275 50.8973 -46.977
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -1.83275 50.8689 -47.2475
-      vertex -1.83275 50.8 -46.977
-      vertex -1.83275 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -1.83275 52 -46.977
-      vertex -1.83275 52.8 -51
-      vertex -1.83275 52.8 -46.977
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -1.83275 52.8 -51
-      vertex -1.83275 52 -46.977
-      vertex -1.83275 52 -51
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.83774 52 -51
-      vertex -1.83275 52.8 -51
-      vertex -1.83275 52 -51
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.83275 52.8 -51
-      vertex -2.83774 52 -51
-      vertex -2.83774 52.8 -51
+      vertex -5.09949 52.8 -51
+      vertex -6.1095 52 -51
+      vertex -6.1095 52.8 -51
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -2.83774 50.8 -46.977
-      vertex -2.83774 50.8689 -47.2475
-      vertex -2.83774 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -2.83774 50.8689 -47.2475
-      vertex -2.83774 50.8 -46.977
-      vertex -2.83774 50.8973 -46.977
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -2.83774 52 -51
-      vertex -2.83774 52.8 -46.977
-      vertex -2.83774 52.8 -51
+      vertex -6.1095 52 -51
+      vertex -6.1095 52.8 -49.976
+      vertex -6.1095 52.8 -51
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex -2.83774 52.8 -46.977
-      vertex -2.83774 52 -51
-      vertex -2.83774 52 -46.977
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.99788 50.979 -46.2
-      vertex -4.99588 50.8 -46.2
-      vertex -4.99588 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.99588 50.8 -46.2
-      vertex -5.99788 50.979 -46.2
-      vertex -5.99788 50.8 -46.2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.99788 52.8 -46.2
-      vertex -4.99588 52 -46.2
-      vertex -4.99588 52.8 -46.2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.99588 52 -46.2
-      vertex -5.99788 52.8 -46.2
-      vertex -5.99788 52 -46.2
-    endloop
-  endfacet
-  facet normal 0.999484 0 -0.0321155
-    outer loop
-      vertex -4.99588 50.8 -46.2
-      vertex -5.00615 50.9454 -46.5196
-      vertex -4.99588 50.979 -46.2
-    endloop
-  endfacet
-  facet normal 0.999484 -1.41549e-006 -0.0321161
-    outer loop
-      vertex -4.99588 50.8 -46.2
-      vertex -5.02954 50.8689 -47.2475
-      vertex -5.00615 50.9454 -46.5196
-    endloop
-  endfacet
-  facet normal 0.999484 3.79779e-006 -0.0321158
-    outer loop
-      vertex -5.02954 50.8689 -47.2475
-      vertex -4.99588 50.8 -46.2
-      vertex -5.03635 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal 0.999484 0 -0.032116
-    outer loop
-      vertex -4.99588 52 -46.2
-      vertex -5.10487 52.8 -49.592
-      vertex -4.99588 52.8 -46.2
-    endloop
-  endfacet
-  facet normal 0.999484 0 -0.032116
-    outer loop
-      vertex -5.10487 52.8 -49.592
-      vertex -4.99588 52 -46.2
-      vertex -5.10487 52 -49.592
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.88887 52 -49.592
-      vertex -5.10487 52.8 -49.592
-      vertex -5.10487 52 -49.592
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -5.10487 52.8 -49.592
-      vertex -5.88887 52 -49.592
-      vertex -5.88887 52.8 -49.592
-    endloop
-  endfacet
-  facet normal -0.999484 -1.63038e-006 -0.0321207
-    outer loop
-      vertex -5.99788 50.8 -46.2
-      vertex -5.98826 50.9475 -46.4992
-      vertex -5.96422 50.8689 -47.2475
-    endloop
-  endfacet
-  facet normal -0.999484 3.9361e-006 -0.0321203
-    outer loop
-      vertex -5.99788 50.8 -46.2
-      vertex -5.96422 50.8689 -47.2475
-      vertex -5.9574 50.8 -47.4595
-    endloop
-  endfacet
-  facet normal -0.999484 0 -0.0321199
-    outer loop
-      vertex -5.98826 50.9475 -46.4992
-      vertex -5.99788 50.8 -46.2
-      vertex -5.99788 50.979 -46.2
-    endloop
-  endfacet
-  facet normal -0.999484 0 -0.0321205
-    outer loop
-      vertex -5.88887 52 -49.592
-      vertex -5.99788 52.8 -46.2
-      vertex -5.88887 52.8 -49.592
-    endloop
-  endfacet
-  facet normal -0.999484 -0 -0.0321205
-    outer loop
-      vertex -5.99788 52.8 -46.2
-      vertex -5.88887 52 -49.592
-      vertex -5.99788 52 -46.2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -5.97687 52.8 -50.104
-      vertex -4.99588 52 -50.104
-      vertex -4.99588 52.8 -50.104
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -4.99588 52 -50.104
-      vertex -5.97687 52.8 -50.104
-      vertex -5.97687 52 -50.104
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex -4.99588 52 -50.104
-      vertex -4.99588 52.8 -51
-      vertex -4.99588 52.8 -50.104
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex -4.99588 52.8 -51
-      vertex -4.99588 52 -50.104
-      vertex -4.99588 52 -51
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -5.97687 52 -51
-      vertex -4.99588 52.8 -51
-      vertex -4.99588 52 -51
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -4.99588 52.8 -51
-      vertex -5.97687 52 -51
-      vertex -5.97687 52.8 -51
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -5.97687 52 -51
-      vertex -5.97687 52.8 -50.104
-      vertex -5.97687 52.8 -51
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex -5.97687 52.8 -50.104
-      vertex -5.97687 52 -51
-      vertex -5.97687 52 -50.104
+      vertex -6.1095 52.8 -49.976
+      vertex -6.1095 52 -51
+      vertex -6.1095 52 -49.976
     endloop
   endfacet
 endsolid OpenSCAD_Model

--- a/Printed-Parts/stl/nozzle-fan.stl
+++ b/Printed-Parts/stl/nozzle-fan.stl
@@ -1,16 +1,114 @@
 solid OpenSCAD_Model
+  facet normal -0.99452 0.104545 0
+    outer loop
+      vertex -23.7898 17 -46.2923
+      vertex -23.4755 19.9899 -53
+      vertex -23.7898 17 -53
+    endloop
+  endfacet
+  facet normal -0.99452 0.104545 0
+    outer loop
+      vertex -23.4755 19.9899 -53
+      vertex -23.7898 17 -46.2923
+      vertex -23.4755 19.9899 -45.7651
+    endloop
+  endfacet
+  facet normal 0.99452 0.104545 -0
+    outer loop
+      vertex 23.7898 17 -47.6073
+      vertex 23.4755 19.9899 -45.7651
+      vertex 23.7898 17 -46.2923
+    endloop
+  endfacet
+  facet normal 0.99452 0.104545 0
+    outer loop
+      vertex 23.4755 19.9899 -45.7651
+      vertex 23.7898 17 -47.6073
+      vertex 23.4755 19.9899 -53
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.91068 35.5 -44
+      vertex 5.39024 30 -44
+      vertex 9.07974 30 -44
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 5.39024 30 -44
+      vertex 7.91068 35.5 -44
+      vertex 3.60318 35.5 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.0591 30 -44
+      vertex 18 30.6799 -44
+      vertex 16.0591 32.8355 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18 30.6799 -44
+      vertex 16.0591 30 -44
+      vertex 18.6122 30 -44
+    endloop
+  endfacet
+  facet normal 0.99452 0.104545 -0
+    outer loop
+      vertex 23.7898 17 -53
+      vertex 23.4755 19.9899 -53
+      vertex 23.7898 17 -47.6073
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 36.6751 -44
+      vertex -12 35.7846 -44
+      vertex -10 35.5 -44
+    endloop
+  endfacet
   facet normal -0 0 1
     outer loop
-      vertex -16.0591 32.8355 -44
-      vertex -12.608 30 -44
-      vertex -12 35.7846 -44
+      vertex -10 35.5 -44
+      vertex -9.07974 30 -44
+      vertex -7.91068 35.5 -44
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
       vertex -12.608 30 -44
-      vertex -16.0591 32.8355 -44
-      vertex -16.0591 30 -44
+      vertex -10 35.5 -44
+      vertex -12 35.7846 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 35.5 -44
+      vertex -12.608 30 -44
+      vertex -9.07974 30 -44
+    endloop
+  endfacet
+  facet normal -0.743137 0.66914 0
+    outer loop
+      vertex -18 30.6799 -53
+      vertex -18.6122 30 -44
+      vertex -18 30.6799 -44
+    endloop
+  endfacet
+  facet normal -0.743151 0.669124 0
+    outer loop
+      vertex -19.4164 29.1068 -44.1575
+      vertex -18 30.6799 -53
+      vertex -19.4164 29.1068 -53
+    endloop
+  endfacet
+  facet normal -0.743161 0.669112 -3.78246e-06
+    outer loop
+      vertex -18 30.6799 -53
+      vertex -19.4164 29.1068 -44.1575
+      vertex -18.6122 30 -44
     endloop
   endfacet
   facet normal 0 0 1
@@ -650,74 +748,18 @@ solid OpenSCAD_Model
       vertex -23.6689 15.7525 -53
     endloop
   endfacet
-  facet normal 0.99452 0.104545 -0
+  facet normal -0 0 1
     outer loop
-      vertex 23.7898 17 -47.6073
-      vertex 23.4755 19.9899 -45.7651
-      vertex 23.7898 17 -46.2923
+      vertex -7.91068 35.5 -44
+      vertex -5.39024 30 -44
+      vertex -3.60318 35.5 -44
     endloop
   endfacet
-  facet normal 0.99452 0.104545 0
+  facet normal 0 0 1
     outer loop
-      vertex 23.4755 19.9899 -45.7651
-      vertex 23.7898 17 -47.6073
-      vertex 23.4755 19.9899 -53
-    endloop
-  endfacet
-  facet normal 0.99452 0.104545 -0
-    outer loop
-      vertex 23.7898 17 -53
-      vertex 23.4755 19.9899 -53
-      vertex 23.7898 17 -47.6073
-    endloop
-  endfacet
-  facet normal -0.99452 0.104545 0
-    outer loop
-      vertex -23.7898 17 -46.2923
-      vertex -23.4755 19.9899 -53
-      vertex -23.7898 17 -53
-    endloop
-  endfacet
-  facet normal -0.99452 0.104545 0
-    outer loop
-      vertex -23.4755 19.9899 -53
-      vertex -23.7898 17 -46.2923
-      vertex -23.4755 19.9899 -45.7651
-    endloop
-  endfacet
-  facet normal -0.743137 0.66914 0
-    outer loop
-      vertex -18 30.6799 -53
-      vertex -18.6122 30 -44
-      vertex -18 30.6799 -44
-    endloop
-  endfacet
-  facet normal -0.743151 0.669124 0
-    outer loop
-      vertex -19.4164 29.1068 -44.1575
-      vertex -18 30.6799 -53
-      vertex -19.4164 29.1068 -53
-    endloop
-  endfacet
-  facet normal -0.743161 0.669112 -3.78246e-06
-    outer loop
-      vertex -18 30.6799 -53
-      vertex -19.4164 29.1068 -44.1575
-      vertex -18.6122 30 -44
-    endloop
-  endfacet
-  facet normal -0.866021 0.500008 0
-    outer loop
-      vertex -21.9251 24.7617 -44.9237
-      vertex -19.4164 29.1068 -53
-      vertex -21.9251 24.7617 -53
-    endloop
-  endfacet
-  facet normal -0.866021 0.500008 0
-    outer loop
-      vertex -19.4164 29.1068 -53
-      vertex -21.9251 24.7617 -44.9237
-      vertex -19.4164 29.1068 -44.1575
+      vertex -5.39024 30 -44
+      vertex -7.91068 35.5 -44
+      vertex -9.07974 30 -44
     endloop
   endfacet
   facet normal -0 0 1
@@ -748,6 +790,20 @@ solid OpenSCAD_Model
       vertex -21.9251 24.7617 -44.9237
     endloop
   endfacet
+  facet normal -0.866021 0.500008 0
+    outer loop
+      vertex -21.9251 24.7617 -44.9237
+      vertex -19.4164 29.1068 -53
+      vertex -21.9251 24.7617 -53
+    endloop
+  endfacet
+  facet normal -0.866021 0.500008 0
+    outer loop
+      vertex -19.4164 29.1068 -53
+      vertex -21.9251 24.7617 -44.9237
+      vertex -19.4164 29.1068 -44.1575
+    endloop
+  endfacet
   facet normal 0 0 1
     outer loop
       vertex 16.0591 32.8355 -44
@@ -767,20 +823,6 @@ solid OpenSCAD_Model
       vertex 12.608 30 -44
       vertex 12.3917 35.5 -44
       vertex 12.0299 35.5 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.0591 30 -44
-      vertex 18 30.6799 -44
-      vertex 16.0591 32.8355 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18 30.6799 -44
-      vertex 16.0591 30 -44
-      vertex 18.6122 30 -44
     endloop
   endfacet
   facet normal 0.866021 0.500008 0
@@ -825,32 +867,18 @@ solid OpenSCAD_Model
       vertex -18.6122 30 -44
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 7.91068 35.5 -44
-      vertex 5.39024 30 -44
-      vertex 9.07974 30 -44
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 5.39024 30 -44
-      vertex 7.91068 35.5 -44
-      vertex 3.60318 35.5 -44
-    endloop
-  endfacet
   facet normal -0 0 1
     outer loop
-      vertex -7.91068 35.5 -44
-      vertex -5.39024 30 -44
-      vertex -3.60318 35.5 -44
+      vertex -16.0591 32.8355 -44
+      vertex -12.608 30 -44
+      vertex -12 35.7846 -44
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -5.39024 30 -44
-      vertex -7.91068 35.5 -44
-      vertex -9.07974 30 -44
+      vertex -12.608 30 -44
+      vertex -16.0591 32.8355 -44
+      vertex -16.0591 30 -44
     endloop
   endfacet
   facet normal 0.743137 0.66914 0
@@ -872,34 +900,6 @@ solid OpenSCAD_Model
       vertex 18 30.6799 -53
       vertex 19.4164 29.1068 -44.1575
       vertex 19.4164 29.1068 -53
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10 36.6751 -44
-      vertex -12 35.7846 -44
-      vertex -10 35.5 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -10 35.5 -44
-      vertex -9.07974 30 -44
-      vertex -7.91068 35.5 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12.608 30 -44
-      vertex -10 35.5 -44
-      vertex -12 35.7846 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10 35.5 -44
-      vertex -12.608 30 -44
-      vertex -9.07974 30 -44
     endloop
   endfacet
   facet normal -0.994572 -0.104048 0
@@ -1285,97 +1285,6 @@ solid OpenSCAD_Model
       vertex 18 35.5 -53
       vertex 18 30.6799 -44
       vertex 18 30.6799 -53
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18 35.5 -44
-      vertex 16.0591 32.8355 -44
-      vertex 18 30.6799 -44
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 16.0591 32.8355 -44
-      vertex 18 35.5 -44
-      vertex 12.3917 35.5 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 10 51 -44
-      vertex 17.8395 40.5 -44
-      vertex 11.2 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10 36.6751 -44
-      vertex 10.5 40.5 -44
-      vertex 10 51 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.8395 40.5 -44
-      vertex 10 51 -44
-      vertex 10.5 40.5 -44
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -11.1397 52 -44
-      vertex 10 51 -44
-      vertex 11.2 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10 51 -44
-      vertex -11.1397 52 -44
-      vertex -10 51 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -18 40.1177 -44
-      vertex -10 51 -44
-      vertex -11.1397 52 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10 51 -44
-      vertex -18 40.1177 -44
-      vertex -10 36.6751 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -10 36.6751 -44
-      vertex -18 40.1177 -44
-      vertex -12 35.7846 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -12 35.7846 -44
-      vertex -18 40.1177 -44
-      vertex -16.0591 32.8355 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -16.0591 32.8355 -44
-      vertex -18 40.1177 -44
-      vertex -18 30.6799 -44
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.5 40.5 -44
-      vertex 10 36.6751 -44
-      vertex 10.5 36.4525 -44
     endloop
   endfacet
   facet normal 0 1 0
@@ -2379,6 +2288,125 @@ solid OpenSCAD_Model
       vertex 6.49101 52 -51
     endloop
   endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18 35.5 -44
+      vertex 16.0591 32.8355 -44
+      vertex 18 30.6799 -44
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 16.0591 32.8355 -44
+      vertex 18 35.5 -44
+      vertex 12.3917 35.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.1397 52 -44
+      vertex 10 51 -44
+      vertex 11.2 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 51 -44
+      vertex -11.1397 52 -44
+      vertex -10 51 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -18 40.1177 -44
+      vertex -10 51 -44
+      vertex -11.1397 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 51 -44
+      vertex -18 40.1177 -44
+      vertex -10 36.6751 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 36.6751 -44
+      vertex -18 40.1177 -44
+      vertex -12 35.7846 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12 35.7846 -44
+      vertex -18 40.1177 -44
+      vertex -16.0591 32.8355 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -16.0591 32.8355 -44
+      vertex -18 40.1177 -44
+      vertex -18 30.6799 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.2 52 -44
+      vertex 11.75 44 -44
+      vertex 17.8395 40.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10 51 -44
+      vertex 11.75 44 -44
+      vertex 11.2 52 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.75 44 -44
+      vertex 10 51 -44
+      vertex 10 44 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.75 41 -44
+      vertex 17.8395 40.5 -44
+      vertex 11.75 44 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.75 41 -44
+      vertex 10.5 40.5 -44
+      vertex 17.8395 40.5 -44
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 10 41 -44
+      vertex 10.5 40.5 -44
+      vertex 11.75 41 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 36.6751 -44
+      vertex 10.5 40.5 -44
+      vertex 10 41 -44
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.5 40.5 -44
+      vertex 10 36.6751 -44
+      vertex 10.5 36.4525 -44
+    endloop
+  endfacet
   facet normal 0 -1 0
     outer loop
       vertex -17.8 11 -47.3502
@@ -2659,20 +2687,6 @@ solid OpenSCAD_Model
       vertex 18.4272 11.0329 -53
     endloop
   endfacet
-  facet normal 0.587788 -0.809015 0
-    outer loop
-      vertex 21.8148 12.5411 -53
-      vertex 20.8 11.8038 -47.2085
-      vertex 20.8 11.8038 -53
-    endloop
-  endfacet
-  facet normal 0.587788 -0.809015 0
-    outer loop
-      vertex 20.8 11.8038 -47.2085
-      vertex 21.8148 12.5411 -53
-      vertex 21.8148 12.5411 -47.0785
-    endloop
-  endfacet
   facet normal 0.866017 -0.500015 0
     outer loop
       vertex 22.6541 13.4733 -46.9141
@@ -2715,6 +2729,20 @@ solid OpenSCAD_Model
       vertex 21.8148 12.5411 -53
     endloop
   endfacet
+  facet normal 0.587788 -0.809015 0
+    outer loop
+      vertex 21.8148 12.5411 -53
+      vertex 20.8 11.8038 -47.2085
+      vertex 20.8 11.8038 -53
+    endloop
+  endfacet
+  facet normal 0.587788 -0.809015 0
+    outer loop
+      vertex 20.8 11.8038 -47.2085
+      vertex 21.8148 12.5411 -53
+      vertex 21.8148 12.5411 -47.0785
+    endloop
+  endfacet
   facet normal 0.207923 -0.978145 0
     outer loop
       vertex 19.6541 11.2937 -53
@@ -2745,42 +2773,14 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 0
     outer loop
-      vertex 18.6122 30 -44
-      vertex 16.0591 30 -44
-      vertex 12.608 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex 11.1204 30 -44
-      vertex 12.365 30 -44
-      vertex 18.6122 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex -11.3909 30 -44
-      vertex 11.1204 30 -44
-      vertex 18.6122 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 -0
-    outer loop
-      vertex -16.0591 30 -44
-      vertex -18.6122 30 -44
-      vertex -12.6355 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
-      vertex -11.3909 30 -44
-      vertex 18.6122 30 -44
-      vertex 12.608 30 -44
-    endloop
-  endfacet
-  facet normal 0 0 0
-    outer loop
+      vertex -5.39024 30 -44
       vertex -9.07974 30 -44
+      vertex -12.608 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -5.39024 30 -44
       vertex -12.608 30 -44
       vertex -16.0591 30 -44
     endloop
@@ -2789,42 +2789,70 @@ solid OpenSCAD_Model
     outer loop
       vertex -12.6355 30 -44
       vertex -11.3909 30 -44
-      vertex 12.608 30 -44
+      vertex 11.1204 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
       vertex -5.39024 30 -44
-      vertex -9.07974 30 -44
       vertex -16.0591 30 -44
+      vertex -18.6122 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
       vertex -12.6355 30 -44
+      vertex 11.1204 30 -44
+      vertex 12.365 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 18.6122 30 -44
+      vertex 16.0591 30 -44
+      vertex 12.608 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -12.6355 30 -44
+      vertex 12.365 30 -44
+      vertex 18.6122 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex -18.6122 30 -44
+      vertex -12.6355 30 -44
+      vertex 18.6122 30 -44
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 18.6122 30 -44
       vertex 12.608 30 -44
       vertex 9.07974 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
-      vertex -12.6355 30 -44
-      vertex 9.07974 30 -44
       vertex 5.39024 30 -44
+      vertex -5.39024 30 -44
+      vertex -18.6122 30 -44
     endloop
   endfacet
   facet normal 0 0 0
     outer loop
+      vertex 9.07974 30 -44
       vertex 5.39024 30 -44
-      vertex -5.39024 30 -44
-      vertex -16.0591 30 -44
+      vertex -18.6122 30 -44
     endloop
   endfacet
-  facet normal 0 -0 0
+  facet normal 0 0 0
     outer loop
-      vertex -12.6355 30 -44
-      vertex 5.39024 30 -44
-      vertex -16.0591 30 -44
+      vertex 18.6122 30 -44
+      vertex 9.07974 30 -44
+      vertex -18.6122 30 -44
     endloop
   endfacet
   facet normal 5.89577e-06 -0.173638 0.98481
@@ -4073,20 +4101,6 @@ solid OpenSCAD_Model
       vertex 13.9901 38 -38.9308
     endloop
   endfacet
-  facet normal -0.951119 0 0.308824
-    outer loop
-      vertex 16.0074 35.5 -41.1711
-      vertex 16.1139 38 -40.8431
-      vertex 16.0074 38 -41.1711
-    endloop
-  endfacet
-  facet normal -0.951119 0 0.308824
-    outer loop
-      vertex 16.1139 38 -40.8431
-      vertex 16.0074 35.5 -41.1711
-      vertex 16.1139 35.5 -40.8431
-    endloop
-  endfacet
   facet normal -0.99451 0 0.10464
     outer loop
       vertex 16.1139 35.5 -40.8431
@@ -4099,6 +4113,20 @@ solid OpenSCAD_Model
       vertex 16.15 38 -40.5
       vertex 16.1139 35.5 -40.8431
       vertex 16.15 35.5 -40.5
+    endloop
+  endfacet
+  facet normal -0.951119 0 0.308824
+    outer loop
+      vertex 16.0074 35.5 -41.1711
+      vertex 16.1139 38 -40.8431
+      vertex 16.0074 38 -41.1711
+    endloop
+  endfacet
+  facet normal -0.951119 0 0.308824
+    outer loop
+      vertex 16.1139 38 -40.8431
+      vertex 16.0074 35.5 -41.1711
+      vertex 16.1139 35.5 -40.8431
     endloop
   endfacet
   facet normal 0.587637 0 0.809125
@@ -4143,34 +4171,6 @@ solid OpenSCAD_Model
       vertex 13.3959 35.5 -41.7262
     endloop
   endfacet
-  facet normal 0.99451 -0 0.10464
-    outer loop
-      vertex 12.85 35.5 -40.5
-      vertex 12.8861 38 -40.8431
-      vertex 12.85 38 -40.5
-    endloop
-  endfacet
-  facet normal 0.99451 0 0.10464
-    outer loop
-      vertex 12.8861 38 -40.8431
-      vertex 12.85 35.5 -40.5
-      vertex 12.8861 35.5 -40.8431
-    endloop
-  endfacet
-  facet normal -0.208143 0 0.978098
-    outer loop
-      vertex 14.6725 38 -42.141
-      vertex 15.0099 35.5 -42.0692
-      vertex 15.0099 38 -42.0692
-    endloop
-  endfacet
-  facet normal -0.208143 0 0.978098
-    outer loop
-      vertex 15.0099 35.5 -42.0692
-      vertex 14.6725 38 -42.141
-      vertex 14.6725 35.5 -42.141
-    endloop
-  endfacet
   facet normal -0.587637 0 0.809125
     outer loop
       vertex 15.325 38 -41.9289
@@ -4183,6 +4183,20 @@ solid OpenSCAD_Model
       vertex 15.6041 35.5 -41.7262
       vertex 15.325 38 -41.9289
       vertex 15.325 35.5 -41.9289
+    endloop
+  endfacet
+  facet normal 0.208143 0 0.978098
+    outer loop
+      vertex 13.9901 38 -42.0692
+      vertex 14.3275 35.5 -42.141
+      vertex 14.3275 38 -42.141
+    endloop
+  endfacet
+  facet normal 0.208143 0 0.978098
+    outer loop
+      vertex 14.3275 35.5 -42.141
+      vertex 13.9901 38 -42.0692
+      vertex 13.9901 35.5 -42.0692
     endloop
   endfacet
   facet normal 0.951119 -0 0.308824
@@ -4199,6 +4213,20 @@ solid OpenSCAD_Model
       vertex 12.9926 35.5 -41.1711
     endloop
   endfacet
+  facet normal 0.99451 -0 0.10464
+    outer loop
+      vertex 12.85 35.5 -40.5
+      vertex 12.8861 38 -40.8431
+      vertex 12.85 38 -40.5
+    endloop
+  endfacet
+  facet normal 0.99451 0 0.10464
+    outer loop
+      vertex 12.8861 38 -40.8431
+      vertex 12.85 35.5 -40.5
+      vertex 12.8861 35.5 -40.8431
+    endloop
+  endfacet
   facet normal -0.406757 0 0.913536
     outer loop
       vertex 15.0099 38 -42.0692
@@ -4211,6 +4239,20 @@ solid OpenSCAD_Model
       vertex 15.325 35.5 -41.9289
       vertex 15.0099 38 -42.0692
       vertex 15.0099 35.5 -42.0692
+    endloop
+  endfacet
+  facet normal -0.208143 0 0.978098
+    outer loop
+      vertex 14.6725 38 -42.141
+      vertex 15.0099 35.5 -42.0692
+      vertex 15.0099 38 -42.0692
+    endloop
+  endfacet
+  facet normal -0.208143 0 0.978098
+    outer loop
+      vertex 15.0099 35.5 -42.0692
+      vertex 14.6725 38 -42.141
+      vertex 14.6725 35.5 -42.141
     endloop
   endfacet
   facet normal -0.743236 0 0.669029
@@ -4239,20 +4281,6 @@ solid OpenSCAD_Model
       vertex 13.9901 35.5 -42.0692
       vertex 13.675 38 -41.9289
       vertex 13.675 35.5 -41.9289
-    endloop
-  endfacet
-  facet normal 0.208143 0 0.978098
-    outer loop
-      vertex 13.9901 38 -42.0692
-      vertex 14.3275 35.5 -42.141
-      vertex 14.3275 38 -42.141
-    endloop
-  endfacet
-  facet normal 0.208143 0 0.978098
-    outer loop
-      vertex 14.3275 35.5 -42.141
-      vertex 13.9901 38 -42.0692
-      vertex 13.9901 35.5 -42.0692
     endloop
   endfacet
   facet normal -0.994528 0 -0.104468
@@ -4913,20 +4941,6 @@ solid OpenSCAD_Model
       vertex 12.95 40.5 -37.8153
     endloop
   endfacet
-  facet normal -0.994528 0 0.104468
-    outer loop
-      vertex 17.5323 38 -41.1445
-      vertex 17.6 40.5 -40.5
-      vertex 17.5323 40.5 -41.1445
-    endloop
-  endfacet
-  facet normal -0.994528 0 0.104468
-    outer loop
-      vertex 17.6 40.5 -40.5
-      vertex 17.5323 38 -41.1445
-      vertex 17.6 38 -40.5
-    endloop
-  endfacet
   facet normal -0.207822 0 0.978167
     outer loop
       vertex 14.824 40.5 -43.583
@@ -4983,6 +4997,20 @@ solid OpenSCAD_Model
       vertex 17.5323 38 -41.1445
     endloop
   endfacet
+  facet normal -0.994528 0 0.104468
+    outer loop
+      vertex 17.5323 38 -41.1445
+      vertex 17.6 40.5 -40.5
+      vertex 17.5323 40.5 -41.1445
+    endloop
+  endfacet
+  facet normal -0.994528 0 0.104468
+    outer loop
+      vertex 17.6 40.5 -40.5
+      vertex 17.5323 38 -41.1445
+      vertex 17.6 38 -40.5
+    endloop
+  endfacet
   facet normal 0.58786 0 0.808963
     outer loop
       vertex 12.4257 40.5 -42.8037
@@ -5025,6 +5053,20 @@ solid OpenSCAD_Model
       vertex 12.4257 38 -42.8037
     endloop
   endfacet
+  facet normal 0.994528 -0 0.104468
+    outer loop
+      vertex 11.4 38 -40.5
+      vertex 11.4677 40.5 -41.1445
+      vertex 11.4 40.5 -40.5
+    endloop
+  endfacet
+  facet normal 0.994528 0 0.104468
+    outer loop
+      vertex 11.4677 40.5 -41.1445
+      vertex 11.4 38 -40.5
+      vertex 11.4677 38 -41.1445
+    endloop
+  endfacet
   facet normal -0.406768 0 0.913531
     outer loop
       vertex 15.458 40.5 -43.4483
@@ -5065,20 +5107,6 @@ solid OpenSCAD_Model
       vertex 11.668 40.5 -41.7609
       vertex 11.4677 38 -41.1445
       vertex 11.668 38 -41.7609
-    endloop
-  endfacet
-  facet normal 0.994528 -0 0.104468
-    outer loop
-      vertex 11.4 38 -40.5
-      vertex 11.4677 40.5 -41.1445
-      vertex 11.4 40.5 -40.5
-    endloop
-  endfacet
-  facet normal 0.994528 0 0.104468
-    outer loop
-      vertex 11.4677 40.5 -41.1445
-      vertex 11.4 38 -40.5
-      vertex 11.4677 38 -41.1445
     endloop
   endfacet
   facet normal 0.406768 0 0.913531
@@ -5212,6 +5240,62 @@ solid OpenSCAD_Model
       vertex -12.0775 29.4238 -45
       vertex -12.0875 29.3287 -45
       vertex -12.1909 29.3287 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.4 30.9123 -45
+      vertex -1.67245 30.9123 -45
+      vertex -0.4 35.4 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.67245 30.9123 -45
+      vertex 3.17551 35.5 -45
+      vertex 4.88823 30.2288 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.4 35.4 -45
+      vertex 1.67245 30.9123 -45
+      vertex 0.4 30.9123 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.67245 30.9123 -45
+      vertex 0.4 35.4 -45
+      vertex 3.17551 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.4 35.4 -45
+      vertex 3.17551 35.5 -45
+      vertex 0.4 35.4 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.4 35.4 -45
+      vertex -3.17551 35.5 -45
+      vertex 3.17551 35.5 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.67245 30.9123 -45
+      vertex -3.17551 35.5 -45
+      vertex -0.4 35.4 -45
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -3.17551 35.5 -45
+      vertex -1.67245 30.9123 -45
+      vertex -4.88823 30.2288 -45
     endloop
   endfacet
   facet normal 0 0 -1
@@ -6201,62 +6285,6 @@ solid OpenSCAD_Model
       vertex -7.68576 34.1533 -45
     endloop
   endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.4 30.9123 -45
-      vertex -1.67245 30.9123 -45
-      vertex -0.4 35.4 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.67245 30.9123 -45
-      vertex 3.17551 35.5 -45
-      vertex 4.88823 30.2288 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.4 35.4 -45
-      vertex 1.67245 30.9123 -45
-      vertex 0.4 30.9123 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.67245 30.9123 -45
-      vertex 0.4 35.4 -45
-      vertex 3.17551 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.4 35.4 -45
-      vertex 3.17551 35.5 -45
-      vertex 0.4 35.4 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.4 35.4 -45
-      vertex -3.17551 35.5 -45
-      vertex 3.17551 35.5 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.67245 30.9123 -45
-      vertex -3.17551 35.5 -45
-      vertex -0.4 35.4 -45
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -3.17551 35.5 -45
-      vertex -1.67245 30.9123 -45
-      vertex -4.88823 30.2288 -45
-    endloop
-  endfacet
   facet normal 0.866035 -0.499984 0
     outer loop
       vertex -21.0115 24.3549 -45.877
@@ -6609,9 +6637,9 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 1
     outer loop
+      vertex -6.93917 29.3287 -45
       vertex -4.94427 30.2169 -45
       vertex -5.43145 30 -45
-      vertex -6.93917 29.3287 -45
     endloop
   endfacet
   facet normal 0.866067 0.499927 0
@@ -6817,45 +6845,108 @@ solid OpenSCAD_Model
       vertex 17 30.3042 -45
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -10.4798 51 -46
-      vertex -10 51 -45
-      vertex -10.4798 51 -45
+      vertex 11.0928 40.8 -45
+      vertex 11.75 41 -45
+      vertex 13.3428 36.9029 -45
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -10 51 -45
-      vertex -10.4798 51 -46
-      vertex 10 51 -45
+      vertex 11.0928 40.8 -45
+      vertex 10 41 -45
+      vertex 11.75 41 -45
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex 10.5 51 -46
-      vertex 10 51 -45
-      vertex -10.4798 51 -46
+      vertex 10.4 40.4 -45
+      vertex 10 41 -45
+      vertex 11.0928 40.8 -45
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex 10 51 -45
-      vertex 10.5 51 -46
+      vertex 10 41 -45
+      vertex 10.4 40.4 -45
+      vertex 10 35.5864 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.39 32.0923 -45
+      vertex 12.65 36.5029 -45
+      vertex 13.3428 36.9029 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5 34.9186 -45
+      vertex 12.65 36.5029 -45
+      vertex 15.39 32.0923 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 35.5864 -45
+      vertex 12.65 36.5029 -45
+      vertex 11.5 34.9186 -45
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 12.65 36.5029 -45
+      vertex 10 35.5864 -45
+      vertex 10.4 40.4 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.39 32.0923 -45
+      vertex 17 36.4008 -45
+      vertex 17 30.3042 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.3428 36.9029 -45
+      vertex 17 36.4008 -45
+      vertex 15.39 32.0923 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.75 41 -45
+      vertex 17 36.4008 -45
+      vertex 13.3428 36.9029 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.75 44 -45
+      vertex 17 36.4008 -45
+      vertex 11.75 41 -45
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.75 44 -45
       vertex 10.5 51 -45
+      vertex 17 36.4008 -45
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 0 -1
     outer loop
-      vertex -10 51 -45
-      vertex 10 51 -44
-      vertex -10 51 -44
+      vertex 10 44 -45
+      vertex 10.5 51 -45
+      vertex 11.75 44 -45
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0 0 -1
     outer loop
-      vertex 10 51 -44
-      vertex -10 51 -45
+      vertex 10.5 51 -45
+      vertex 10 44 -45
       vertex 10 51 -45
     endloop
   endfacet
@@ -6938,83 +7029,6 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 15.39 32.0923 -45
-      vertex 12.65 36.5029 -45
-      vertex 13.3428 36.9029 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.5 34.9186 -45
-      vertex 12.65 36.5029 -45
-      vertex 15.39 32.0923 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 35.5864 -45
-      vertex 12.65 36.5029 -45
-      vertex 11.5 34.9186 -45
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.65 36.5029 -45
-      vertex 10 35.5864 -45
-      vertex 10.4 40.4 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.39 32.0923 -45
-      vertex 17 36.4008 -45
-      vertex 17 30.3042 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.3428 36.9029 -45
-      vertex 17 36.4008 -45
-      vertex 15.39 32.0923 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.0928 40.8 -45
-      vertex 17 36.4008 -45
-      vertex 13.3428 36.9029 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.0928 40.8 -45
-      vertex 10.5 51 -45
-      vertex 17 36.4008 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 51 -45
-      vertex 11.0928 40.8 -45
-      vertex 10.4 40.4 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10 51 -45
-      vertex 10.4 40.4 -45
-      vertex 10 35.5864 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.0928 40.8 -45
-      vertex 10 51 -45
-      vertex 10.5 51 -45
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
       vertex -0.4 30 -45
       vertex -1.67245 30.9123 -45
       vertex -0.4 30.9123 -45
@@ -7053,6 +7067,48 @@ solid OpenSCAD_Model
       vertex 1.67245 30.9123 -45
       vertex 0.4 30 -45
       vertex 0.4 30.9123 -45
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -10.4798 51 -46
+      vertex -10 51 -45
+      vertex -10.4798 51 -45
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -10 51 -45
+      vertex -10.4798 51 -46
+      vertex 10 51 -45
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10.5 51 -46
+      vertex 10 51 -45
+      vertex -10.4798 51 -46
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10 51 -45
+      vertex 10.5 51 -46
+      vertex 10.5 51 -45
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -10 51 -45
+      vertex 10 51 -44
+      vertex -10 51 -44
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 10 51 -44
+      vertex -10 51 -45
+      vertex 10 51 -45
     endloop
   endfacet
   facet normal 0 1 0
@@ -7216,6 +7272,20 @@ solid OpenSCAD_Model
       vertex 15.8 12 -49
     endloop
   endfacet
+  facet normal 0 -0.743167 0.669106
+    outer loop
+      vertex -11.3637 49.0148 -50.4589
+      vertex 11.0102 49.8541 -49.5267
+      vertex -10.99 49.8541 -49.5267
+    endloop
+  endfacet
+  facet normal 0 -0.743167 0.669106
+    outer loop
+      vertex 11.0102 49.8541 -49.5267
+      vertex -11.3637 49.0148 -50.4589
+      vertex 11.3839 49.0148 -50.4589
+    endloop
+  endfacet
   facet normal 2.71289e-08 -0.406688 0.913567
     outer loop
       vertex -12.3257 46.8541 -51.7063
@@ -7328,20 +7398,6 @@ solid OpenSCAD_Model
       vertex 11.0102 49.8541 -49.5267
     endloop
   endfacet
-  facet normal 0 -0.743167 0.669106
-    outer loop
-      vertex -11.3637 49.0148 -50.4589
-      vertex 11.0102 49.8541 -49.5267
-      vertex -10.99 49.8541 -49.5267
-    endloop
-  endfacet
-  facet normal 0 -0.743167 0.669106
-    outer loop
-      vertex 11.0102 49.8541 -49.5267
-      vertex -11.3637 49.0148 -50.4589
-      vertex 11.3839 49.0148 -50.4589
-    endloop
-  endfacet
   facet normal 0 -0.207923 0.978145
     outer loop
       vertex -12.3257 46.8541 -51.7063
@@ -7398,20 +7454,6 @@ solid OpenSCAD_Model
       vertex -22.6907 15.9604 -52
     endloop
   endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -17.8 12.0274 -52
-      vertex -18.3226 12.0274 -48.0507
-      vertex -17.8 12.0274 -48.0507
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -18.3226 12.0274 -48.0507
-      vertex -17.8 12.0274 -52
-      vertex -18.3226 12.0274 -52
-    endloop
-  endfacet
   facet normal 0.587762 0.809034 0
     outer loop
       vertex -21.1457 13.2843 -52
@@ -7466,6 +7508,20 @@ solid OpenSCAD_Model
       vertex -21.8451 14.0611 -52
       vertex -21.1457 13.2843 -47.8291
       vertex -21.1457 13.2843 -52
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.8 12.0274 -52
+      vertex -18.3226 12.0274 -48.0507
+      vertex -17.8 12.0274 -48.0507
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.3226 12.0274 -48.0507
+      vertex -17.8 12.0274 -52
+      vertex -18.3226 12.0274 -52
     endloop
   endfacet
   facet normal 0.951057 0.309015 0
@@ -8324,16 +8380,30 @@ solid OpenSCAD_Model
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 10 51 -45
-      vertex 10 36.6751 -44
+      vertex 10 44 -45
       vertex 10 51 -44
+      vertex 10 51 -45
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 10 51 -44
+      vertex 10 44 -45
+      vertex 10 44 -44
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 10 41 -45
+      vertex 10 36.6751 -44
+      vertex 10 41 -44
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
       vertex 10 35.5864 -45
       vertex 10 36.6751 -44
-      vertex 10 51 -45
+      vertex 10 41 -45
     endloop
   endfacet
   facet normal -1 0 0
@@ -8348,6 +8418,48 @@ solid OpenSCAD_Model
       vertex 10 35.5864 -45
       vertex 10 35.5 -44
       vertex 10 36.6751 -44
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 11.75 41 -45
+      vertex 10 41 -44
+      vertex 11.75 41 -44
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 10 41 -44
+      vertex 11.75 41 -45
+      vertex 10 41 -45
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 11.75 41 -45
+      vertex 11.75 44 -44
+      vertex 11.75 44 -45
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 11.75 44 -44
+      vertex 11.75 41 -45
+      vertex 11.75 41 -44
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10 44 -45
+      vertex 11.75 44 -44
+      vertex 10 44 -44
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 11.75 44 -44
+      vertex 10 44 -45
+      vertex 11.75 44 -45
     endloop
   endfacet
   facet normal -0.994525 0.104495 -4.99444e-05
@@ -8523,62 +8635,6 @@ solid OpenSCAD_Model
       vertex -9.36783 25.404 -49
       vertex -11.1196 26.431 -49
       vertex -10.7061 26.8903 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.4634 28.9233 -49
-      vertex -0.4 29 -49
-      vertex 0.4 29 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -0.4 29 -49
-      vertex 1.4634 28.9233 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -0.4 30 -49
-      vertex -0.4 29 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.4634 28.9233 -49
-      vertex -1.9774 30 -49
-      vertex -0.4 30 -49
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -1.9774 30 -49
-      vertex -1.4634 28.9233 -49
-      vertex -2.1049 28.787 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.4634 28.9233 -49
-      vertex 1.9774 30 -49
-      vertex 2.1049 28.787 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.4 30 -49
-      vertex 1.4634 28.9233 -49
-      vertex 0.4 29 -49
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.4634 28.9233 -49
-      vertex 0.4 30 -49
-      vertex 1.9774 30 -49
     endloop
   endfacet
   facet normal 0 0 -1
@@ -8796,6 +8852,34 @@ solid OpenSCAD_Model
       vertex -13.7043 17.8133 -49
       vertex -15.7825 17.0692 -49
       vertex -15.6504 18.3266 -49
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -1.77698 31.9069 -53
+      vertex -0.4 31.9069 -52
+      vertex -1.77698 31.9069 -52
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.4 31.9069 -52
+      vertex -1.77698 31.9069 -53
+      vertex -0.4 31.9069 -53
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.4 31.9069 -53
+      vertex 1.77698 31.9069 -52
+      vertex 0.4 31.9069 -52
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1.77698 31.9069 -52
+      vertex 0.4 31.9069 -53
+      vertex 1.77698 31.9069 -53
     endloop
   endfacet
   facet normal 0 0 -1
@@ -9106,6 +9190,20 @@ solid OpenSCAD_Model
       vertex -8 28.8564 -49
     endloop
   endfacet
+  facet normal 0.866027 -0.499997 0
+    outer loop
+      vertex -15.5303 21.9145 -52
+      vertex -13.9594 24.6354 -53
+      vertex -13.9594 24.6354 -52
+    endloop
+  endfacet
+  facet normal 0.866027 -0.499997 0
+    outer loop
+      vertex -13.9594 24.6354 -53
+      vertex -15.5303 21.9145 -52
+      vertex -15.5303 21.9145 -53
+    endloop
+  endfacet
   facet normal 0.207908 -0.978148 0
     outer loop
       vertex -5.25329 31.168 -53
@@ -9118,34 +9216,6 @@ solid OpenSCAD_Model
       vertex -1.77698 31.9069 -52
       vertex -5.25329 31.168 -53
       vertex -1.77698 31.9069 -53
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -1.77698 31.9069 -53
-      vertex -0.4 31.9069 -52
-      vertex -1.77698 31.9069 -52
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -0.4 31.9069 -52
-      vertex -1.77698 31.9069 -53
-      vertex -0.4 31.9069 -53
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 0.4 31.9069 -53
-      vertex 1.77698 31.9069 -52
-      vertex 0.4 31.9069 -52
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 1.77698 31.9069 -52
-      vertex 0.4 31.9069 -53
-      vertex 1.77698 31.9069 -53
     endloop
   endfacet
   facet normal 0.994518 0.104569 0
@@ -9302,6 +9372,48 @@ solid OpenSCAD_Model
       vertex 17 15 -53
     endloop
   endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -8.5 29.7224 -53
+      vertex -6.40917 30.6533 -52
+      vertex -8.5 29.7224 -52
+    endloop
+  endfacet
+  facet normal 0.406738 -0.913545 0
+    outer loop
+      vertex -6.40917 30.6533 -52
+      vertex -8.5 29.7224 -53
+      vertex -6.40917 30.6533 -53
+    endloop
+  endfacet
+  facet normal 0.406982 -0.913436 0
+    outer loop
+      vertex -5.48424 31.0651 -53
+      vertex -5.25329 31.168 -52
+      vertex -5.48424 31.0651 -52
+    endloop
+  endfacet
+  facet normal 0.406982 -0.913436 0
+    outer loop
+      vertex -5.25329 31.168 -52
+      vertex -5.48424 31.0651 -53
+      vertex -5.25329 31.168 -53
+    endloop
+  endfacet
+  facet normal 0.587775 -0.809024 0
+    outer loop
+      vertex -11.3752 27.6335 -53
+      vertex -8.5 29.7224 -52
+      vertex -11.3752 27.6335 -52
+    endloop
+  endfacet
+  facet normal 0.587775 -0.809024 0
+    outer loop
+      vertex -8.5 29.7224 -52
+      vertex -11.3752 27.6335 -53
+      vertex -8.5 29.7224 -53
+    endloop
+  endfacet
   facet normal 0 0 -1
     outer loop
       vertex -14.6167 21.5078 -49
@@ -9386,6 +9498,20 @@ solid OpenSCAD_Model
       vertex -11.1196 26.431 -49
     endloop
   endfacet
+  facet normal 0.743146 -0.669129 0
+    outer loop
+      vertex -13.3559 25.4337 -52
+      vertex -11.3752 27.6335 -53
+      vertex -11.3752 27.6335 -52
+    endloop
+  endfacet
+  facet normal 0.743146 -0.669129 0
+    outer loop
+      vertex -11.3752 27.6335 -53
+      vertex -13.3559 25.4337 -52
+      vertex -13.3559 25.4337 -53
+    endloop
+  endfacet
   facet normal 0 0 -1
     outer loop
       vertex -5.25329 27.902 -49
@@ -9421,74 +9547,60 @@ solid OpenSCAD_Model
       vertex -1.9774 30 -49
     endloop
   endfacet
-  facet normal 0.587775 -0.809024 0
+  facet normal 0 0 -1
     outer loop
-      vertex -11.3752 27.6335 -53
-      vertex -8.5 29.7224 -52
-      vertex -11.3752 27.6335 -52
+      vertex 1.4634 28.9233 -49
+      vertex -0.4 29 -49
+      vertex 0.4 29 -49
     endloop
   endfacet
-  facet normal 0.587775 -0.809024 0
+  facet normal 0 0 -1
     outer loop
-      vertex -8.5 29.7224 -52
-      vertex -11.3752 27.6335 -53
-      vertex -8.5 29.7224 -53
+      vertex -1.4634 28.9233 -49
+      vertex -0.4 29 -49
+      vertex 1.4634 28.9233 -49
     endloop
   endfacet
-  facet normal 0.406738 -0.913545 0
+  facet normal 0 0 -1
     outer loop
-      vertex -8.5 29.7224 -53
-      vertex -6.40917 30.6533 -52
-      vertex -8.5 29.7224 -52
+      vertex -1.4634 28.9233 -49
+      vertex -0.4 30 -49
+      vertex -0.4 29 -49
     endloop
   endfacet
-  facet normal 0.406738 -0.913545 0
+  facet normal 0 0 -1
     outer loop
-      vertex -6.40917 30.6533 -52
-      vertex -8.5 29.7224 -53
-      vertex -6.40917 30.6533 -53
+      vertex -1.4634 28.9233 -49
+      vertex -1.9774 30 -49
+      vertex -0.4 30 -49
     endloop
   endfacet
-  facet normal 0.406982 -0.913436 0
+  facet normal 0 -0 -1
     outer loop
-      vertex -5.48424 31.0651 -53
-      vertex -5.25329 31.168 -52
-      vertex -5.48424 31.0651 -52
+      vertex -1.9774 30 -49
+      vertex -1.4634 28.9233 -49
+      vertex -2.1049 28.787 -49
     endloop
   endfacet
-  facet normal 0.406982 -0.913436 0
+  facet normal 0 0 -1
     outer loop
-      vertex -5.25329 31.168 -52
-      vertex -5.48424 31.0651 -53
-      vertex -5.25329 31.168 -53
+      vertex 1.4634 28.9233 -49
+      vertex 1.9774 30 -49
+      vertex 2.1049 28.787 -49
     endloop
   endfacet
-  facet normal 0.866027 -0.499997 0
+  facet normal 0 0 -1
     outer loop
-      vertex -15.5303 21.9145 -52
-      vertex -13.9594 24.6354 -53
-      vertex -13.9594 24.6354 -52
+      vertex 0.4 30 -49
+      vertex 1.4634 28.9233 -49
+      vertex 0.4 29 -49
     endloop
   endfacet
-  facet normal 0.866027 -0.499997 0
+  facet normal 0 0 -1
     outer loop
-      vertex -13.9594 24.6354 -53
-      vertex -15.5303 21.9145 -52
-      vertex -15.5303 21.9145 -53
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex -13.3559 25.4337 -52
-      vertex -11.3752 27.6335 -53
-      vertex -11.3752 27.6335 -52
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex -11.3752 27.6335 -53
-      vertex -13.3559 25.4337 -52
-      vertex -13.3559 25.4337 -53
+      vertex 1.4634 28.9233 -49
+      vertex 0.4 30 -49
+      vertex 1.9774 30 -49
     endloop
   endfacet
   facet normal -0.939696 -0.342011 0
@@ -10856,20 +10968,6 @@ solid OpenSCAD_Model
       vertex -12.7572 36.7029 -52
     endloop
   endfacet
-  facet normal 0.866025 -0.500001 0
-    outer loop
-      vertex -12.7572 36.7029 -45
-      vertex -10.5072 40.6 -52
-      vertex -10.5072 40.6 -45
-    endloop
-  endfacet
-  facet normal 0.866025 -0.500001 0
-    outer loop
-      vertex -10.5072 40.6 -52
-      vertex -12.7572 36.7029 -45
-      vertex -12.7572 36.7029 -52
-    endloop
-  endfacet
   facet normal 0.500011 0.866019 -0
     outer loop
       vertex -10.5072 40.6 -52
@@ -10882,6 +10980,20 @@ solid OpenSCAD_Model
       vertex -11.2 41 -45
       vertex -10.5072 40.6 -52
       vertex -11.2 41 -52
+    endloop
+  endfacet
+  facet normal 0.866025 -0.500001 0
+    outer loop
+      vertex -12.7572 36.7029 -45
+      vertex -10.5072 40.6 -52
+      vertex -10.5072 40.6 -45
+    endloop
+  endfacet
+  facet normal 0.866025 -0.500001 0
+    outer loop
+      vertex -10.5072 40.6 -52
+      vertex -12.7572 36.7029 -45
+      vertex -12.7572 36.7029 -52
     endloop
   endfacet
   facet normal 0 1 -0


### PR DESCRIPTION
The MK3 fan nozzle model has multiple problems

a) the text "HOT!2" is extruded wrong: it reaches to the inside of the fan nozzle which degrades air flow
b) the cutout for the fan is too big. Air can easily escape. I reduced it by 0.5 mm. It could be even a little smaller

Since the production part's text does NOT reach INSIDE - I wonder why the production version is not the same as is the GitHub version? 

I wonder how the other parts differ from production to open source versions (Please Prusa Research, make sure to publish up to dates files)

Best regards