### PR TITLE
rebuilt optimized SCAD for rpi-zero-frame.scad, regen rpi-zero-frame.stl

### DIFF
--- a/Printed-Parts/SCAD/rpi-zero-frame.scad
+++ b/Printed-Parts/SCAD/rpi-zero-frame.scad
@@ -1,0 +1,248 @@
+// lee@braains.net pi zero frame for Einsy RAMBo 2020-07-18
+
+// b/c Prusa's SCAD is MIA
+// re: https://github.com/prusa3d/Original-Prusa-i3/issues/132
+
+// dimensions are derrived from the original STL, with some cleanup
+//color("red") translate([0,pizd[1],0]) translate([3.5,-3.5,4.5]) import("rpi-zero-frame.stl");
+
+// pi zero dimensions
+pizd=[65,30,4];
+
+// pin shroud thickness
+pinz=2.5;
+
+// pin clearance
+pc=1.8;
+
+// part thickness
+pt=2;
+
+// pcb thickness
+pcbt=1.4;
+
+inch=25.4;
+
+// f'n around
+$fn=32;
+
+
+final_part();
+module final_part(){
+    difference(){
+        base();
+        pins_cut();
+        hdmi_cut();
+        usb_cut();
+        inductor_cut();
+        weight_loss();
+        //mounting_fasteners();
+        under_cuts();
+        nice_cut();
+    }
+}
+
+module base(){
+    // inset for "shrunk" outer dims, matching OEM.
+    translate([0.5,0.5,0])
+    
+    // base block
+    cheese_slice(pizd[0]-1,pizd[1]-1,pt,6);
+    
+    // support columns & pegs
+    translate([3.5,3.5,0]){
+        for(x=[0:58:58]){
+            for(y=[0:23:23]){
+                // peg
+                translate([x,y,0]) cylinder(d=2.70, h=pt+pinz+pcbt);
+                // column
+                translate([x,y,0]) cylinder(d=6, h=pt+pinz);
+            }
+        }
+    }
+    
+    // braces around gpio pins
+    arm_rests();
+    
+    // this isn't really needed, but it's on the OEM frame.
+    arm_rest_flap();
+    
+    // support flap for SD Card side under cuts
+    // could be shorter to save a little material
+    hull(){
+        translate([3.5,3.5,pt]) cylinder(d=6,h=pinz-1.5);
+        translate([3.5,pizd[1]-3.5,pt]) cylinder(d=6,h=pinz-1.5);
+    }
+    
+    // support flap for camera connector side
+    // could also be shorter to save a little material
+    hull(){
+        translate([pizd[0]-3.5,0.5+3,pt]) cylinder(d=6,h=pinz-1.2);
+        translate([pizd[0]-3.5,pizd[1]-3.5,pt]) cylinder(d=6,h=pinz-1.2);
+    }
+    
+    // extension above USB power connector to prevent shorting.
+    usb_flap();
+}
+
+module nice_cut(){
+    // it bugged me, so I fixed it.
+    translate([3.5,3.5+pizd[1]-7,pt-4.4+pinz+1])
+    difference(){
+        translate([-3,0,0]) cube([6,6,10]);
+        cylinder(d=6,h=10);
+    }
+}
+
+module pins_cut(){
+    // all the pins
+//    translate([(pizd[0]-inch*2)/2,3.5-(inch*.05),0])
+//    for(x=[0:inch*.1:inch*2]){
+//        for(y=[0:inch*.1:inch*.1]){
+//            translate([x,y,0]) cylinder(d=1,h=20);
+//        }
+//    }
+    
+    // first four
+    translate([(pizd[0]-inch*2)/2+inch*.05,3.5-(inch*.05),0])
+    for(x=[inch*.1:inch*.1:inch*.4]){
+        for(y=[0:inch*.1:0]){
+            translate([x,y,0]) cylinder(d=1.6,h=20);
+        }
+    }
+    // other two
+    translate([(pizd[0]-inch*2)/2+inch*.05,3.5-(inch*.05),0])
+    for(x=[inch*.7:inch*.1:inch*.7]){
+        for(y=[0:inch*.1:inch*.1]){
+            translate([x,y,0]) cylinder(d=1.6,h=20);
+        }
+    }
+}
+
+module inductor_cut(){
+    translate([pizd[0]-5-6.5+2,10.5,pt+1.3-.6]) cheese_slice(5,5,.6,2);
+}
+
+module hdmi_cut(){
+    translate([6.5,pizd[1]-8,pt-4.4+pinz+1]) cube([12,8,4.4]);
+}
+
+module usb_flap(){
+    translate([47.7+1+3,pizd[1]-2.5,0]) cheese_slice(6,4,pt+.4,2);
+}
+
+module usb_cut(){
+    //translate([47.7-10,pizd[1]-5.5,pt+pinz+1.6-4]) cube([20,7,4]);
+    translate([47.7-10,pizd[1]-5.5,pt+pinz+1.6-4]) 
+    cheese_slice(20,7,4,1);
+    
+    // nice edge for usb flange
+    translate([48.5,pizd[1]-2.5+4,1.5]) rotate([45,0,0]) cube(10);
+}
+
+module weight_loss(){
+    translate([6.5,6.5,0]) cube(pizd-[13,13,0]+[0,0,10]);
+}
+
+module under_cuts(){
+    // sorry for the translate wrap, I manually shifted the geometry against
+    // the abandoned rpi-zero-frame.stl.    
+    translate([0,pizd[1],0]){
+        // under usb power input
+        hull(){
+            translate([54.7,-4.3,0]) twoby();
+            translate([54.7,-4.3+inch*.2,0]) twoby();
+        }
+        
+        // beside usb power input
+        translate([54.7-inch*.25,-4.3-inch*.1,0]) twoby();
+        
+        // straddle cut on gpio side
+        translate([34,-26,0]){
+            hull(){
+                twoby();
+                translate([inch*.4,0,0]) twoby();
+            }
+        }
+        
+        // straddle cut above sd card slot
+        translate([0,-8.4,0]) twoby();
+        
+        // through cut under sd card slot
+        hull(){
+            translate([2.3-inch*.1,-21,0]) twoby();
+            translate([2.3+inch*.2,-21,0]) twoby();
+        }
+        
+        // through cut gpio side
+        hull(){
+            translate([52.7,-26.3-inch*.2,0]) rotate([0,0,-90]) twoby();
+            translate([52.7,-26.3+inch*.2,0]) rotate([0,0,-90]) twoby();
+        }
+        
+        // corner cut (supports here)
+        hull(){
+            translate([3.6,-30.3,0]) twoby();
+            translate([3.6-inch*.1,-30.3,0]) twoby();
+        }
+    } // end translate
+}
+
+module twoby(){
+    // seemed like a good idea, got the job done
+    hull(){
+        cylinder(d=2.5,h=pc);
+        translate([0,inch*.1,0]) cylinder(d=2.5,h=pc);
+    }
+}
+
+module mounting_fasteners(){
+    translate([3.5,(pizd[1]-10)/2,0])
+    for(x=[0:58:58]){
+        for(y=[0:10:10]){
+            translate([x,y,0]) screw_hole();
+        }
+    }
+}
+
+module screw_hole(){
+    translate([0,0,2]) cylinder(d=6,h=pt);
+    cylinder(d=3,h=pt);
+}
+
+module arm_rests(){
+    // long side from camera side
+    hull(){
+        translate([0.5+pizd[0]-33-3.5,0.5,pt]) cheese_slice(33,6,pinz,3);
+        translate([0.5+pizd[0]-33/2-3.5,0.5,pt]) cube([33/2,6,pinz]);
+        translate([pizd[0]-3.5,0.5+3,pt]) cylinder(d=6,h=pinz);
+    }
+    
+    // short side from sd card slot side
+    hull(){
+        translate([0.5+3.5+2,0.5,pt]) cheese_slice(inch*.1,6,pinz,3);
+        translate([0.5+3.5,0.5,pt]) cube([inch*.1/2,6,pinz]);
+        translate([3.5,0.5+3,pt]) cylinder(d=6,h=pinz);
+    }
+}
+
+module arm_rest_flap(){
+    hull(){
+        translate([0.5+pizd[0]-36.5-3.5,0.5+pizd[1]-7,pt]) cheese_slice(33,6,.4,1);
+        translate([0.5+pizd[0]-36.5/2-3.5,0.5+pizd[1]-7,pt]) cube([33/2,6,.4]);
+        translate([pizd[0]-3.5,0.5+3+pizd[1]-7,pt]) cylinder(d=6,h=.4);
+    }
+    
+    // stand
+    translate([26.5-1,pizd[1]-3.5-1,pt]) cheese_slice(3,4,pinz,1);
+}
+
+module cheese_slice(width,depth,height,radius){
+    hull(){
+        for(x=[0:width-radius:width-radius]){
+            for(y=[0:depth-radius:depth-radius]){
+                translate([x,y,0]+[radius,radius]/2) cylinder(d=radius, h=height);
+            }
+        }
+    }
+}

--- a/Printed-Parts/STL/rpi-zero-frame.stl
+++ b/Printed-Parts/STL/rpi-zero-frame.stl
@@ -1,23032 +1,18986 @@
 solid OpenSCAD_Model
-  facet normal 0.994522 -0.104531 1.10638e-17
-    outer loop
-      vertex 1.22268 -0.25989 1.5
-      vertex 1.25 0 0
-      vertex 1.25 1.83697e-16 1.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104531 0
-    outer loop
-      vertex 1.25 0 0
-      vertex 1.22268 -0.25989 1.5
-      vertex 1.22268 -0.25989 3.18273e-17
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104531 1.10638e-17
-    outer loop
-      vertex -1.22268 -0.25989 3.18273e-17
-      vertex -1.25 1.83697e-16 1.5
-      vertex -1.25 0 0
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104531 0
-    outer loop
-      vertex -1.25 1.83697e-16 1.5
-      vertex -1.22268 -0.25989 3.18273e-17
-      vertex -1.22268 -0.25989 1.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.13066 -1.24315 1.52242e-16
-      vertex 0.13066 -1.24315 1.5
-      vertex -0.13066 -1.24315 1.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 0.13066 -1.24315 1.5
-      vertex -0.13066 -1.24315 1.52242e-16
-      vertex 0.13066 -1.24315 1.52242e-16
-    endloop
-  endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 0.13066 1.24315 -1.52242e-16
-      vertex -0.13066 1.24315 1.5
-      vertex 0.13066 1.24315 1.5
+      vertex 51.45 6.5 0
+      vertex 45.41 6.5 1.8
+      vertex 51.45 6.5 1.8
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.13066 1.24315 1.5
-      vertex 0.13066 1.24315 -1.52242e-16
-      vertex -0.13066 1.24315 -1.52242e-16
+      vertex 45.41 6.5 1.8
+      vertex 51.45 6.5 0
+      vertex 45.41 6.5 0
     endloop
   endfacet
-  facet normal 0.587787 -0.809016 0
+  facet normal 0 1 0
     outer loop
-      vertex 0.625 -1.08253 1.32572e-16
-      vertex 0.836412 -0.92893 1.5
-      vertex 0.625 -1.08253 1.5
+      vertex 56.49 6.5 1.8
+      vertex 58.5 6.5 4.5
+      vertex 58.5 6.5 3.3
     endloop
   endfacet
-  facet normal 0.587787 -0.809016 0
+  facet normal 0 1 0
     outer loop
-      vertex 0.836412 -0.92893 1.5
-      vertex 0.625 -1.08253 1.32572e-16
-      vertex 0.836412 -0.92893 1.13761e-16
+      vertex 58.5 6.5 4.5
+      vertex 45.41 6.5 1.8
+      vertex 30.5 6.5 4.5
     endloop
   endfacet
-  facet normal -0.587785 -0.809017 0
+  facet normal 0 1 0
     outer loop
-      vertex -0.836412 -0.92893 1.5
-      vertex -0.624999 -1.08253 1.32572e-16
-      vertex -0.624999 -1.08253 1.5
+      vertex 58.5 6.5 4.5
+      vertex 51.45 6.5 1.8
+      vertex 45.41 6.5 1.8
     endloop
   endfacet
-  facet normal -0.587785 -0.809017 0
+  facet normal 0 1 0
     outer loop
-      vertex -0.624999 -1.08253 1.32572e-16
-      vertex -0.836412 -0.92893 1.5
-      vertex -0.836412 -0.92893 1.13761e-16
+      vertex 58.5 6.5 4.5
+      vertex 56.49 6.5 1.8
+      vertex 51.45 6.5 1.8
     endloop
   endfacet
-  facet normal -0.207912 -0.978148 0
+  facet normal 0 1 -0
     outer loop
-      vertex -0.386271 -1.18882 1.5
-      vertex -0.13066 -1.24315 1.52242e-16
-      vertex -0.13066 -1.24315 1.5
+      vertex 58.5 6.5 0
+      vertex 56.49 6.5 1.8
+      vertex 58.5 6.5 3.3
     endloop
   endfacet
-  facet normal -0.207912 -0.978148 0
+  facet normal 0 1 0
     outer loop
-      vertex -0.13066 -1.24315 1.52242e-16
-      vertex -0.386271 -1.18882 1.5
-      vertex -0.386271 -1.18882 1.45588e-16
+      vertex 56.49 6.5 1.8
+      vertex 58.5 6.5 0
+      vertex 56.49 6.5 0
     endloop
   endfacet
-  facet normal 0.951057 0.309017 0
+  facet normal 0 1 0
     outer loop
-      vertex 1.22268 0.25989 1.5
-      vertex 1.14193 0.50842 -6.22635e-17
-      vertex 1.14193 0.50842 1.5
+      vertex 7.5 6.5 4.5
+      vertex 6.5 6.5 3
+      vertex 6.5 6.5 4.5
     endloop
   endfacet
-  facet normal 0.951057 0.309017 0
+  facet normal 0 1 -0
     outer loop
-      vertex 1.14193 0.50842 -6.22635e-17
-      vertex 1.22268 0.25989 1.5
-      vertex 1.22268 0.25989 -3.18273e-17
+      vertex 7.5 6.5 2
+      vertex 6.5 6.5 3
+      vertex 7.5 6.5 4.5
     endloop
   endfacet
-  facet normal 0.866025 -0.500001 0
+  facet normal 0 1 -0
     outer loop
-      vertex 1.01127 -0.734731 1.5
-      vertex 1.14193 -0.50842 6.22635e-17
-      vertex 1.14193 -0.50842 1.5
+      vertex 32.75 6.5 1.8
+      vertex 30.5 6.5 4.5
+      vertex 45.41 6.5 1.8
     endloop
   endfacet
-  facet normal 0.866025 -0.500001 0
+  facet normal 0 1 0
     outer loop
-      vertex 1.14193 -0.50842 6.22635e-17
-      vertex 1.01127 -0.734731 1.5
-      vertex 1.01127 -0.734731 8.99786e-17
+      vertex 30.5 6.5 4.5
+      vertex 32.75 6.5 1.8
+      vertex 30.5 6.5 2
     endloop
   endfacet
-  facet normal 0.951057 -0.309017 0
+  facet normal 0 1 -0
     outer loop
-      vertex 1.14193 -0.50842 1.5
-      vertex 1.22268 -0.25989 3.18273e-17
-      vertex 1.22268 -0.25989 1.5
+      vertex 32.75 6.5 0
+      vertex 30.5 6.5 2
+      vertex 32.75 6.5 1.8
     endloop
   endfacet
-  facet normal 0.951057 -0.309017 0
+  facet normal 0 1 0
     outer loop
-      vertex 1.22268 -0.25989 3.18273e-17
-      vertex 1.14193 -0.50842 1.5
-      vertex 1.14193 -0.50842 6.22635e-17
+      vertex 6.5 6.5 0
+      vertex 30.5 6.5 2
+      vertex 32.75 6.5 0
     endloop
   endfacet
-  facet normal 0.743145 -0.669131 0
+  facet normal 0 1 0
     outer loop
-      vertex 0.836412 -0.92893 1.5
-      vertex 1.01127 -0.734731 8.99786e-17
-      vertex 1.01127 -0.734731 1.5
+      vertex 7.5 6.5 2
+      vertex 6.5 6.5 0
+      vertex 6.5 6.5 3
     endloop
   endfacet
-  facet normal 0.743145 -0.669131 0
+  facet normal 0 1 0
     outer loop
-      vertex 1.01127 -0.734731 8.99786e-17
-      vertex 0.836412 -0.92893 1.5
-      vertex 0.836412 -0.92893 1.13761e-16
+      vertex 30.5 6.5 2
+      vertex 6.5 6.5 0
+      vertex 7.5 6.5 2
     endloop
   endfacet
-  facet normal 0.207912 -0.978148 0
+  facet normal 0 1 -0
     outer loop
-      vertex 0.13066 -1.24315 1.52242e-16
-      vertex 0.386271 -1.18882 1.5
-      vertex 0.13066 -1.24315 1.5
+      vertex 6.5 6.5 3
+      vertex 3.5 6.5 4.5
+      vertex 6.5 6.5 4.5
     endloop
   endfacet
-  facet normal 0.207912 -0.978148 0
+  facet normal 0 1 0
     outer loop
-      vertex 0.386271 -1.18882 1.5
-      vertex 0.13066 -1.24315 1.52242e-16
-      vertex 0.386271 -1.18882 1.45588e-16
+      vertex 3.5 6.5 4.5
+      vertex 6.5 6.5 3
+      vertex 3.5 6.5 3
     endloop
   endfacet
-  facet normal 0.406736 -0.913546 0
+  facet normal 0 1 -0
     outer loop
-      vertex 0.386271 -1.18882 1.45588e-16
-      vertex 0.625 -1.08253 1.5
-      vertex 0.386271 -1.18882 1.5
+      vertex 62 6.5 3.3
+      vertex 58.5 6.5 4.5
+      vertex 62 6.5 4.5
     endloop
   endfacet
-  facet normal 0.406736 -0.913546 0
+  facet normal 0 1 0
     outer loop
-      vertex 0.625 -1.08253 1.5
-      vertex 0.386271 -1.18882 1.45588e-16
-      vertex 0.625 -1.08253 1.32572e-16
+      vertex 58.5 6.5 4.5
+      vertex 62 6.5 3.3
+      vertex 58.5 6.5 3.3
     endloop
   endfacet
-  facet normal -0.866025 -0.500001 0
+  facet normal 0 -1 0
     outer loop
-      vertex -1.01127 -0.734731 8.99786e-17
-      vertex -1.14193 -0.50842 1.5
-      vertex -1.14193 -0.50842 6.22635e-17
+      vertex 51.45 0.5 0
+      vertex 30.5 0.5 2
+      vertex 4.85 0.5 0
     endloop
   endfacet
-  facet normal -0.866025 -0.500001 0
+  facet normal 0 -1 0
     outer loop
-      vertex -1.14193 -0.50842 1.5
-      vertex -1.01127 -0.734731 8.99786e-17
-      vertex -1.01127 -0.734731 1.5
+      vertex 30.5 0.5 2
+      vertex 51.45 0.5 0
+      vertex 51.45 0.5 1.8
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 0
+  facet normal 0 -1 0
     outer loop
-      vertex -0.836412 -0.92893 1.13761e-16
-      vertex -1.01127 -0.734731 1.5
-      vertex -1.01127 -0.734731 8.99786e-17
+      vertex 4.85 0.5 1.8
+      vertex 7.5 0.5 4.5
+      vertex 3.5 0.5 4.5
     endloop
   endfacet
-  facet normal -0.743145 -0.669131 0
+  facet normal 0 -1 0
     outer loop
-      vertex -1.01127 -0.734731 1.5
-      vertex -0.836412 -0.92893 1.13761e-16
-      vertex -0.836412 -0.92893 1.5
+      vertex 4.85 0.5 0
+      vertex 7.5 0.5 2
+      vertex 4.85 0.5 1.8
     endloop
   endfacet
-  facet normal -0.951057 -0.309017 0
+  facet normal 0 -1 0
     outer loop
-      vertex -1.14193 -0.50842 6.22635e-17
-      vertex -1.22268 -0.25989 1.5
-      vertex -1.22268 -0.25989 3.18273e-17
+      vertex 4.85 0.5 1.8
+      vertex 3.5 0.5 4.5
+      vertex 3.5 0.5 1.8
     endloop
   endfacet
-  facet normal -0.951057 -0.309017 0
+  facet normal 0 -1 -0
     outer loop
-      vertex -1.22268 -0.25989 1.5
-      vertex -1.14193 -0.50842 6.22635e-17
-      vertex -1.14193 -0.50842 1.5
+      vertex 7.5 0.5 4.5
+      vertex 4.85 0.5 1.8
+      vertex 7.5 0.5 2
     endloop
   endfacet
-  facet normal -0.406737 -0.913545 0
+  facet normal 0 -1 -0
     outer loop
-      vertex -0.624999 -1.08253 1.5
-      vertex -0.386271 -1.18882 1.45588e-16
-      vertex -0.386271 -1.18882 1.5
+      vertex 7.5 0.5 2
+      vertex 4.85 0.5 0
+      vertex 30.5 0.5 2
     endloop
   endfacet
-  facet normal -0.406737 -0.913545 0
+  facet normal 0 -1 0
     outer loop
-      vertex -0.386271 -1.18882 1.45588e-16
-      vertex -0.624999 -1.08253 1.5
-      vertex -0.624999 -1.08253 1.32572e-16
+      vertex 30.5 0.5 2
+      vertex 51.45 0.5 1.8
+      vertex 61.5 0.5 2
     endloop
   endfacet
-  facet normal 0.994522 0.104531 0
+  facet normal 0 -1 0
     outer loop
-      vertex 1.25 1.83697e-16 1.5
-      vertex 1.22268 0.25989 -3.18273e-17
-      vertex 1.22268 0.25989 1.5
+      vertex 56.49 0.5 1.8
+      vertex 61.5 0.5 2
+      vertex 51.45 0.5 1.8
     endloop
   endfacet
-  facet normal 0.994522 0.104531 -1.10638e-17
+  facet normal 0 -1 0
     outer loop
-      vertex 1.22268 0.25989 -3.18273e-17
-      vertex 1.25 1.83697e-16 1.5
-      vertex 1.25 0 0
+      vertex 61.5 0.5 0
+      vertex 56.49 0.5 1.8
+      vertex 56.49 0.5 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 56.49 0.5 1.8
+      vertex 61.5 0.5 0
+      vertex 61.5 0.5 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 61.5 0.5 2
+      vertex 30.5 0.5 4.5
+      vertex 30.5 0.5 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 30.5 0.5 4.5
+      vertex 61.5 0.5 2
+      vertex 62 0.5 4.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 62 0.5 4.5
+      vertex 61.5 0.5 2
+      vertex 62 0.5 2
+    endloop
+  endfacet
+  facet normal 0.634403 0.773003 -0
+    outer loop
+      vertex 63.6213 5.62132 3.3
+      vertex 63.1667 5.99441 4.5
+      vertex 63.6213 5.62132 4.5
+    endloop
+  endfacet
+  facet normal 0.634403 0.773003 0
+    outer loop
+      vertex 63.1667 5.99441 4.5
+      vertex 63.6213 5.62132 3.3
+      vertex 63.1667 5.99441 3.3
+    endloop
+  endfacet
+  facet normal 0.881942 0.471358 0
+    outer loop
+      vertex 64.2716 4.64805 4.5
+      vertex 63.9944 5.16671 3.3
+      vertex 63.9944 5.16671 4.5
+    endloop
+  endfacet
+  facet normal 0.881942 0.471358 0
+    outer loop
+      vertex 63.9944 5.16671 3.3
+      vertex 64.2716 4.64805 4.5
+      vertex 64.2716 4.64805 3.3
+    endloop
+  endfacet
+  facet normal 0.332372 0.943148 -0
+    outer loop
+      vertex 62.648 6.27164 3.3
+      vertex 62 6.5 4.5
+      vertex 62.648 6.27164 4.5
+    endloop
+  endfacet
+  facet normal 0.332372 0.943148 0
+    outer loop
+      vertex 62 6.5 4.5
+      vertex 62.648 6.27164 3.3
+      vertex 62 6.5 3.3
+    endloop
+  endfacet
+  facet normal 0.471369 0.881936 -0
+    outer loop
+      vertex 63.1667 5.99441 3.3
+      vertex 62.648 6.27164 4.5
+      vertex 63.1667 5.99441 4.5
+    endloop
+  endfacet
+  facet normal 0.471369 0.881936 0
+    outer loop
+      vertex 62.648 6.27164 4.5
+      vertex 63.1667 5.99441 3.3
+      vertex 62.648 6.27164 3.3
+    endloop
+  endfacet
+  facet normal -0.290279 0.956942 0
+    outer loop
+      vertex 30.2074 6.47118 2
+      vertex 29.926 6.38582 4.5
+      vertex 30.2074 6.47118 4.5
+    endloop
+  endfacet
+  facet normal -0.290279 0.956942 0
+    outer loop
+      vertex 29.926 6.38582 4.5
+      vertex 30.2074 6.47118 2
+      vertex 29.926 6.38582 2
+    endloop
+  endfacet
+  facet normal -0.881942 -0.471358 0
+    outer loop
+      vertex 29.2528 1.16664 2
+      vertex 29.1142 1.42597 4.5
+      vertex 29.1142 1.42597 2
+    endloop
+  endfacet
+  facet normal -0.881942 -0.471358 0
+    outer loop
+      vertex 29.1142 1.42597 4.5
+      vertex 29.2528 1.16664 2
+      vertex 29.2528 1.16664 4.5
+    endloop
+  endfacet
+  facet normal -0.290276 -0.956943 0
+    outer loop
+      vertex 29.926 0.614181 2
+      vertex 30.2074 0.528822 4.5
+      vertex 29.926 0.614181 4.5
+    endloop
+  endfacet
+  facet normal -0.290276 -0.956943 -0
+    outer loop
+      vertex 30.2074 0.528822 4.5
+      vertex 29.926 0.614181 2
+      vertex 30.2074 0.528822 2
+    endloop
+  endfacet
+  facet normal 0.956901 -0.290413 0
+    outer loop
+      vertex 64.2716 2.35195 4.5
+      vertex 64.4424 2.91473 0
+      vertex 64.4424 2.91473 4.5
+    endloop
+  endfacet
+  facet normal 0.956901 -0.290413 0
+    outer loop
+      vertex 64.4424 2.91473 0
+      vertex 64.2716 2.35195 4.5
+      vertex 64.2716 2.35195 0
+    endloop
+  endfacet
+  facet normal 0.995192 0.0979429 0
+    outer loop
+      vertex 64.5 3.5 4.5
+      vertex 64.4424 4.08527 3.3
+      vertex 64.4424 4.08527 4.5
+    endloop
+  endfacet
+  facet normal 0.995192 0.0979429 0
+    outer loop
+      vertex 64.4424 4.08527 3.3
+      vertex 64.5 3.5 4.5
+      vertex 64.5 3.5 3.3
+    endloop
+  endfacet
+  facet normal -0.634393 0.773011 0
+    outer loop
+      vertex 29.6666 6.2472 2
+      vertex 29.4393 6.06066 4.5
+      vertex 29.6666 6.2472 4.5
+    endloop
+  endfacet
+  facet normal -0.634393 0.773011 0
+    outer loop
+      vertex 29.4393 6.06066 4.5
+      vertex 29.6666 6.2472 2
+      vertex 29.4393 6.06066 2
+    endloop
+  endfacet
+  facet normal -0.471312 0.881967 0
+    outer loop
+      vertex 29.926 6.38582 2
+      vertex 29.6666 6.2472 4.5
+      vertex 29.926 6.38582 4.5
+    endloop
+  endfacet
+  facet normal -0.471312 0.881967 0
+    outer loop
+      vertex 29.6666 6.2472 4.5
+      vertex 29.926 6.38582 2
+      vertex 29.6666 6.2472 2
+    endloop
+  endfacet
+  facet normal -0.995192 -0.0979413 0
+    outer loop
+      vertex 29.0288 1.70736 2
+      vertex 29 2 4.5
+      vertex 29 2 2
+    endloop
+  endfacet
+  facet normal -0.995192 -0.0979413 0
+    outer loop
+      vertex 29 2 4.5
+      vertex 29.0288 1.70736 2
+      vertex 29.0288 1.70736 4.5
+    endloop
+  endfacet
+  facet normal -0.881942 0.471358 0
+    outer loop
+      vertex 29.1142 5.57402 2
+      vertex 29.2528 5.83335 4.5
+      vertex 29.2528 5.83335 2
+    endloop
+  endfacet
+  facet normal -0.881942 0.471358 0
+    outer loop
+      vertex 29.2528 5.83335 4.5
+      vertex 29.1142 5.57402 2
+      vertex 29.1142 5.57402 4.5
+    endloop
+  endfacet
+  facet normal -0.634403 -0.773003 0
+    outer loop
+      vertex 29.4393 0.93934 2
+      vertex 29.6666 0.752795 4.5
+      vertex 29.4393 0.93934 4.5
+    endloop
+  endfacet
+  facet normal -0.634403 -0.773003 -0
+    outer loop
+      vertex 29.6666 0.752795 4.5
+      vertex 29.4393 0.93934 2
+      vertex 29.6666 0.752795 2
+    endloop
+  endfacet
+  facet normal -0.773078 -0.634311 0
+    outer loop
+      vertex 29.4393 0.93934 2
+      vertex 29.2528 1.16664 4.5
+      vertex 29.2528 1.16664 2
+    endloop
+  endfacet
+  facet normal -0.773078 -0.634311 0
+    outer loop
+      vertex 29.2528 1.16664 4.5
+      vertex 29.4393 0.93934 2
+      vertex 29.4393 0.93934 4.5
+    endloop
+  endfacet
+  facet normal -0.956901 -0.290413 0
+    outer loop
+      vertex 29.1142 1.42597 2
+      vertex 29.0288 1.70736 4.5
+      vertex 29.0288 1.70736 2
+    endloop
+  endfacet
+  facet normal -0.956901 -0.290413 0
+    outer loop
+      vertex 29.0288 1.70736 4.5
+      vertex 29.1142 1.42597 2
+      vertex 29.1142 1.42597 4.5
+    endloop
+  endfacet
+  facet normal -0.995192 0.0979446 0
+    outer loop
+      vertex 29 5 2
+      vertex 29.0288 5.29263 4.5
+      vertex 29.0288 5.29263 2
+    endloop
+  endfacet
+  facet normal -0.995192 0.0979446 0
+    outer loop
+      vertex 29.0288 5.29263 4.5
+      vertex 29 5 2
+      vertex 29 5 4.5
+    endloop
+  endfacet
+  facet normal -0.0980219 0.995184 0
+    outer loop
+      vertex 30.5 6.5 2
+      vertex 30.2074 6.47118 4.5
+      vertex 30.5 6.5 4.5
+    endloop
+  endfacet
+  facet normal -0.0980219 0.995184 0
+    outer loop
+      vertex 30.2074 6.47118 4.5
+      vertex 30.5 6.5 2
+      vertex 30.2074 6.47118 2
+    endloop
+  endfacet
+  facet normal 0.332374 -0.943148 0
+    outer loop
+      vertex 62 0.5 2
+      vertex 62.648 0.728361 4.5
+      vertex 62 0.5 4.5
+    endloop
+  endfacet
+  facet normal 0.332374 -0.943148 0
+    outer loop
+      vertex 62.648 0.728361 4.5
+      vertex 62 0.5 2
+      vertex 62.648 0.728361 2
+    endloop
+  endfacet
+  facet normal 0.773001 0.634405 0
+    outer loop
+      vertex 63.9944 5.16671 4.5
+      vertex 63.6213 5.62132 3.3
+      vertex 63.6213 5.62132 4.5
+    endloop
+  endfacet
+  facet normal 0.773001 0.634405 0
+    outer loop
+      vertex 63.6213 5.62132 3.3
+      vertex 63.9944 5.16671 4.5
+      vertex 63.9944 5.16671 3.3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 29 2 2
+      vertex 29 5 4.5
+      vertex 29 5 2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 29 5 4.5
+      vertex 29 2 2
+      vertex 29 2 4.5
+    endloop
+  endfacet
+  facet normal -0.0980286 -0.995184 0
+    outer loop
+      vertex 30.2074 0.528822 2
+      vertex 30.5 0.5 4.5
+      vertex 30.2074 0.528822 4.5
+    endloop
+  endfacet
+  facet normal -0.0980286 -0.995184 -0
+    outer loop
+      vertex 30.5 0.5 4.5
+      vertex 30.2074 0.528822 2
+      vertex 30.5 0.5 2
+    endloop
+  endfacet
+  facet normal 0.773001 -0.634405 0
+    outer loop
+      vertex 63.6213 1.37868 4.5
+      vertex 63.9944 1.83329 0
+      vertex 63.9944 1.83329 4.5
+    endloop
+  endfacet
+  facet normal 0.773001 -0.634405 0
+    outer loop
+      vertex 63.9944 1.83329 0
+      vertex 63.6213 1.37868 4.5
+      vertex 63.6213 1.37868 0
+    endloop
+  endfacet
+  facet normal 0.634403 -0.773003 0
+    outer loop
+      vertex 63.1667 1.00559 0
+      vertex 63.6213 1.37868 4.5
+      vertex 63.1667 1.00559 4.5
+    endloop
+  endfacet
+  facet normal 0.634403 -0.773003 0
+    outer loop
+      vertex 63.6213 1.37868 4.5
+      vertex 63.1667 1.00559 0
+      vertex 63.6213 1.37868 0
+    endloop
+  endfacet
+  facet normal 0.995192 -0.0979429 0
+    outer loop
+      vertex 64.4424 2.91473 4.5
+      vertex 64.5 3.5 3.3
+      vertex 64.5 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0.995192 -0.0979429 0
+    outer loop
+      vertex 64.4424 2.91473 0
+      vertex 64.5 3.5 3.3
+      vertex 64.4424 2.91473 4.5
+    endloop
+  endfacet
+  facet normal 0.995192 -0.0979429 0
+    outer loop
+      vertex 64.5 3.5 3.3
+      vertex 64.4424 2.91473 0
+      vertex 64.5 3.5 0
+    endloop
+  endfacet
+  facet normal 0.956901 0.290413 0
+    outer loop
+      vertex 64.4424 4.08527 4.5
+      vertex 64.2716 4.64805 3.3
+      vertex 64.2716 4.64805 4.5
+    endloop
+  endfacet
+  facet normal 0.956901 0.290413 0
+    outer loop
+      vertex 64.2716 4.64805 3.3
+      vertex 64.4424 4.08527 4.5
+      vertex 64.4424 4.08527 3.3
+    endloop
+  endfacet
+  facet normal 0.471368 -0.881937 0
+    outer loop
+      vertex 62.648 0.728361 2
+      vertex 63.1667 1.00559 4.5
+      vertex 62.648 0.728361 4.5
+    endloop
+  endfacet
+  facet normal 0.471368 -0.881937 0
+    outer loop
+      vertex 63.1667 1.00559 0
+      vertex 62.648 0.728361 2
+      vertex 62.648 0.728361 0
+    endloop
+  endfacet
+  facet normal 0.471368 -0.881937 0
+    outer loop
+      vertex 62.648 0.728361 2
+      vertex 63.1667 1.00559 0
+      vertex 63.1667 1.00559 4.5
+    endloop
+  endfacet
+  facet normal 0.881942 -0.471358 0
+    outer loop
+      vertex 63.9944 1.83329 4.5
+      vertex 64.2716 2.35195 0
+      vertex 64.2716 2.35195 4.5
+    endloop
+  endfacet
+  facet normal 0.881942 -0.471358 0
+    outer loop
+      vertex 64.2716 2.35195 0
+      vertex 63.9944 1.83329 4.5
+      vertex 63.9944 1.83329 0
+    endloop
+  endfacet
+  facet normal -0.471296 -0.881975 0
+    outer loop
+      vertex 29.6666 0.752795 2
+      vertex 29.926 0.614181 4.5
+      vertex 29.6666 0.752795 4.5
+    endloop
+  endfacet
+  facet normal -0.471296 -0.881975 -0
+    outer loop
+      vertex 29.926 0.614181 4.5
+      vertex 29.6666 0.752795 2
+      vertex 29.926 0.614181 2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62 0.5 2
+      vertex 62.0853 0.557644 2
+      vertex 62.648 0.728361 2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 62.0853 0.557644 2
+      vertex 62 0.5 2
+      vertex 61.5 0.5 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.22268 0.25989 1.5
-      vertex 1.22268 -0.25989 1.5
-      vertex 1.25 1.83697e-16 1.5
+      vertex 25.5 29 2
+      vertex 18.5 29.5 2
+      vertex 25.5 24 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.14193 0.50842 1.5
-      vertex 1.22268 -0.25989 1.5
-      vertex 1.22268 0.25989 1.5
+      vertex 25.5096 29.0975 2
+      vertex 18.5 29.5 2
+      vertex 25.5 29 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.14193 0.50842 1.5
-      vertex 1.14193 -0.50842 1.5
-      vertex 1.22268 -0.25989 1.5
+      vertex 25.5381 29.1913 2
+      vertex 18.5 29.5 2
+      vertex 25.5096 29.0975 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.01127 0.734731 1.5
-      vertex 1.14193 -0.50842 1.5
-      vertex 1.14193 0.50842 1.5
+      vertex 25.5843 29.2778 2
+      vertex 18.5 29.5 2
+      vertex 25.5381 29.1913 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.01127 0.734731 1.5
-      vertex 1.01127 -0.734731 1.5
-      vertex 1.14193 -0.50842 1.5
+      vertex 25.6464 29.3536 2
+      vertex 18.5 29.5 2
+      vertex 25.5843 29.2778 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.836412 0.92893 1.5
-      vertex 1.01127 -0.734731 1.5
-      vertex 1.01127 0.734731 1.5
+      vertex 25.7222 29.4157 2
+      vertex 18.5 29.5 2
+      vertex 25.6464 29.3536 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.836412 0.92893 1.5
-      vertex 0.836412 -0.92893 1.5
-      vertex 1.01127 -0.734731 1.5
+      vertex 25.8087 29.4619 2
+      vertex 18.5 29.5 2
+      vertex 25.7222 29.4157 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.625 1.08253 1.5
-      vertex 0.836412 -0.92893 1.5
-      vertex 0.836412 0.92893 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.625 1.08253 1.5
-      vertex 0.625 -1.08253 1.5
-      vertex 0.836412 -0.92893 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.386271 1.18882 1.5
-      vertex 0.625 -1.08253 1.5
-      vertex 0.625 1.08253 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.386271 1.18882 1.5
-      vertex 0.386271 -1.18882 1.5
-      vertex 0.625 -1.08253 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.13066 1.24315 1.5
-      vertex 0.386271 -1.18882 1.5
-      vertex 0.386271 1.18882 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.13066 1.24315 1.5
-      vertex 0.13066 -1.24315 1.5
-      vertex 0.386271 -1.18882 1.5
+      vertex 25.9025 29.4904 2
+      vertex 18.5 29.5 2
+      vertex 25.8087 29.4619 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -0.13066 1.24315 1.5
-      vertex 0.13066 -1.24315 1.5
-      vertex 0.13066 1.24315 1.5
+      vertex 18.5 29.5 2
+      vertex 25.9025 29.4904 2
+      vertex 26 29.5 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.13066 1.24315 1.5
-      vertex -0.13066 -1.24315 1.5
-      vertex 0.13066 -1.24315 1.5
+      vertex 18.5 23.5 2
+      vertex 25.5 24 2
+      vertex 18.5 29.5 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2
+      vertex 18.5 23.5 2
+      vertex 25.5096 23.9025 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5096 23.9025 2
+      vertex 18.5 23.5 2
+      vertex 25.5381 23.8087 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5381 23.8087 2
+      vertex 18.5 23.5 2
+      vertex 25.5843 23.7222 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5843 23.7222 2
+      vertex 18.5 23.5 2
+      vertex 25.6464 23.6464 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9025 23.5096 2
+      vertex 18.5 23.5 2
+      vertex 26 23.5 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8087 23.5381 2
+      vertex 18.5 23.5 2
+      vertex 25.9025 23.5096 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7222 23.5843 2
+      vertex 18.5 23.5 2
+      vertex 25.8087 23.5381 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.6464 23.6464 2
+      vertex 18.5 23.5 2
+      vertex 25.7222 23.5843 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8152 4.32554 2
+      vertex 29 5 2
+      vertex 26.8891 4.46385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 2 2
+      vertex 26.9346 2.38607 2
+      vertex 26.95 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 2
+      vertex 26.8152 4.32554 2
+      vertex 29 2 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 2 2
+      vertex 26.8891 2.53615 2
+      vertex 26.9346 2.38607 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -0.386271 1.18882 1.5
-      vertex -0.13066 -1.24315 1.5
-      vertex -0.13066 1.24315 1.5
+      vertex 26.8152 2.67446 2
+      vertex 29 2 2
+      vertex 26.8152 4.32554 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.386271 1.18882 1.5
-      vertex -0.386271 -1.18882 1.5
-      vertex -0.13066 -1.24315 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.386271 1.18882 1.5
-      vertex -0.624999 -1.08253 1.5
-      vertex -0.386271 -1.18882 1.5
+      vertex 29 2 2
+      vertex 26.8152 2.67446 2
+      vertex 26.8891 2.53615 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -0.625 1.08253 1.5
-      vertex -0.624999 -1.08253 1.5
-      vertex -0.386271 1.18882 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.836412 0.92893 1.5
-      vertex -0.624999 -1.08253 1.5
-      vertex -0.625 1.08253 1.5
+      vertex 26.7157 4.20431 2
+      vertex 26.8152 2.67446 2
+      vertex 26.8152 4.32554 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.836412 0.92893 1.5
-      vertex -0.836412 -0.92893 1.5
-      vertex -0.624999 -1.08253 1.5
+      vertex 26.7157 4.20431 2
+      vertex 26.7157 2.79569 2
+      vertex 26.8152 2.67446 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -1.01127 0.734731 1.5
-      vertex -0.836412 -0.92893 1.5
-      vertex -0.836412 0.92893 1.5
+      vertex 26.5945 4.10482 2
+      vertex 26.7157 2.79569 2
+      vertex 26.7157 4.20431 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.01127 0.734731 1.5
-      vertex -1.01127 -0.734731 1.5
-      vertex -0.836412 -0.92893 1.5
+      vertex 26.5945 4.10482 2
+      vertex 26.5945 2.89518 2
+      vertex 26.7157 2.79569 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -1.14193 0.50842 1.5
-      vertex -1.01127 -0.734731 1.5
-      vertex -1.01127 0.734731 1.5
+      vertex 26.4561 4.0309 2
+      vertex 26.5945 2.89518 2
+      vertex 26.5945 4.10482 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.14193 0.50842 1.5
-      vertex -1.14193 -0.50842 1.5
-      vertex -1.01127 -0.734731 1.5
+      vertex 26.4561 4.0309 2
+      vertex 26.4561 2.9691 2
+      vertex 26.5945 2.89518 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -1.22268 0.25989 1.5
-      vertex -1.14193 -0.50842 1.5
-      vertex -1.14193 0.50842 1.5
+      vertex 26.3061 3.98537 2
+      vertex 26.4561 2.9691 2
+      vertex 26.4561 4.0309 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.22268 0.25989 1.5
-      vertex -1.22268 -0.25989 1.5
-      vertex -1.14193 -0.50842 1.5
+      vertex 26.3061 3.98537 2
+      vertex 26.3061 3.01463 2
+      vertex 26.4561 2.9691 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.15 3.97 2
+      vertex 26.3061 3.01463 2
+      vertex 26.3061 3.98537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.15 3.97 2
+      vertex 26.15 3.03 2
+      vertex 26.3061 3.01463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9939 3.98537 2
+      vertex 26.15 3.03 2
+      vertex 26.15 3.97 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9939 3.98537 2
+      vertex 25.9939 3.01463 2
+      vertex 26.15 3.03 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8439 4.0309 2
+      vertex 25.9939 3.01463 2
+      vertex 25.9939 3.98537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8439 4.0309 2
+      vertex 25.8439 2.9691 2
+      vertex 25.9939 3.01463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7055 4.10482 2
+      vertex 25.8439 2.9691 2
+      vertex 25.8439 4.0309 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7055 4.10482 2
+      vertex 25.7055 2.89518 2
+      vertex 25.8439 2.9691 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5843 4.20431 2
+      vertex 25.7055 2.89518 2
+      vertex 25.7055 4.10482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5843 4.20431 2
+      vertex 25.5843 2.79569 2
+      vertex 25.7055 2.89518 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4848 4.32554 2
+      vertex 25.5843 2.79569 2
+      vertex 25.5843 4.20431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4848 4.32554 2
+      vertex 25.4848 2.67446 2
+      vertex 25.5843 2.79569 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4109 4.46385 2
+      vertex 25.4848 2.67446 2
+      vertex 25.4848 4.32554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4109 4.46385 2
+      vertex 25.4109 2.53615 2
+      vertex 25.4848 2.67446 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.2691 2.53615 2
+      vertex 25.4109 4.46385 2
+      vertex 25.3654 4.61393 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4109 4.46385 2
+      vertex 19.2691 2.53615 2
+      vertex 25.4109 2.53615 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.1952 2.67446 2
+      vertex 25.3654 4.61393 2
+      vertex 25.35 4.77 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4109 2.53615 2
+      vertex 19.2691 2.53615 2
+      vertex 25.3654 2.38607 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9346 4.61393 2
+      vertex 29 5 2
+      vertex 26.95 4.77 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.9346 4.92607 2
+      vertex 29 5 2
+      vertex 29.0288 5.29263 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.8152 5.21446 2
+      vertex 29.0288 5.29263 2
+      vertex 29.1142 5.57402 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.7157 5.33569 2
+      vertex 29.1142 5.57402 2
+      vertex 29.2528 5.83335 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.5945 5.43518 2
+      vertex 29.2528 5.83335 2
+      vertex 29.4393 6.06066 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.4561 5.5091 2
+      vertex 29.4393 6.06066 2
+      vertex 29.6666 6.2472 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 2
+      vertex 26.9346 4.92607 2
+      vertex 26.95 4.77 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26.15 5.57 2
+      vertex 29.6666 6.2472 2
+      vertex 29.926 6.38582 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.0288 5.29263 2
+      vertex 26.8891 5.07615 2
+      vertex 26.9346 4.92607 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.0288 5.29263 2
+      vertex 26.8152 5.21446 2
+      vertex 26.8891 5.07615 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.1142 5.57402 2
+      vertex 26.7157 5.33569 2
+      vertex 26.8152 5.21446 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.2528 5.83335 2
+      vertex 26.5945 5.43518 2
+      vertex 26.7157 5.33569 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9939 5.55463 2
+      vertex 29.926 6.38582 2
+      vertex 30.2074 6.47118 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.4393 6.06066 2
+      vertex 26.4561 5.5091 2
+      vertex 26.5945 5.43518 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.6666 6.2472 2
+      vertex 26.3061 5.55463 2
+      vertex 26.4561 5.5091 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.6666 6.2472 2
+      vertex 26.15 5.57 2
+      vertex 26.3061 5.55463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.926 6.38582 2
+      vertex 25.9939 5.55463 2
+      vertex 26.15 5.57 2
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex -1.22268 -0.25989 1.5
-      vertex -1.22268 0.25989 1.5
-      vertex -1.25 1.83697e-16 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 1.14193 0.50842 1.5
-      vertex 1.01127 0.734731 -8.99786e-17
-      vertex 1.01127 0.734731 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 1.01127 0.734731 -8.99786e-17
-      vertex 1.14193 0.50842 1.5
-      vertex 1.14193 0.50842 -6.22635e-17
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex -1.14193 0.50842 -6.22635e-17
-      vertex -1.01127 0.734731 1.5
-      vertex -1.01127 0.734731 -8.99786e-17
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex -1.01127 0.734731 1.5
-      vertex -1.14193 0.50842 -6.22635e-17
-      vertex -1.14193 0.50842 1.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.669131 0
-    outer loop
-      vertex -1.01127 0.734731 -8.99786e-17
-      vertex -0.836412 0.92893 1.5
-      vertex -0.836412 0.92893 -1.13761e-16
-    endloop
-  endfacet
-  facet normal -0.743145 0.669131 0
-    outer loop
-      vertex -0.836412 0.92893 1.5
-      vertex -1.01127 0.734731 -8.99786e-17
-      vertex -1.01127 0.734731 1.5
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 -0
-    outer loop
-      vertex 0.836412 0.92893 -1.13761e-16
-      vertex 0.625 1.08253 1.5
-      vertex 0.836412 0.92893 1.5
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 0
-    outer loop
-      vertex 0.625 1.08253 1.5
-      vertex 0.836412 0.92893 -1.13761e-16
-      vertex 0.625 1.08253 -1.32572e-16
-    endloop
-  endfacet
-  facet normal -0.207912 0.978148 0
-    outer loop
-      vertex -0.13066 1.24315 1.5
-      vertex -0.386271 1.18882 -1.45588e-16
-      vertex -0.386271 1.18882 1.5
-    endloop
-  endfacet
-  facet normal -0.207912 0.978148 0
-    outer loop
-      vertex -0.386271 1.18882 -1.45588e-16
-      vertex -0.13066 1.24315 1.5
-      vertex -0.13066 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal -0.951057 0.309017 0
-    outer loop
-      vertex -1.22268 0.25989 -3.18273e-17
-      vertex -1.14193 0.50842 1.5
-      vertex -1.14193 0.50842 -6.22635e-17
-    endloop
-  endfacet
-  facet normal -0.951057 0.309017 0
-    outer loop
-      vertex -1.14193 0.50842 1.5
-      vertex -1.22268 0.25989 -3.18273e-17
-      vertex -1.22268 0.25989 1.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104531 0
-    outer loop
-      vertex -1.22268 0.25989 -3.18273e-17
-      vertex -1.25 1.83697e-16 1.5
-      vertex -1.22268 0.25989 1.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104531 -1.28013e-17
-    outer loop
-      vertex -1.25 1.83697e-16 1.5
-      vertex -1.22268 0.25989 -3.18273e-17
-      vertex -1.25 0 0
-    endloop
-  endfacet
-  facet normal 0.406736 0.913546 -0
-    outer loop
-      vertex 0.625 1.08253 -1.32572e-16
-      vertex 0.386271 1.18882 1.5
-      vertex 0.625 1.08253 1.5
-    endloop
-  endfacet
-  facet normal 0.406736 0.913546 0
-    outer loop
-      vertex 0.386271 1.18882 1.5
-      vertex 0.625 1.08253 -1.32572e-16
-      vertex 0.386271 1.18882 -1.45588e-16
-    endloop
-  endfacet
-  facet normal 0.207912 0.978148 -0
-    outer loop
-      vertex 0.386271 1.18882 -1.45588e-16
-      vertex 0.13066 1.24315 1.5
-      vertex 0.386271 1.18882 1.5
-    endloop
-  endfacet
-  facet normal 0.207912 0.978148 0
-    outer loop
-      vertex 0.13066 1.24315 1.5
-      vertex 0.386271 1.18882 -1.45588e-16
-      vertex 0.13066 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal 0.743145 0.669131 0
-    outer loop
-      vertex 1.01127 0.734731 1.5
-      vertex 0.836412 0.92893 -1.13761e-16
-      vertex 0.836412 0.92893 1.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.669131 0
-    outer loop
-      vertex 0.836412 0.92893 -1.13761e-16
-      vertex 1.01127 0.734731 1.5
-      vertex 1.01127 0.734731 -8.99786e-17
-    endloop
-  endfacet
-  facet normal -0.406736 0.913546 0
-    outer loop
-      vertex -0.386271 1.18882 1.5
-      vertex -0.625 1.08253 -1.32572e-16
-      vertex -0.625 1.08253 1.5
-    endloop
-  endfacet
-  facet normal -0.406736 0.913546 0
-    outer loop
-      vertex -0.625 1.08253 -1.32572e-16
-      vertex -0.386271 1.18882 1.5
-      vertex -0.386271 1.18882 -1.45588e-16
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex -0.625 1.08253 1.5
-      vertex -0.836412 0.92893 -1.13761e-16
-      vertex -0.836412 0.92893 1.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex -0.836412 0.92893 -1.13761e-16
-      vertex -0.625 1.08253 1.5
-      vertex -0.625 1.08253 -1.32572e-16
+      vertex 19.3146 2.38607 2
+      vertex 25.3654 2.38607 2
+      vertex 19.2691 2.53615 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 59.2227 0.25989 1.5
-      vertex 59.2227 -0.25989 1.5
-      vertex 59.25 1.83697e-16 1.5
+      vertex 19.0957 2.79569 2
+      vertex 25.35 4.77 2
+      vertex 25.3654 4.92607 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 59.1419 0.50842 1.5
-      vertex 59.2227 -0.25989 1.5
-      vertex 59.2227 0.25989 1.5
+      vertex 18.9745 2.89518 2
+      vertex 25.3654 4.92607 2
+      vertex 25.4109 5.07615 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 59.1419 0.50842 1.5
-      vertex 59.1419 -0.50842 1.5
-      vertex 59.2227 -0.25989 1.5
+      vertex 18.8361 2.9691 2
+      vertex 25.4109 5.07615 2
+      vertex 25.4848 5.21446 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 59.0113 0.734731 1.5
-      vertex 59.1419 -0.50842 1.5
-      vertex 59.1419 0.50842 1.5
+      vertex 18.6861 3.01463 2
+      vertex 25.4848 5.21446 2
+      vertex 25.5843 5.33569 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 59.0113 0.734731 1.5
-      vertex 59.0113 -0.734731 1.5
-      vertex 59.1419 -0.50842 1.5
+      vertex 18.53 3.03 2
+      vertex 25.5843 5.33569 2
+      vertex 25.7055 5.43518 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58.8364 0.92893 1.5
-      vertex 59.0113 -0.734731 1.5
-      vertex 59.0113 0.734731 1.5
+      vertex 8.33335 6.2472 2
+      vertex 25.7055 5.43518 2
+      vertex 25.8439 5.5091 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58.8364 0.92893 1.5
-      vertex 58.8364 -0.92893 1.5
-      vertex 59.0113 -0.734731 1.5
+      vertex 25.35 2.23 2
+      vertex 19.3146 2.38607 2
+      vertex 19.33 2.23 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58.625 1.08253 1.5
-      vertex 58.8364 -0.92893 1.5
-      vertex 58.8364 0.92893 1.5
+      vertex 25.3654 2.38607 2
+      vertex 19.3146 2.38607 2
+      vertex 25.35 2.23 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58.625 1.08253 1.5
-      vertex 58.625 -1.08253 1.5
-      vertex 58.8364 -0.92893 1.5
+      vertex 25.3654 4.61393 2
+      vertex 19.1952 2.67446 2
+      vertex 19.2691 2.53615 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58.3863 1.18882 1.5
-      vertex 58.625 -1.08253 1.5
-      vertex 58.625 1.08253 1.5
+      vertex 25.35 4.77 2
+      vertex 19.0957 2.79569 2
+      vertex 19.1952 2.67446 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58.3863 1.18882 1.5
-      vertex 58.3863 -1.18882 1.5
-      vertex 58.625 -1.08253 1.5
+      vertex 25.3654 4.92607 2
+      vertex 18.9745 2.89518 2
+      vertex 19.0957 2.79569 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58.1307 1.24315 1.5
-      vertex 58.3863 -1.18882 1.5
-      vertex 58.3863 1.18882 1.5
+      vertex 25.4109 5.07615 2
+      vertex 18.8361 2.9691 2
+      vertex 18.9745 2.89518 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58.1307 1.24315 1.5
-      vertex 58.1307 -1.24315 1.5
-      vertex 58.3863 -1.18882 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 57.8693 1.24315 1.5
-      vertex 58.1307 -1.24315 1.5
-      vertex 58.1307 1.24315 1.5
+      vertex 25.4848 5.21446 2
+      vertex 18.6861 3.01463 2
+      vertex 18.8361 2.9691 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 57.8693 1.24315 1.5
-      vertex 57.8693 -1.24315 1.5
-      vertex 58.1307 -1.24315 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 57.6137 1.18882 1.5
-      vertex 57.8693 -1.24315 1.5
-      vertex 57.8693 1.24315 1.5
+      vertex 25.5843 5.33569 2
+      vertex 18.53 3.03 2
+      vertex 18.6861 3.01463 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 57.6137 1.18882 1.5
-      vertex 57.6137 -1.18882 1.5
-      vertex 57.8693 -1.24315 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 57.375 1.08253 1.5
-      vertex 57.6137 -1.18882 1.5
-      vertex 57.6137 1.18882 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 57.375 1.08253 1.5
-      vertex 57.375 -1.08253 1.5
-      vertex 57.6137 -1.18882 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 57.1636 0.92893 1.5
-      vertex 57.375 -1.08253 1.5
-      vertex 57.375 1.08253 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 57.1636 0.92893 1.5
-      vertex 57.1636 -0.92893 1.5
-      vertex 57.375 -1.08253 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 56.9887 0.734731 1.5
-      vertex 57.1636 -0.92893 1.5
-      vertex 57.1636 0.92893 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 56.9887 0.734731 1.5
-      vertex 56.9887 -0.734731 1.5
-      vertex 57.1636 -0.92893 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 56.8581 0.50842 1.5
-      vertex 56.9887 -0.734731 1.5
-      vertex 56.9887 0.734731 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 56.8581 0.50842 1.5
-      vertex 56.8581 -0.50842 1.5
-      vertex 56.9887 -0.734731 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 56.7773 0.25989 1.5
-      vertex 56.8581 -0.50842 1.5
-      vertex 56.8581 0.50842 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 56.7773 0.25989 1.5
-      vertex 56.7773 -0.25989 1.5
-      vertex 56.8581 -0.50842 1.5
+      vertex 25.7055 5.43518 2
+      vertex 8.33335 6.2472 2
+      vertex 18.53 3.03 2
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex 56.7773 -0.25989 1.5
-      vertex 56.7773 0.25989 1.5
-      vertex 56.75 1.83697e-16 1.5
-    endloop
-  endfacet
-  facet normal 0.406733 -0.913547 0
-    outer loop
-      vertex 58.3863 -1.18882 1.45588e-16
-      vertex 58.625 -1.08253 1.5
-      vertex 58.3863 -1.18882 1.5
-    endloop
-  endfacet
-  facet normal 0.406733 -0.913547 0
-    outer loop
-      vertex 58.625 -1.08253 1.5
-      vertex 58.3863 -1.18882 1.45588e-16
-      vertex 58.625 -1.08253 1.32572e-16
-    endloop
-  endfacet
-  facet normal -0.994523 -0.10452 1.10638e-17
-    outer loop
-      vertex 56.7773 -0.25989 3.18273e-17
-      vertex 56.75 1.83697e-16 1.5
-      vertex 56.75 0 0
-    endloop
-  endfacet
-  facet normal -0.994523 -0.10452 0
-    outer loop
-      vertex 56.75 1.83697e-16 1.5
-      vertex 56.7773 -0.25989 3.18273e-17
-      vertex 56.7773 -0.25989 1.5
-    endloop
-  endfacet
-  facet normal 0.994521 0.104534 0
-    outer loop
-      vertex 59.25 1.83697e-16 1.5
-      vertex 59.2227 0.25989 -3.18273e-17
-      vertex 59.2227 0.25989 1.5
-    endloop
-  endfacet
-  facet normal 0.994521 0.104534 -1.10638e-17
-    outer loop
-      vertex 59.2227 0.25989 -3.18273e-17
-      vertex 59.25 1.83697e-16 1.5
-      vertex 59.25 0 0
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex 57.8693 1.24315 1.5
-      vertex 57.6137 1.18882 -1.45588e-16
-      vertex 57.6137 1.18882 1.5
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex 57.6137 1.18882 -1.45588e-16
-      vertex 57.8693 1.24315 1.5
-      vertex 57.8693 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 57.8693 -1.24315 1.52242e-16
-      vertex 58.1307 -1.24315 1.5
-      vertex 57.8693 -1.24315 1.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 58.1307 -1.24315 1.5
-      vertex 57.8693 -1.24315 1.52242e-16
-      vertex 58.1307 -1.24315 1.52242e-16
-    endloop
-  endfacet
-  facet normal -0.406738 -0.913545 0
-    outer loop
-      vertex 57.375 -1.08253 1.5
-      vertex 57.6137 -1.18882 1.45588e-16
-      vertex 57.6137 -1.18882 1.5
-    endloop
-  endfacet
-  facet normal -0.406738 -0.913545 0
-    outer loop
-      vertex 57.6137 -1.18882 1.45588e-16
-      vertex 57.375 -1.08253 1.5
-      vertex 57.375 -1.08253 1.32572e-16
-    endloop
-  endfacet
-  facet normal -0.951055 -0.30902 0
-    outer loop
-      vertex 56.8581 -0.50842 6.22635e-17
-      vertex 56.7773 -0.25989 1.5
-      vertex 56.7773 -0.25989 3.18273e-17
-    endloop
-  endfacet
-  facet normal -0.951055 -0.30902 0
-    outer loop
-      vertex 56.7773 -0.25989 1.5
-      vertex 56.8581 -0.50842 6.22635e-17
-      vertex 56.8581 -0.50842 1.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.669131 0
-    outer loop
-      vertex 59.0113 0.734731 1.5
-      vertex 58.8364 0.92893 -1.13761e-16
-      vertex 58.8364 0.92893 1.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.669131 0
-    outer loop
-      vertex 58.8364 0.92893 -1.13761e-16
-      vertex 59.0113 0.734731 1.5
-      vertex 59.0113 0.734731 -8.99786e-17
-    endloop
-  endfacet
-  facet normal -0.951055 0.30902 0
-    outer loop
-      vertex 56.7773 0.25989 -3.18273e-17
-      vertex 56.8581 0.50842 1.5
-      vertex 56.8581 0.50842 -6.22635e-17
-    endloop
-  endfacet
-  facet normal -0.951055 0.30902 0
-    outer loop
-      vertex 56.8581 0.50842 1.5
-      vertex 56.7773 0.25989 -3.18273e-17
-      vertex 56.7773 0.25989 1.5
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex 56.8581 0.50842 -6.22635e-17
-      vertex 56.9887 0.734731 1.5
-      vertex 56.9887 0.734731 -8.99786e-17
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex 56.9887 0.734731 1.5
-      vertex 56.8581 0.50842 -6.22635e-17
-      vertex 56.8581 0.50842 1.5
-    endloop
-  endfacet
-  facet normal 0.951055 -0.30902 0
-    outer loop
-      vertex 59.1419 -0.50842 1.5
-      vertex 59.2227 -0.25989 3.18273e-17
-      vertex 59.2227 -0.25989 1.5
-    endloop
-  endfacet
-  facet normal 0.951055 -0.30902 0
-    outer loop
-      vertex 59.2227 -0.25989 3.18273e-17
-      vertex 59.1419 -0.50842 1.5
-      vertex 59.1419 -0.50842 6.22635e-17
-    endloop
-  endfacet
-  facet normal 0.866025 -0.500001 0
-    outer loop
-      vertex 59.0113 -0.734731 1.5
-      vertex 59.1419 -0.50842 6.22635e-17
-      vertex 59.1419 -0.50842 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 -0.500001 0
-    outer loop
-      vertex 59.1419 -0.50842 6.22635e-17
-      vertex 59.0113 -0.734731 1.5
-      vertex 59.0113 -0.734731 8.99786e-17
-    endloop
-  endfacet
-  facet normal 0.743145 -0.669131 0
-    outer loop
-      vertex 58.8364 -0.92893 1.5
-      vertex 59.0113 -0.734731 8.99786e-17
-      vertex 59.0113 -0.734731 1.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.669131 0
-    outer loop
-      vertex 59.0113 -0.734731 8.99786e-17
-      vertex 58.8364 -0.92893 1.5
-      vertex 58.8364 -0.92893 1.13761e-16
-    endloop
-  endfacet
-  facet normal 0.58779 -0.809013 0
-    outer loop
-      vertex 58.625 -1.08253 1.32572e-16
-      vertex 58.8364 -0.92893 1.5
-      vertex 58.625 -1.08253 1.5
-    endloop
-  endfacet
-  facet normal 0.58779 -0.809013 0
-    outer loop
-      vertex 58.8364 -0.92893 1.5
-      vertex 58.625 -1.08253 1.32572e-16
-      vertex 58.8364 -0.92893 1.13761e-16
-    endloop
-  endfacet
-  facet normal 0.207914 -0.978147 0
-    outer loop
-      vertex 58.1307 -1.24315 1.52242e-16
-      vertex 58.3863 -1.18882 1.5
-      vertex 58.1307 -1.24315 1.5
-    endloop
-  endfacet
-  facet normal 0.207914 -0.978147 0
-    outer loop
-      vertex 58.3863 -1.18882 1.5
-      vertex 58.1307 -1.24315 1.52242e-16
-      vertex 58.3863 -1.18882 1.45588e-16
-    endloop
-  endfacet
-  facet normal -0.994523 0.10452 0
-    outer loop
-      vertex 56.7773 0.25989 -3.18273e-17
-      vertex 56.75 1.83697e-16 1.5
-      vertex 56.7773 0.25989 1.5
-    endloop
-  endfacet
-  facet normal -0.994523 0.10452 -1.28e-17
-    outer loop
-      vertex 56.75 1.83697e-16 1.5
-      vertex 56.7773 0.25989 -3.18273e-17
-      vertex 56.75 0 0
-    endloop
-  endfacet
-  facet normal -0.866025 -0.500001 0
-    outer loop
-      vertex 56.9887 -0.734731 8.99786e-17
-      vertex 56.8581 -0.50842 1.5
-      vertex 56.8581 -0.50842 6.22635e-17
-    endloop
-  endfacet
-  facet normal -0.866025 -0.500001 0
-    outer loop
-      vertex 56.8581 -0.50842 1.5
-      vertex 56.9887 -0.734731 8.99786e-17
-      vertex 56.9887 -0.734731 1.5
-    endloop
-  endfacet
-  facet normal -0.587783 -0.809018 0
-    outer loop
-      vertex 57.1636 -0.92893 1.5
-      vertex 57.375 -1.08253 1.32572e-16
-      vertex 57.375 -1.08253 1.5
-    endloop
-  endfacet
-  facet normal -0.587783 -0.809018 0
-    outer loop
-      vertex 57.375 -1.08253 1.32572e-16
-      vertex 57.1636 -0.92893 1.5
-      vertex 57.1636 -0.92893 1.13761e-16
-    endloop
-  endfacet
-  facet normal -0.207911 -0.978148 0
-    outer loop
-      vertex 57.6137 -1.18882 1.5
-      vertex 57.8693 -1.24315 1.52242e-16
-      vertex 57.8693 -1.24315 1.5
-    endloop
-  endfacet
-  facet normal -0.207911 -0.978148 0
-    outer loop
-      vertex 57.8693 -1.24315 1.52242e-16
-      vertex 57.6137 -1.18882 1.5
-      vertex 57.6137 -1.18882 1.45588e-16
-    endloop
-  endfacet
-  facet normal -0.743145 -0.669131 0
-    outer loop
-      vertex 57.1636 -0.92893 1.13761e-16
-      vertex 56.9887 -0.734731 1.5
-      vertex 56.9887 -0.734731 8.99786e-17
-    endloop
-  endfacet
-  facet normal -0.743145 -0.669131 0
-    outer loop
-      vertex 56.9887 -0.734731 1.5
-      vertex 57.1636 -0.92893 1.13761e-16
-      vertex 57.1636 -0.92893 1.5
-    endloop
-  endfacet
-  facet normal 0.994521 -0.104534 1.10638e-17
-    outer loop
-      vertex 59.2227 -0.25989 1.5
-      vertex 59.25 0 0
-      vertex 59.25 1.83697e-16 1.5
-    endloop
-  endfacet
-  facet normal 0.994521 -0.104534 0
-    outer loop
-      vertex 59.25 0 0
-      vertex 59.2227 -0.25989 1.5
-      vertex 59.2227 -0.25989 3.18273e-17
-    endloop
-  endfacet
-  facet normal 0.207914 0.978147 -0
-    outer loop
-      vertex 58.3863 1.18882 -1.45588e-16
-      vertex 58.1307 1.24315 1.5
-      vertex 58.3863 1.18882 1.5
-    endloop
-  endfacet
-  facet normal 0.207914 0.978147 0
-    outer loop
-      vertex 58.1307 1.24315 1.5
-      vertex 58.3863 1.18882 -1.45588e-16
-      vertex 58.1307 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 59.1419 0.50842 1.5
-      vertex 59.0113 0.734731 -8.99786e-17
-      vertex 59.0113 0.734731 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 59.0113 0.734731 -8.99786e-17
-      vertex 59.1419 0.50842 1.5
-      vertex 59.1419 0.50842 -6.22635e-17
-    endloop
-  endfacet
-  facet normal 0.951055 0.30902 0
-    outer loop
-      vertex 59.2227 0.25989 1.5
-      vertex 59.1419 0.50842 -6.22635e-17
-      vertex 59.1419 0.50842 1.5
-    endloop
-  endfacet
-  facet normal 0.951055 0.30902 0
-    outer loop
-      vertex 59.1419 0.50842 -6.22635e-17
-      vertex 59.2227 0.25989 1.5
-      vertex 59.2227 0.25989 -3.18273e-17
-    endloop
-  endfacet
-  facet normal 0.406733 0.913547 -0
-    outer loop
-      vertex 58.625 1.08253 -1.32572e-16
-      vertex 58.3863 1.18882 1.5
-      vertex 58.625 1.08253 1.5
-    endloop
-  endfacet
-  facet normal 0.406733 0.913547 0
-    outer loop
-      vertex 58.3863 1.18882 1.5
-      vertex 58.625 1.08253 -1.32572e-16
-      vertex 58.3863 1.18882 -1.45588e-16
-    endloop
-  endfacet
-  facet normal 0.58779 0.809013 -0
-    outer loop
-      vertex 58.8364 0.92893 -1.13761e-16
-      vertex 58.625 1.08253 1.5
-      vertex 58.8364 0.92893 1.5
-    endloop
-  endfacet
-  facet normal 0.58779 0.809013 0
-    outer loop
-      vertex 58.625 1.08253 1.5
-      vertex 58.8364 0.92893 -1.13761e-16
-      vertex 58.625 1.08253 -1.32572e-16
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 58.1307 1.24315 -1.52242e-16
-      vertex 57.8693 1.24315 1.5
-      vertex 58.1307 1.24315 1.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 57.8693 1.24315 1.5
-      vertex 58.1307 1.24315 -1.52242e-16
-      vertex 57.8693 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal -0.587783 0.809018 0
-    outer loop
-      vertex 57.375 1.08253 1.5
-      vertex 57.1636 0.92893 -1.13761e-16
-      vertex 57.1636 0.92893 1.5
-    endloop
-  endfacet
-  facet normal -0.587783 0.809018 0
-    outer loop
-      vertex 57.1636 0.92893 -1.13761e-16
-      vertex 57.375 1.08253 1.5
-      vertex 57.375 1.08253 -1.32572e-16
-    endloop
-  endfacet
-  facet normal -0.406738 0.913545 0
-    outer loop
-      vertex 57.6137 1.18882 1.5
-      vertex 57.375 1.08253 -1.32572e-16
-      vertex 57.375 1.08253 1.5
-    endloop
-  endfacet
-  facet normal -0.406738 0.913545 0
-    outer loop
-      vertex 57.375 1.08253 -1.32572e-16
-      vertex 57.6137 1.18882 1.5
-      vertex 57.6137 1.18882 -1.45588e-16
-    endloop
-  endfacet
-  facet normal -0.743145 0.669131 0
-    outer loop
-      vertex 56.9887 0.734731 -8.99786e-17
-      vertex 57.1636 0.92893 1.5
-      vertex 57.1636 0.92893 -1.13761e-16
-    endloop
-  endfacet
-  facet normal -0.743145 0.669131 0
-    outer loop
-      vertex 57.1636 0.92893 1.5
-      vertex 56.9887 0.734731 -8.99786e-17
-      vertex 56.9887 0.734731 1.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104531 0
-    outer loop
-      vertex 1.22268 -23.2599 1.5
-      vertex 1.25 -23 2.81669e-15
-      vertex 1.25 -23 1.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104531 0
-    outer loop
-      vertex 1.25 -23 2.81669e-15
-      vertex 1.22268 -23.2599 1.5
-      vertex 1.22268 -23.2599 2.84851e-15
-    endloop
-  endfacet
-  facet normal -0.207909 -0.978148 1.24378e-06
-    outer loop
-      vertex -0.386271 -24.1888 1.5
-      vertex -0.13066 -24.2432 2.96893e-15
-      vertex -0.13066 -24.2432 1.5
-    endloop
-  endfacet
-  facet normal -0.207916 -0.978147 0
-    outer loop
-      vertex -0.13066 -24.2432 2.96893e-15
-      vertex -0.386271 -24.1888 1.5
-      vertex -0.386271 -24.1888 2.96228e-15
-    endloop
-  endfacet
-  facet normal 0.207909 0.978148 -1.24378e-06
-    outer loop
-      vertex 0.386271 -21.8112 2.6711e-15
-      vertex 0.13066 -21.7568 1.5
-      vertex 0.386271 -21.8112 1.5
-    endloop
-  endfacet
-  facet normal 0.207916 0.978147 0
-    outer loop
-      vertex 0.13066 -21.7568 1.5
-      vertex 0.386271 -21.8112 2.6711e-15
-      vertex 0.13066 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal 0.587787 -0.809016 0
-    outer loop
-      vertex 0.625 -24.0825 2.94926e-15
-      vertex 0.836412 -23.9289 1.5
-      vertex 0.625 -24.0825 1.5
-    endloop
-  endfacet
-  facet normal 0.587787 -0.809016 0
-    outer loop
-      vertex 0.836412 -23.9289 1.5
-      vertex 0.625 -24.0825 2.94926e-15
-      vertex 0.836412 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal -0.866025 -0.500001 0
-    outer loop
-      vertex -1.01127 -23.7347 2.90667e-15
-      vertex -1.14193 -23.5084 1.5
-      vertex -1.14193 -23.5084 2.87895e-15
-    endloop
-  endfacet
-  facet normal -0.866025 -0.500001 0
-    outer loop
-      vertex -1.14193 -23.5084 1.5
-      vertex -1.01127 -23.7347 2.90667e-15
-      vertex -1.01127 -23.7347 1.5
+      vertex 15.99 3.03 2
+      vertex 18.53 3.03 2
+      vertex 8.33335 6.2472 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.22268 -22.7401 1.5
-      vertex 1.22268 -23.2599 1.5
-      vertex 1.25 -23 1.5
+      vertex 17.7454 2.38607 2
+      vertex 16.79 2.23 2
+      vertex 17.73 2.23 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.14193 -22.4916 1.5
-      vertex 1.22268 -23.2599 1.5
-      vertex 1.22268 -22.7401 1.5
+      vertex 16.7746 2.38607 2
+      vertex 17.7454 2.38607 2
+      vertex 17.7909 2.53615 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.14193 -22.4916 1.5
-      vertex 1.14193 -23.5084 1.5
-      vertex 1.22268 -23.2599 1.5
+      vertex 16.7291 2.53615 2
+      vertex 17.7909 2.53615 2
+      vertex 17.8648 2.67446 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.01127 -22.2653 1.5
-      vertex 1.14193 -23.5084 1.5
-      vertex 1.14193 -22.4916 1.5
+      vertex 16.6552 2.67446 2
+      vertex 17.8648 2.67446 2
+      vertex 17.9643 2.79569 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 1.01127 -22.2653 1.5
-      vertex 1.01127 -23.7347 1.5
-      vertex 1.14193 -23.5084 1.5
+      vertex 16.5557 2.79569 2
+      vertex 17.9643 2.79569 2
+      vertex 18.0855 2.89518 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.836412 -22.0711 1.5
-      vertex 1.01127 -23.7347 1.5
-      vertex 1.01127 -22.2653 1.5
+      vertex 16.4345 2.89518 2
+      vertex 18.0855 2.89518 2
+      vertex 18.2239 2.9691 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.836412 -22.0711 1.5
-      vertex 0.836412 -23.9289 1.5
-      vertex 1.01127 -23.7347 1.5
+      vertex 17.7454 2.38607 2
+      vertex 16.7746 2.38607 2
+      vertex 16.79 2.23 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.625 -21.9175 1.5
-      vertex 0.836412 -23.9289 1.5
-      vertex 0.836412 -22.0711 1.5
+      vertex 17.7909 2.53615 2
+      vertex 16.7291 2.53615 2
+      vertex 16.7746 2.38607 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.625 -21.9175 1.5
-      vertex 0.625 -24.0825 1.5
-      vertex 0.836412 -23.9289 1.5
+      vertex 18.3739 3.01463 2
+      vertex 16.1461 3.01463 2
+      vertex 18.2239 2.9691 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.386271 -21.8112 1.5
-      vertex 0.625 -24.0825 1.5
-      vertex 0.625 -21.9175 1.5
+      vertex 17.8648 2.67446 2
+      vertex 16.6552 2.67446 2
+      vertex 16.7291 2.53615 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.386271 -21.8112 1.5
-      vertex 0.386271 -24.1888 1.5
-      vertex 0.625 -24.0825 1.5
+      vertex 17.9643 2.79569 2
+      vertex 16.5557 2.79569 2
+      vertex 16.6552 2.67446 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.13066 -21.7568 1.5
-      vertex 0.386271 -24.1888 1.5
-      vertex 0.386271 -21.8112 1.5
+      vertex 8.07402 6.38582 2
+      vertex 25.8439 5.5091 2
+      vertex 25.9939 5.55463 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 0.13066 -21.7568 1.5
-      vertex 0.13066 -24.2432 1.5
-      vertex 0.386271 -24.1888 1.5
+      vertex 18.0855 2.89518 2
+      vertex 16.4345 2.89518 2
+      vertex 16.5557 2.79569 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2239 2.9691 2
+      vertex 16.2961 2.9691 2
+      vertex 16.4345 2.89518 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2239 2.9691 2
+      vertex 16.1461 3.01463 2
+      vertex 16.2961 2.9691 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3739 3.01463 2
+      vertex 15.99 3.03 2
+      vertex 16.1461 3.01463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.53 3.03 2
+      vertex 15.99 3.03 2
+      vertex 18.3739 3.01463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.2054 2.38607 2
+      vertex 14.25 2.23 2
+      vertex 15.19 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.2346 2.38607 2
+      vertex 15.2054 2.38607 2
+      vertex 15.2509 2.53615 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1891 2.53615 2
+      vertex 15.2509 2.53615 2
+      vertex 15.3248 2.67446 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1152 2.67446 2
+      vertex 15.3248 2.67446 2
+      vertex 15.4243 2.79569 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.0157 2.79569 2
+      vertex 15.4243 2.79569 2
+      vertex 15.5455 2.89518 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8945 2.89518 2
+      vertex 15.5455 2.89518 2
+      vertex 15.6839 2.9691 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.2054 2.38607 2
+      vertex 14.2346 2.38607 2
+      vertex 14.25 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.2509 2.53615 2
+      vertex 14.1891 2.53615 2
+      vertex 14.2346 2.38607 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7561 2.9691 2
+      vertex 15.6839 2.9691 2
+      vertex 15.8339 3.01463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.3248 2.67446 2
+      vertex 14.1152 2.67446 2
+      vertex 14.1891 2.53615 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.99 3.03 2
+      vertex 8.56066 6.06066 2
+      vertex 15.8339 3.01463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4243 2.79569 2
+      vertex 14.0157 2.79569 2
+      vertex 14.1152 2.67446 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.5455 2.89518 2
+      vertex 13.8945 2.89518 2
+      vertex 14.0157 2.79569 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6839 2.9691 2
+      vertex 13.7561 2.9691 2
+      vertex 13.8945 2.89518 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex -0.13066 -21.7568 1.5
-      vertex 0.13066 -24.2432 1.5
-      vertex 0.13066 -21.7568 1.5
+      vertex 7.79263 6.47118 2
+      vertex 25.9939 5.55463 2
+      vertex 30.2074 6.47118 2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 8.7472 5.83335 2
+      vertex 15.8339 3.01463 2
+      vertex 8.56066 6.06066 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.13066 -21.7568 1.5
-      vertex -0.13066 -24.2432 1.5
-      vertex 0.13066 -24.2432 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.386271 -21.8112 1.5
-      vertex -0.13066 -24.2432 1.5
-      vertex -0.13066 -21.7568 1.5
+      vertex 15.8339 3.01463 2
+      vertex 13.6061 3.01463 2
+      vertex 13.7561 2.9691 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.386271 -21.8112 1.5
-      vertex -0.386271 -24.1888 1.5
-      vertex -0.13066 -24.2432 1.5
+      vertex 15.8339 3.01463 2
+      vertex 8.7472 5.83335 2
+      vertex 13.6061 3.01463 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.386271 -21.8112 1.5
-      vertex -0.624999 -24.0825 1.5
-      vertex -0.386271 -24.1888 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.625 -21.9175 1.5
-      vertex -0.624999 -24.0825 1.5
-      vertex -0.386271 -21.8112 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.836412 -22.0711 1.5
-      vertex -0.624999 -24.0825 1.5
-      vertex -0.625 -21.9175 1.5
+      vertex 12.6654 2.38607 2
+      vertex 11.71 2.23 2
+      vertex 12.65 2.23 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -0.836412 -22.0711 1.5
-      vertex -0.836412 -23.9289 1.5
-      vertex -0.624999 -24.0825 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.01127 -22.2653 1.5
-      vertex -0.836412 -23.9289 1.5
-      vertex -0.836412 -22.0711 1.5
+      vertex 11.6946 2.38607 2
+      vertex 12.6654 2.38607 2
+      vertex 12.7109 2.53615 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.01127 -22.2653 1.5
-      vertex -1.01127 -23.7347 1.5
-      vertex -0.836412 -23.9289 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.14193 -22.4916 1.5
-      vertex -1.01127 -23.7347 1.5
-      vertex -1.01127 -22.2653 1.5
+      vertex 11.6491 2.53615 2
+      vertex 12.7109 2.53615 2
+      vertex 12.7848 2.67446 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.14193 -22.4916 1.5
-      vertex -1.14193 -23.5084 1.5
-      vertex -1.01127 -23.7347 1.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -1.22268 -22.7401 1.5
-      vertex -1.14193 -23.5084 1.5
-      vertex -1.14193 -22.4916 1.5
+      vertex 11.5752 2.67446 2
+      vertex 12.7848 2.67446 2
+      vertex 12.8843 2.79569 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex -1.22268 -22.7401 1.5
-      vertex -1.22268 -23.2599 1.5
-      vertex -1.14193 -23.5084 1.5
+      vertex 11.4757 2.79569 2
+      vertex 12.8843 2.79569 2
+      vertex 13.0055 2.89518 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.3545 2.89518 2
+      vertex 13.0055 2.89518 2
+      vertex 13.1439 2.9691 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.6654 2.38607 2
+      vertex 11.6946 2.38607 2
+      vertex 11.71 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7109 2.53615 2
+      vertex 11.6491 2.53615 2
+      vertex 11.6946 2.38607 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.97118 5.29263 2
+      vertex 13.1439 2.9691 2
+      vertex 13.2939 3.01463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7848 2.67446 2
+      vertex 11.5752 2.67446 2
+      vertex 11.6491 2.53615 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6061 3.01463 2
+      vertex 8.7472 5.83335 2
+      vertex 13.45 3.03 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.8843 2.79569 2
+      vertex 11.4757 2.79569 2
+      vertex 11.5752 2.67446 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0055 2.89518 2
+      vertex 11.3545 2.89518 2
+      vertex 11.4757 2.79569 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.45 3.03 2
+      vertex 8.88582 5.57402 2
+      vertex 13.2939 3.01463 2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 8.97118 5.29263 2
+      vertex 13.2939 3.01463 2
+      vertex 8.88582 5.57402 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.1439 2.9691 2
+      vertex 11.2161 2.9691 2
+      vertex 11.3545 2.89518 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.1439 2.9691 2
+      vertex 8.97118 5.29263 2
+      vertex 11.2161 2.9691 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.1709 2.53615 2
+      vertex 9 2 2
+      vertex 10.1254 2.38607 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.2448 2.67446 2
+      vertex 9 2 2
+      vertex 10.1709 2.53615 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9 2 2
+      vertex 10.2448 2.67446 2
+      vertex 9 5 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.3443 2.79569 2
+      vertex 9 5 2
+      vertex 10.2448 2.67446 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.4655 2.89518 2
+      vertex 9 5 2
+      vertex 10.3443 2.79569 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6039 2.9691 2
+      vertex 9 5 2
+      vertex 10.4655 2.89518 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.7539 3.01463 2
+      vertex 9 5 2
+      vertex 10.6039 2.9691 2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 9 5 2
+      vertex 11.0661 3.01463 2
+      vertex 8.97118 5.29263 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.79263 6.47118 2
+      vertex 30.2074 6.47118 2
+      vertex 30.5 6.5 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.91 3.03 2
+      vertex 9 5 2
+      vertex 10.7539 3.01463 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.0661 3.01463 2
+      vertex 9 5 2
+      vertex 10.91 3.03 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.2161 2.9691 2
+      vertex 8.97118 5.29263 2
+      vertex 11.0661 3.01463 2
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 8.88582 5.57402 2
+      vertex 13.45 3.03 2
+      vertex 8.7472 5.83335 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.99 3.03 2
+      vertex 8.33335 6.2472 2
+      vertex 8.56066 6.06066 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8439 5.5091 2
+      vertex 8.07402 6.38582 2
+      vertex 8.33335 6.2472 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9939 5.55463 2
+      vertex 7.79263 6.47118 2
+      vertex 8.07402 6.38582 2
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex -1.22268 -23.2599 1.5
-      vertex -1.22268 -22.7401 1.5
-      vertex -1.25 -23 1.5
-    endloop
-  endfacet
-  facet normal -0.587785 -0.809017 0
-    outer loop
-      vertex -0.836412 -23.9289 1.5
-      vertex -0.624999 -24.0825 2.94926e-15
-      vertex -0.624999 -24.0825 1.5
-    endloop
-  endfacet
-  facet normal -0.587785 -0.809017 0
-    outer loop
-      vertex -0.624999 -24.0825 2.94926e-15
-      vertex -0.836412 -23.9289 1.5
-      vertex -0.836412 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal 0.866025 -0.500001 0
-    outer loop
-      vertex 1.01127 -23.7347 1.5
-      vertex 1.14193 -23.5084 2.87895e-15
-      vertex 1.14193 -23.5084 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 -0.500001 0
-    outer loop
-      vertex 1.14193 -23.5084 2.87895e-15
-      vertex 1.01127 -23.7347 1.5
-      vertex 1.01127 -23.7347 2.90667e-15
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309018 0
-    outer loop
-      vertex 1.14193 -23.5084 1.5
-      vertex 1.22268 -23.2599 2.84851e-15
-      vertex 1.22268 -23.2599 1.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309018 0
-    outer loop
-      vertex 1.22268 -23.2599 2.84851e-15
-      vertex 1.14193 -23.5084 1.5
-      vertex 1.14193 -23.5084 2.87895e-15
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex 0.836412 -23.9289 1.5
-      vertex 1.01127 -23.7347 2.90667e-15
-      vertex 1.01127 -23.7347 1.5
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex 1.01127 -23.7347 2.90667e-15
-      vertex 0.836412 -23.9289 1.5
-      vertex 0.836412 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal 0.207909 -0.978148 1.24378e-06
-    outer loop
-      vertex 0.13066 -24.2432 2.96893e-15
-      vertex 0.386271 -24.1888 1.5
-      vertex 0.13066 -24.2432 1.5
-    endloop
-  endfacet
-  facet normal 0.207916 -0.978147 0
-    outer loop
-      vertex 0.386271 -24.1888 1.5
-      vertex 0.13066 -24.2432 2.96893e-15
-      vertex 0.386271 -24.1888 2.96228e-15
-    endloop
-  endfacet
-  facet normal 0 -1 1.27157e-06
-    outer loop
-      vertex -0.13066 -24.2432 2.96893e-15
-      vertex 0.13066 -24.2432 1.5
-      vertex -0.13066 -24.2432 1.5
-    endloop
-  endfacet
-  facet normal 0 -1 1.27157e-06
-    outer loop
-      vertex 0.13066 -24.2432 1.5
-      vertex -0.13066 -24.2432 2.96893e-15
-      vertex 0.13066 -24.2432 2.96893e-15
-    endloop
-  endfacet
-  facet normal 0.406736 -0.913546 0
-    outer loop
-      vertex 0.386271 -24.1888 2.96228e-15
-      vertex 0.625 -24.0825 1.5
-      vertex 0.386271 -24.1888 1.5
-    endloop
-  endfacet
-  facet normal 0.406736 -0.913546 0
-    outer loop
-      vertex 0.625 -24.0825 1.5
-      vertex 0.386271 -24.1888 2.96228e-15
-      vertex 0.625 -24.0825 2.94926e-15
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309018 0
-    outer loop
-      vertex -1.14193 -23.5084 2.87895e-15
-      vertex -1.22268 -23.2599 1.5
-      vertex -1.22268 -23.2599 2.84851e-15
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309018 0
-    outer loop
-      vertex -1.22268 -23.2599 1.5
-      vertex -1.14193 -23.5084 2.87895e-15
-      vertex -1.14193 -23.5084 1.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104531 0
-    outer loop
-      vertex -1.22268 -23.2599 2.84851e-15
-      vertex -1.25 -23 1.5
-      vertex -1.25 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104531 0
-    outer loop
-      vertex -1.25 -23 1.5
-      vertex -1.22268 -23.2599 2.84851e-15
-      vertex -1.22268 -23.2599 1.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.10453 0
-    outer loop
-      vertex -1.25 -23 2.81669e-15
-      vertex -1.22268 -22.7401 1.5
-      vertex -1.22268 -22.7401 2.78486e-15
-    endloop
-  endfacet
-  facet normal -0.994522 0.10453 0
-    outer loop
-      vertex -1.22268 -22.7401 1.5
-      vertex -1.25 -23 2.81669e-15
-      vertex -1.25 -23 1.5
-    endloop
-  endfacet
-  facet normal -0.743146 -0.669129 0
-    outer loop
-      vertex -0.836412 -23.9289 2.93045e-15
-      vertex -1.01127 -23.7347 1.5
-      vertex -1.01127 -23.7347 2.90667e-15
-    endloop
-  endfacet
-  facet normal -0.743146 -0.669129 0
-    outer loop
-      vertex -1.01127 -23.7347 1.5
-      vertex -0.836412 -23.9289 2.93045e-15
-      vertex -0.836412 -23.9289 1.5
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 0
-    outer loop
-      vertex -0.624999 -24.0825 1.5
-      vertex -0.386271 -24.1888 2.96228e-15
-      vertex -0.386271 -24.1888 1.5
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 0
-    outer loop
-      vertex -0.386271 -24.1888 2.96228e-15
-      vertex -0.624999 -24.0825 1.5
-      vertex -0.624999 -24.0825 2.94926e-15
-    endloop
-  endfacet
-  facet normal 0.994522 0.10453 0
-    outer loop
-      vertex 1.25 -23 1.5
-      vertex 1.22268 -22.7401 2.78486e-15
-      vertex 1.22268 -22.7401 1.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.10453 0
-    outer loop
-      vertex 1.22268 -22.7401 2.78486e-15
-      vertex 1.25 -23 1.5
-      vertex 1.25 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal 0.406736 0.913546 -1.16163e-06
-    outer loop
-      vertex 0.625 -21.9175 2.68412e-15
-      vertex 0.386271 -21.8112 1.5
-      vertex 0.625 -21.9175 1.5
-    endloop
-  endfacet
-  facet normal 0.406736 0.913546 -1.16163e-06
-    outer loop
-      vertex 0.386271 -21.8112 1.5
-      vertex 0.625 -21.9175 2.68412e-15
-      vertex 0.386271 -21.8112 2.6711e-15
-    endloop
-  endfacet
-  facet normal 0.951056 0.309018 0
-    outer loop
-      vertex 1.22268 -22.7401 1.5
-      vertex 1.14193 -22.4916 2.75442e-15
-      vertex 1.14193 -22.4916 1.5
-    endloop
-  endfacet
-  facet normal 0.951056 0.309018 0
-    outer loop
-      vertex 1.14193 -22.4916 2.75442e-15
-      vertex 1.22268 -22.7401 1.5
-      vertex 1.22268 -22.7401 2.78486e-15
-    endloop
-  endfacet
-  facet normal -0.406736 0.913546 -1.16163e-06
-    outer loop
-      vertex -0.386271 -21.8112 1.5
-      vertex -0.625 -21.9175 2.68412e-15
-      vertex -0.625 -21.9175 1.5
-    endloop
-  endfacet
-  facet normal -0.406736 0.913546 -1.16163e-06
-    outer loop
-      vertex -0.625 -21.9175 2.68412e-15
-      vertex -0.386271 -21.8112 1.5
-      vertex -0.386271 -21.8112 2.6711e-15
-    endloop
-  endfacet
-  facet normal -0.743146 0.669129 0
-    outer loop
-      vertex -1.01127 -22.2653 2.72671e-15
-      vertex -0.836412 -22.0711 1.5
-      vertex -0.836412 -22.0711 2.70293e-15
-    endloop
-  endfacet
-  facet normal -0.743146 0.669129 0
-    outer loop
-      vertex -0.836412 -22.0711 1.5
-      vertex -1.01127 -22.2653 2.72671e-15
-      vertex -1.01127 -22.2653 1.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex -0.625 -21.9175 1.5
-      vertex -0.836412 -22.0711 2.70293e-15
-      vertex -0.836412 -22.0711 1.5
-    endloop
-  endfacet
-  facet normal -0.587782 0.809019 -1.02872e-06
-    outer loop
-      vertex -0.836412 -22.0711 2.70293e-15
-      vertex -0.625 -21.9175 1.5
-      vertex -0.625 -21.9175 2.68412e-15
-    endloop
-  endfacet
-  facet normal 0.743146 0.669129 0
-    outer loop
-      vertex 1.01127 -22.2653 1.5
-      vertex 0.836412 -22.0711 2.70293e-15
-      vertex 0.836412 -22.0711 1.5
-    endloop
-  endfacet
-  facet normal 0.743146 0.669129 0
-    outer loop
-      vertex 0.836412 -22.0711 2.70293e-15
-      vertex 1.01127 -22.2653 1.5
-      vertex 1.01127 -22.2653 2.72671e-15
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 -0
-    outer loop
-      vertex 0.836412 -22.0711 2.70293e-15
-      vertex 0.625 -21.9175 1.5
-      vertex 0.836412 -22.0711 1.5
-    endloop
-  endfacet
-  facet normal 0.587782 0.809019 -1.02872e-06
-    outer loop
-      vertex 0.625 -21.9175 1.5
-      vertex 0.836412 -22.0711 2.70293e-15
-      vertex 0.625 -21.9175 2.68412e-15
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.13066 -21.7568 2.66445e-15
-      vertex -0.13066 -21.7568 1.5
-      vertex 0.13066 -21.7568 1.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.13066 -21.7568 1.5
-      vertex 0.13066 -21.7568 2.66445e-15
-      vertex -0.13066 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex -1.14193 -22.4916 2.75442e-15
-      vertex -1.01127 -22.2653 1.5
-      vertex -1.01127 -22.2653 2.72671e-15
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex -1.01127 -22.2653 1.5
-      vertex -1.14193 -22.4916 2.75442e-15
-      vertex -1.14193 -22.4916 1.5
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex -1.22268 -22.7401 2.78486e-15
-      vertex -1.14193 -22.4916 1.5
-      vertex -1.14193 -22.4916 2.75442e-15
-    endloop
-  endfacet
-  facet normal -0.951056 0.309018 0
-    outer loop
-      vertex -1.14193 -22.4916 1.5
-      vertex -1.22268 -22.7401 2.78486e-15
-      vertex -1.22268 -22.7401 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 1.14193 -22.4916 1.5
-      vertex 1.01127 -22.2653 2.72671e-15
-      vertex 1.01127 -22.2653 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 1.01127 -22.2653 2.72671e-15
-      vertex 1.14193 -22.4916 1.5
-      vertex 1.14193 -22.4916 2.75442e-15
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 -1.24378e-06
-    outer loop
-      vertex -0.13066 -21.7568 1.5
-      vertex -0.386271 -21.8112 2.6711e-15
-      vertex -0.386271 -21.8112 1.5
-    endloop
-  endfacet
-  facet normal -0.207916 0.978147 0
-    outer loop
-      vertex -0.386271 -21.8112 2.6711e-15
-      vertex -0.13066 -21.7568 1.5
-      vertex -0.13066 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal 0.994521 -0.104534 0
-    outer loop
-      vertex 59.2227 -23.2599 1.5
-      vertex 59.25 -23 2.81669e-15
-      vertex 59.25 -23 1.5
-    endloop
-  endfacet
-  facet normal 0.994521 -0.104534 0
-    outer loop
-      vertex 59.25 -23 2.81669e-15
-      vertex 59.2227 -23.2599 1.5
-      vertex 59.2227 -23.2599 2.84851e-15
-    endloop
-  endfacet
-  facet normal -0.207908 -0.978148 1.24378e-06
-    outer loop
-      vertex 57.6137 -24.1888 1.5
-      vertex 57.8693 -24.2432 2.96893e-15
-      vertex 57.8693 -24.2432 1.5
-    endloop
-  endfacet
-  facet normal -0.207915 -0.978147 0
-    outer loop
-      vertex 57.8693 -24.2432 2.96893e-15
-      vertex 57.6137 -24.1888 1.5
-      vertex 57.6137 -24.1888 2.96228e-15
-    endloop
-  endfacet
-  facet normal 0.58779 -0.809013 0
-    outer loop
-      vertex 58.625 -24.0825 2.94926e-15
-      vertex 58.8364 -23.9289 1.5
-      vertex 58.625 -24.0825 1.5
-    endloop
-  endfacet
-  facet normal 0.58779 -0.809013 0
-    outer loop
-      vertex 58.8364 -23.9289 1.5
-      vertex 58.625 -24.0825 2.94926e-15
-      vertex 58.8364 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal -0.866025 -0.500001 0
-    outer loop
-      vertex 56.9887 -23.7347 2.90667e-15
-      vertex 56.8581 -23.5084 1.5
-      vertex 56.8581 -23.5084 2.87895e-15
-    endloop
-  endfacet
-  facet normal -0.866025 -0.500001 0
-    outer loop
-      vertex 56.8581 -23.5084 1.5
-      vertex 56.9887 -23.7347 2.90667e-15
-      vertex 56.9887 -23.7347 1.5
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309021 0
-    outer loop
-      vertex 56.8581 -23.5084 2.87895e-15
-      vertex 56.7773 -23.2599 1.5
-      vertex 56.7773 -23.2599 2.84851e-15
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309021 0
-    outer loop
-      vertex 56.7773 -23.2599 1.5
-      vertex 56.8581 -23.5084 2.87895e-15
-      vertex 56.8581 -23.5084 1.5
-    endloop
-  endfacet
-  facet normal -0.587783 -0.809018 0
-    outer loop
-      vertex 57.1636 -23.9289 1.5
-      vertex 57.375 -24.0825 2.94926e-15
-      vertex 57.375 -24.0825 1.5
-    endloop
-  endfacet
-  facet normal -0.587783 -0.809018 0
-    outer loop
-      vertex 57.375 -24.0825 2.94926e-15
-      vertex 57.1636 -23.9289 1.5
-      vertex 57.1636 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 59.1419 -22.4916 1.5
-      vertex 59.0113 -22.2653 2.72671e-15
-      vertex 59.0113 -22.2653 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 59.0113 -22.2653 2.72671e-15
-      vertex 59.1419 -22.4916 1.5
-      vertex 59.1419 -22.4916 2.75442e-15
-    endloop
-  endfacet
-  facet normal 0.866025 -0.500001 0
-    outer loop
-      vertex 59.0113 -23.7347 1.5
-      vertex 59.1419 -23.5084 2.87895e-15
-      vertex 59.1419 -23.5084 1.5
-    endloop
-  endfacet
-  facet normal 0.866025 -0.500001 0
-    outer loop
-      vertex 59.1419 -23.5084 2.87895e-15
-      vertex 59.0113 -23.7347 1.5
-      vertex 59.0113 -23.7347 2.90667e-15
-    endloop
-  endfacet
-  facet normal 0.951055 -0.309021 0
-    outer loop
-      vertex 59.1419 -23.5084 1.5
-      vertex 59.2227 -23.2599 2.84851e-15
-      vertex 59.2227 -23.2599 1.5
-    endloop
-  endfacet
-  facet normal 0.951055 -0.309021 0
-    outer loop
-      vertex 59.2227 -23.2599 2.84851e-15
-      vertex 59.1419 -23.5084 1.5
-      vertex 59.1419 -23.5084 2.87895e-15
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex 58.8364 -23.9289 1.5
-      vertex 59.0113 -23.7347 2.90667e-15
-      vertex 59.0113 -23.7347 1.5
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex 59.0113 -23.7347 2.90667e-15
-      vertex 58.8364 -23.9289 1.5
-      vertex 58.8364 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal 0.207911 -0.978148 1.24378e-06
-    outer loop
-      vertex 58.1307 -24.2432 2.96893e-15
-      vertex 58.3863 -24.1888 1.5
-      vertex 58.1307 -24.2432 1.5
-    endloop
-  endfacet
-  facet normal 0.207918 -0.978146 0
-    outer loop
-      vertex 58.3863 -24.1888 1.5
-      vertex 58.1307 -24.2432 2.96893e-15
-      vertex 58.3863 -24.1888 2.96228e-15
-    endloop
-  endfacet
-  facet normal 0 -1 1.27157e-06
-    outer loop
-      vertex 57.8693 -24.2432 2.96893e-15
-      vertex 58.1307 -24.2432 1.5
-      vertex 57.8693 -24.2432 1.5
-    endloop
-  endfacet
-  facet normal 0 -1 1.27157e-06
-    outer loop
-      vertex 58.1307 -24.2432 1.5
-      vertex 57.8693 -24.2432 2.96893e-15
-      vertex 58.1307 -24.2432 2.96893e-15
-    endloop
-  endfacet
-  facet normal 0.406733 -0.913547 0
-    outer loop
-      vertex 58.3863 -24.1888 2.96228e-15
-      vertex 58.625 -24.0825 1.5
-      vertex 58.3863 -24.1888 1.5
-    endloop
-  endfacet
-  facet normal 0.406733 -0.913547 0
-    outer loop
-      vertex 58.625 -24.0825 1.5
-      vertex 58.3863 -24.1888 2.96228e-15
-      vertex 58.625 -24.0825 2.94926e-15
+      vertex 7.79263 6.47118 2
+      vertex 30.5 6.5 2
+      vertex 7.5 6.5 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 59.2227 -22.7401 1.5
-      vertex 59.2227 -23.2599 1.5
-      vertex 59.25 -23 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 59.1419 -22.4916 1.5
-      vertex 59.2227 -23.2599 1.5
-      vertex 59.2227 -22.7401 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 59.1419 -22.4916 1.5
-      vertex 59.1419 -23.5084 1.5
-      vertex 59.2227 -23.2599 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 59.0113 -22.2653 1.5
-      vertex 59.1419 -23.5084 1.5
-      vertex 59.1419 -22.4916 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 59.0113 -22.2653 1.5
-      vertex 59.0113 -23.7347 1.5
-      vertex 59.1419 -23.5084 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.8364 -22.0711 1.5
-      vertex 59.0113 -23.7347 1.5
-      vertex 59.0113 -22.2653 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.8364 -22.0711 1.5
-      vertex 58.8364 -23.9289 1.5
-      vertex 59.0113 -23.7347 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -21.9175 1.5
-      vertex 58.8364 -23.9289 1.5
-      vertex 58.8364 -22.0711 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.625 -21.9175 1.5
-      vertex 58.625 -24.0825 1.5
-      vertex 58.8364 -23.9289 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.3863 -21.8112 1.5
-      vertex 58.625 -24.0825 1.5
-      vertex 58.625 -21.9175 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.3863 -21.8112 1.5
-      vertex 58.3863 -24.1888 1.5
-      vertex 58.625 -24.0825 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.1307 -21.7568 1.5
-      vertex 58.3863 -24.1888 1.5
-      vertex 58.3863 -21.8112 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.1307 -21.7568 1.5
-      vertex 58.1307 -24.2432 1.5
-      vertex 58.3863 -24.1888 1.5
+      vertex 26.8891 4.46385 2
+      vertex 29 5 2
+      vertex 26.9346 4.61393 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 57.8693 -21.7568 1.5
-      vertex 58.1307 -24.2432 1.5
-      vertex 58.1307 -21.7568 1.5
+      vertex 26.9346 2.07393 2
+      vertex 29 2 2
+      vertex 26.95 2.23 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 57.8693 -21.7568 1.5
-      vertex 57.8693 -24.2432 1.5
-      vertex 58.1307 -24.2432 1.5
+      vertex 29 2 2
+      vertex 26.9346 2.07393 2
+      vertex 29.0288 1.70736 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 57.6137 -21.8112 1.5
-      vertex 57.8693 -24.2432 1.5
-      vertex 57.8693 -21.7568 1.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 57.6137 -21.8112 1.5
-      vertex 57.6137 -24.1888 1.5
-      vertex 57.8693 -24.2432 1.5
+      vertex 26.8891 1.92385 2
+      vertex 29.0288 1.70736 2
+      vertex 26.9346 2.07393 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 57.375 -21.9175 1.5
-      vertex 57.6137 -24.1888 1.5
-      vertex 57.6137 -21.8112 1.5
+      vertex 26.8152 1.78554 2
+      vertex 29.0288 1.70736 2
+      vertex 26.8891 1.92385 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 57.375 -21.9175 1.5
-      vertex 57.375 -24.0825 1.5
-      vertex 57.6137 -24.1888 1.5
+      vertex 29.0288 1.70736 2
+      vertex 26.8152 1.78554 2
+      vertex 29.1142 1.42597 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 57.1636 -22.0711 1.5
-      vertex 57.375 -24.0825 1.5
-      vertex 57.375 -21.9175 1.5
+      vertex 26.7157 1.66431 2
+      vertex 29.1142 1.42597 2
+      vertex 26.8152 1.78554 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 57.1636 -22.0711 1.5
-      vertex 57.1636 -23.9289 1.5
-      vertex 57.375 -24.0825 1.5
+      vertex 29.1142 1.42597 2
+      vertex 26.7157 1.66431 2
+      vertex 29.2528 1.16664 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 56.9887 -22.2653 1.5
-      vertex 57.1636 -23.9289 1.5
-      vertex 57.1636 -22.0711 1.5
+      vertex 26.5945 1.56482 2
+      vertex 29.2528 1.16664 2
+      vertex 26.7157 1.66431 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 56.9887 -22.2653 1.5
-      vertex 56.9887 -23.7347 1.5
-      vertex 57.1636 -23.9289 1.5
+      vertex 29.2528 1.16664 2
+      vertex 26.5945 1.56482 2
+      vertex 29.4393 0.93934 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 56.8581 -22.4916 1.5
-      vertex 56.9887 -23.7347 1.5
-      vertex 56.9887 -22.2653 1.5
+      vertex 26.4561 1.4909 2
+      vertex 29.4393 0.93934 2
+      vertex 26.5945 1.56482 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 56.8581 -22.4916 1.5
-      vertex 56.8581 -23.5084 1.5
-      vertex 56.9887 -23.7347 1.5
+      vertex 29.4393 0.93934 2
+      vertex 26.4561 1.4909 2
+      vertex 29.6666 0.752795 2
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 56.7773 -22.7401 1.5
-      vertex 56.8581 -23.5084 1.5
-      vertex 56.8581 -22.4916 1.5
+      vertex 26.3061 1.44537 2
+      vertex 29.6666 0.752795 2
+      vertex 26.4561 1.4909 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 26.15 1.43 2
+      vertex 29.6666 0.752795 2
+      vertex 26.3061 1.44537 2
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 56.7773 -22.7401 1.5
-      vertex 56.7773 -23.2599 1.5
-      vertex 56.8581 -23.5084 1.5
+      vertex 29.6666 0.752795 2
+      vertex 26.15 1.43 2
+      vertex 29.926 0.614181 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9939 1.44537 2
+      vertex 29.926 0.614181 2
+      vertex 26.15 1.43 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.926 0.614181 2
+      vertex 25.9939 1.44537 2
+      vertex 30.2074 0.528822 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 19.33 2.23 2
+      vertex 25.3654 2.07393 2
+      vertex 25.35 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.3146 2.07393 2
+      vertex 25.3654 2.07393 2
+      vertex 19.33 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.3654 2.07393 2
+      vertex 19.3146 2.07393 2
+      vertex 25.4109 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.2691 1.92385 2
+      vertex 25.4109 1.92385 2
+      vertex 19.3146 2.07393 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4109 1.92385 2
+      vertex 19.2691 1.92385 2
+      vertex 25.4848 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.1952 1.78554 2
+      vertex 25.4848 1.78554 2
+      vertex 19.2691 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.4848 1.78554 2
+      vertex 19.1952 1.78554 2
+      vertex 25.5843 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 19.0957 1.66431 2
+      vertex 25.5843 1.66431 2
+      vertex 19.1952 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5843 1.66431 2
+      vertex 19.0957 1.66431 2
+      vertex 25.7055 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.9745 1.56482 2
+      vertex 25.7055 1.56482 2
+      vertex 19.0957 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7055 1.56482 2
+      vertex 18.9745 1.56482 2
+      vertex 25.8439 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.8361 1.4909 2
+      vertex 25.8439 1.4909 2
+      vertex 18.9745 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8439 1.4909 2
+      vertex 18.8361 1.4909 2
+      vertex 25.9939 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.6861 1.44537 2
+      vertex 25.9939 1.44537 2
+      vertex 18.8361 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9939 1.44537 2
+      vertex 18.6861 1.44537 2
+      vertex 30.2074 0.528822 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 18.53 1.43 2
+      vertex 30.2074 0.528822 2
+      vertex 18.6861 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.79263 0.528822 2
+      vertex 30.2074 0.528822 2
+      vertex 18.53 1.43 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 16.79 2.23 2
+      vertex 17.7454 2.07393 2
+      vertex 17.73 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7746 2.07393 2
+      vertex 17.7454 2.07393 2
+      vertex 16.79 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7454 2.07393 2
+      vertex 16.7746 2.07393 2
+      vertex 17.7909 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.7291 1.92385 2
+      vertex 17.7909 1.92385 2
+      vertex 16.7746 2.07393 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.7909 1.92385 2
+      vertex 16.7291 1.92385 2
+      vertex 17.8648 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.6552 1.78554 2
+      vertex 17.8648 1.78554 2
+      vertex 16.7291 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.8648 1.78554 2
+      vertex 16.6552 1.78554 2
+      vertex 17.9643 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.5557 1.66431 2
+      vertex 17.9643 1.66431 2
+      vertex 16.6552 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 17.9643 1.66431 2
+      vertex 16.5557 1.66431 2
+      vertex 18.0855 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.4345 1.56482 2
+      vertex 18.0855 1.56482 2
+      vertex 16.5557 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.0855 1.56482 2
+      vertex 16.4345 1.56482 2
+      vertex 18.2239 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.2961 1.4909 2
+      vertex 18.2239 1.4909 2
+      vertex 16.4345 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.2239 1.4909 2
+      vertex 16.2961 1.4909 2
+      vertex 18.3739 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 16.1461 1.44537 2
+      vertex 18.3739 1.44537 2
+      vertex 16.2961 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.3739 1.44537 2
+      vertex 16.1461 1.44537 2
+      vertex 18.53 1.43 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.99 1.43 2
+      vertex 18.53 1.43 2
+      vertex 16.1461 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.79263 0.528822 2
+      vertex 18.53 1.43 2
+      vertex 15.99 1.43 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 14.25 2.23 2
+      vertex 15.2054 2.07393 2
+      vertex 15.19 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.2346 2.07393 2
+      vertex 15.2054 2.07393 2
+      vertex 14.25 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.2054 2.07393 2
+      vertex 14.2346 2.07393 2
+      vertex 15.2509 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1891 1.92385 2
+      vertex 15.2509 1.92385 2
+      vertex 14.2346 2.07393 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.2509 1.92385 2
+      vertex 14.1891 1.92385 2
+      vertex 15.3248 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.1152 1.78554 2
+      vertex 15.3248 1.78554 2
+      vertex 14.1891 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.3248 1.78554 2
+      vertex 14.1152 1.78554 2
+      vertex 15.4243 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 14.0157 1.66431 2
+      vertex 15.4243 1.66431 2
+      vertex 14.1152 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.4243 1.66431 2
+      vertex 14.0157 1.66431 2
+      vertex 15.5455 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.8945 1.56482 2
+      vertex 15.5455 1.56482 2
+      vertex 14.0157 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.5455 1.56482 2
+      vertex 13.8945 1.56482 2
+      vertex 15.6839 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.7561 1.4909 2
+      vertex 15.6839 1.4909 2
+      vertex 13.8945 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.6839 1.4909 2
+      vertex 13.7561 1.4909 2
+      vertex 15.8339 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.6061 1.44537 2
+      vertex 15.8339 1.44537 2
+      vertex 13.7561 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 15.8339 1.44537 2
+      vertex 13.6061 1.44537 2
+      vertex 15.99 1.43 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.45 1.43 2
+      vertex 15.99 1.43 2
+      vertex 13.6061 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.79263 0.528822 2
+      vertex 15.99 1.43 2
+      vertex 13.45 1.43 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 11.71 2.23 2
+      vertex 12.6654 2.07393 2
+      vertex 12.65 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6946 2.07393 2
+      vertex 12.6654 2.07393 2
+      vertex 11.71 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.6654 2.07393 2
+      vertex 11.6946 2.07393 2
+      vertex 12.7109 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.6491 1.92385 2
+      vertex 12.7109 1.92385 2
+      vertex 11.6946 2.07393 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7109 1.92385 2
+      vertex 11.6491 1.92385 2
+      vertex 12.7848 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.5752 1.78554 2
+      vertex 12.7848 1.78554 2
+      vertex 11.6491 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.7848 1.78554 2
+      vertex 11.5752 1.78554 2
+      vertex 12.8843 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.4757 1.66431 2
+      vertex 12.8843 1.66431 2
+      vertex 11.5752 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 12.8843 1.66431 2
+      vertex 11.4757 1.66431 2
+      vertex 13.0055 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.3545 1.56482 2
+      vertex 13.0055 1.56482 2
+      vertex 11.4757 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.0055 1.56482 2
+      vertex 11.3545 1.56482 2
+      vertex 13.1439 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.2161 1.4909 2
+      vertex 13.1439 1.4909 2
+      vertex 11.3545 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.1439 1.4909 2
+      vertex 11.2161 1.4909 2
+      vertex 13.2939 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 11.0661 1.44537 2
+      vertex 13.2939 1.44537 2
+      vertex 11.2161 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.07402 0.614181 2
+      vertex 13.2939 1.44537 2
+      vertex 11.0661 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 13.2939 1.44537 2
+      vertex 8.07402 0.614181 2
+      vertex 13.45 1.43 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.07402 0.614181 2
+      vertex 11.0661 1.44537 2
+      vertex 10.91 1.43 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.1254 2.38607 2
+      vertex 9 2 2
+      vertex 10.11 2.23 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.11 2.23 2
+      vertex 9 2 2
+      vertex 10.1254 2.07393 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.1254 2.07393 2
+      vertex 9 2 2
+      vertex 10.1709 1.92385 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.97118 1.70736 2
+      vertex 10.1709 1.92385 2
+      vertex 9 2 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.1709 1.92385 2
+      vertex 8.97118 1.70736 2
+      vertex 10.2448 1.78554 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.88582 1.42597 2
+      vertex 10.2448 1.78554 2
+      vertex 8.97118 1.70736 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.2448 1.78554 2
+      vertex 8.88582 1.42597 2
+      vertex 10.3443 1.66431 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.3443 1.66431 2
+      vertex 8.88582 1.42597 2
+      vertex 10.4655 1.56482 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.7472 1.16664 2
+      vertex 10.4655 1.56482 2
+      vertex 8.88582 1.42597 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.4655 1.56482 2
+      vertex 8.7472 1.16664 2
+      vertex 10.6039 1.4909 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.56066 0.93934 2
+      vertex 10.6039 1.4909 2
+      vertex 8.7472 1.16664 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.6039 1.4909 2
+      vertex 8.56066 0.93934 2
+      vertex 10.7539 1.44537 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.33335 0.752795 2
+      vertex 10.7539 1.44537 2
+      vertex 8.56066 0.93934 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10.7539 1.44537 2
+      vertex 8.33335 0.752795 2
+      vertex 10.91 1.43 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.07402 0.614181 2
+      vertex 10.91 1.43 2
+      vertex 8.33335 0.752795 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.79263 0.528822 2
+      vertex 13.45 1.43 2
+      vertex 8.07402 0.614181 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.2074 0.528822 2
+      vertex 7.79263 0.528822 2
+      vertex 30.5 0.5 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5 0.5 2
+      vertex 7.79263 0.528822 2
+      vertex 7.5 0.5 2
+    endloop
+  endfacet
+  facet normal -0.773091 0.634295 0
+    outer loop
+      vertex 29.2528 5.83335 2
+      vertex 29.4393 6.06066 4.5
+      vertex 29.4393 6.06066 2
+    endloop
+  endfacet
+  facet normal -0.773091 0.634295 0
+    outer loop
+      vertex 29.4393 6.06066 4.5
+      vertex 29.2528 5.83335 2
+      vertex 29.2528 5.83335 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.85 3.5 4.5
+      vertex 64.5 3.5 4.5
+      vertex 64.4424 4.08527 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8241 3.76337 4.5
+      vertex 64.4424 4.08527 4.5
+      vertex 64.2716 4.64805 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5 3.5 4.5
+      vertex 62.85 3.5 4.5
+      vertex 64.4424 2.91473 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7472 4.01662 4.5
+      vertex 64.2716 4.64805 4.5
+      vertex 63.9944 5.16671 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.8241 3.23663 4.5
+      vertex 64.4424 2.91473 4.5
+      vertex 62.85 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6225 4.25002 4.5
+      vertex 63.9944 5.16671 4.5
+      vertex 63.6213 5.62132 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4424 2.91473 4.5
+      vertex 62.8241 3.23663 4.5
+      vertex 64.2716 2.35195 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4546 4.45459 4.5
+      vertex 63.6213 5.62132 4.5
+      vertex 63.1667 5.99441 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.7472 2.98338 4.5
+      vertex 64.2716 2.35195 4.5
+      vertex 62.8241 3.23663 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2716 2.35195 4.5
+      vertex 62.7472 2.98338 4.5
+      vertex 63.9944 1.83329 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4424 4.08527 4.5
+      vertex 62.8241 3.76337 4.5
+      vertex 62.85 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2716 4.64805 4.5
+      vertex 62.7472 4.01662 4.5
+      vertex 62.8241 3.76337 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.25 4.62248 4.5
+      vertex 63.1667 5.99441 4.5
+      vertex 62.648 6.27164 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9944 5.16671 4.5
+      vertex 62.6225 4.25002 4.5
+      vertex 62.7472 4.01662 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6213 5.62132 4.5
+      vertex 62.4546 4.45459 4.5
+      vertex 62.6225 4.25002 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1667 5.99441 4.5
+      vertex 62.25 4.62248 4.5
+      vertex 62.4546 4.45459 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.648 6.27164 4.5
+      vertex 62.0166 4.74724 4.5
+      vertex 62.25 4.62248 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7634 4.82406 4.5
+      vertex 62.648 6.27164 4.5
+      vertex 62 6.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.648 6.27164 4.5
+      vertex 61.7634 4.82406 4.5
+      vertex 62.0166 4.74724 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62 6.5 4.5
+      vertex 61.5 4.85 4.5
+      vertex 61.7634 4.82406 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62 6.5 4.5
+      vertex 61.2366 4.82406 4.5
+      vertex 61.5 4.85 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62 6.5 4.5
+      vertex 60.9834 4.74724 4.5
+      vertex 61.2366 4.82406 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.5 6.5 4.5
+      vertex 60.9834 4.74724 4.5
+      vertex 62 6.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9834 4.74724 4.5
+      vertex 58.5 6.5 4.5
+      vertex 60.75 4.62248 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.75 4.62248 4.5
+      vertex 58.5 6.5 4.5
+      vertex 60.5454 4.45459 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.1759 3.76337 4.5
+      vertex 58.5 6.5 4.5
+      vertex 60.15 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.2528 4.01662 4.5
+      vertex 58.5 6.5 4.5
+      vertex 60.1759 3.76337 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3775 4.25002 4.5
+      vertex 58.5 6.5 4.5
+      vertex 60.2528 4.01662 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5454 4.45459 4.5
+      vertex 58.5 6.5 4.5
+      vertex 60.3775 4.25002 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.6225 2.74998 4.5
+      vertex 63.9944 1.83329 4.5
+      vertex 62.7472 2.98338 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9944 1.83329 4.5
+      vertex 62.6225 2.74998 4.5
+      vertex 63.6213 1.37868 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.4546 2.54541 4.5
+      vertex 63.6213 1.37868 4.5
+      vertex 62.6225 2.74998 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6213 1.37868 4.5
+      vertex 62.4546 2.54541 4.5
+      vertex 63.1667 1.00559 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.25 2.37752 4.5
+      vertex 63.1667 1.00559 4.5
+      vertex 62.4546 2.54541 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1667 1.00559 4.5
+      vertex 62.25 2.37752 4.5
+      vertex 62.648 0.728361 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.0166 2.25276 4.5
+      vertex 62.648 0.728361 4.5
+      vertex 62.25 2.37752 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.7634 2.17594 4.5
+      vertex 62.648 0.728361 4.5
+      vertex 62.0166 2.25276 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.648 0.728361 4.5
+      vertex 61.7634 2.17594 4.5
+      vertex 62 0.5 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.5 2.15 4.5
+      vertex 62 0.5 4.5
+      vertex 61.7634 2.17594 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2366 2.17594 4.5
+      vertex 62 0.5 4.5
+      vertex 61.5 2.15 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9834 2.25276 4.5
+      vertex 62 0.5 4.5
+      vertex 61.2366 2.17594 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.75 2.37752 4.5
+      vertex 62 0.5 4.5
+      vertex 60.9834 2.25276 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5454 2.54541 4.5
+      vertex 62 0.5 4.5
+      vertex 60.75 2.37752 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3775 2.74998 4.5
+      vertex 62 0.5 4.5
+      vertex 60.5454 2.54541 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 6.5 4.5
+      vertex 60.1759 3.23663 4.5
+      vertex 60.15 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 6.5 4.5
+      vertex 60.2528 2.98338 4.5
+      vertex 60.1759 3.23663 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5 0.5 4.5
+      vertex 58.5 6.5 4.5
+      vertex 30.5 6.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 6.5 4.5
+      vertex 30.5 0.5 4.5
+      vertex 60.2528 2.98338 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.2528 2.98338 4.5
+      vertex 30.5 0.5 4.5
+      vertex 60.3775 2.74998 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3775 2.74998 4.5
+      vertex 30.5 0.5 4.5
+      vertex 62 0.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 4.5
+      vertex 30.5 6.5 4.5
+      vertex 30.2074 6.47118 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5 6.5 4.5
+      vertex 29 5 4.5
+      vertex 30.5 0.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 4.5
+      vertex 30.2074 6.47118 4.5
+      vertex 29.926 6.38582 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 29 2 4.5
+      vertex 30.5 0.5 4.5
+      vertex 29 5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 4.5
+      vertex 29.926 6.38582 4.5
+      vertex 29.6666 6.2472 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.5 0.5 4.5
+      vertex 29 2 4.5
+      vertex 30.2074 0.528822 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 4.5
+      vertex 29.6666 6.2472 4.5
+      vertex 29.4393 6.06066 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 30.2074 0.528822 4.5
+      vertex 29 2 4.5
+      vertex 29.926 0.614181 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 4.5
+      vertex 29.4393 6.06066 4.5
+      vertex 29.2528 5.83335 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.926 0.614181 4.5
+      vertex 29 2 4.5
+      vertex 29.6666 0.752795 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 4.5
+      vertex 29.2528 5.83335 4.5
+      vertex 29.1142 5.57402 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.6666 0.752795 4.5
+      vertex 29 2 4.5
+      vertex 29.4393 0.93934 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29 5 4.5
+      vertex 29.1142 5.57402 4.5
+      vertex 29.0288 5.29263 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.4393 0.93934 4.5
+      vertex 29 2 4.5
+      vertex 29.2528 1.16664 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.2528 1.16664 4.5
+      vertex 29 2 4.5
+      vertex 29.1142 1.42597 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 29.1142 1.42597 4.5
+      vertex 29 2 4.5
+      vertex 29.0288 1.70736 4.5
+    endloop
+  endfacet
+  facet normal -0.956901 0.290413 0
+    outer loop
+      vertex 29.0288 5.29263 2
+      vertex 29.1142 5.57402 4.5
+      vertex 29.1142 5.57402 2
+    endloop
+  endfacet
+  facet normal -0.956901 0.290413 0
+    outer loop
+      vertex 29.1142 5.57402 4.5
+      vertex 29.0288 5.29263 2
+      vertex 29.0288 5.29263 4.5
+    endloop
+  endfacet
+  facet normal 0.956939 0.290289 0
+    outer loop
+      vertex 8.97118 5.29263 4.5
+      vertex 8.88582 5.57402 2
+      vertex 8.88582 5.57402 4.5
+    endloop
+  endfacet
+  facet normal 0.956939 0.290289 0
+    outer loop
+      vertex 8.88582 5.57402 2
+      vertex 8.97118 5.29263 4.5
+      vertex 8.97118 5.29263 2
+    endloop
+  endfacet
+  facet normal 0.881914 0.471411 0
+    outer loop
+      vertex 8.88582 5.57402 4.5
+      vertex 8.7472 5.83335 2
+      vertex 8.7472 5.83335 4.5
+    endloop
+  endfacet
+  facet normal 0.881914 0.471411 0
+    outer loop
+      vertex 8.7472 5.83335 2
+      vertex 8.88582 5.57402 4.5
+      vertex 8.88582 5.57402 2
+    endloop
+  endfacet
+  facet normal 0.0980187 -0.995185 0
+    outer loop
+      vertex 7.5 0.5 2
+      vertex 7.79263 0.528822 4.5
+      vertex 7.5 0.5 4.5
+    endloop
+  endfacet
+  facet normal 0.0980187 -0.995185 0
+    outer loop
+      vertex 7.79263 0.528822 4.5
+      vertex 7.5 0.5 2
+      vertex 7.79263 0.528822 2
+    endloop
+  endfacet
+  facet normal -0.956941 0.290284 0
+    outer loop
+      vertex 0.557644 4.08527 3
+      vertex 0.728361 4.64805 4.5
+      vertex 0.728361 4.64805 3
+    endloop
+  endfacet
+  facet normal -0.956941 0.290284 0
+    outer loop
+      vertex 0.728361 4.64805 4.5
+      vertex 0.557644 4.08527 3
+      vertex 0.557644 4.08527 4.5
+    endloop
+  endfacet
+  facet normal 0.995185 0.098012 0
+    outer loop
+      vertex 9 5 4.5
+      vertex 8.97118 5.29263 2
+      vertex 8.97118 5.29263 4.5
+    endloop
+  endfacet
+  facet normal 0.995185 0.098012 0
+    outer loop
+      vertex 8.97118 5.29263 2
+      vertex 9 5 4.5
+      vertex 9 5 2
+    endloop
+  endfacet
+  facet normal -0.634395 -0.773009 0
+    outer loop
+      vertex 1.37868 1.37868 1.8
+      vertex 1.83329 1.00559 4.5
+      vertex 1.37868 1.37868 4.5
+    endloop
+  endfacet
+  facet normal -0.634395 -0.773009 -0
+    outer loop
+      vertex 1.83329 1.00559 4.5
+      vertex 1.37868 1.37868 1.8
+      vertex 1.83329 1.00559 1.8
+    endloop
+  endfacet
+  facet normal 0.773025 0.634376 0
+    outer loop
+      vertex 8.7472 5.83335 4.5
+      vertex 8.56066 6.06066 2
+      vertex 8.56066 6.06066 4.5
+    endloop
+  endfacet
+  facet normal 0.773025 0.634376 0
+    outer loop
+      vertex 8.56066 6.06066 2
+      vertex 8.7472 5.83335 4.5
+      vertex 8.7472 5.83335 2
+    endloop
+  endfacet
+  facet normal -0.634395 0.773009 0
+    outer loop
+      vertex 1.83329 5.99441 3
+      vertex 1.37868 5.62132 4.5
+      vertex 1.83329 5.99441 4.5
+    endloop
+  endfacet
+  facet normal -0.634395 0.773009 0
+    outer loop
+      vertex 1.37868 5.62132 4.5
+      vertex 1.83329 5.99441 3
+      vertex 1.37868 5.62132 3
+    endloop
+  endfacet
+  facet normal -0.956941 -0.290284 0
+    outer loop
+      vertex 0.728361 2.35195 1.8
+      vertex 0.557644 2.91473 4.5
+      vertex 0.557644 2.91473 1.8
+    endloop
+  endfacet
+  facet normal -0.956941 -0.290284 0
+    outer loop
+      vertex 0.557644 2.91473 4.5
+      vertex 0.728361 2.35195 1.8
+      vertex 0.728361 2.35195 4.5
+    endloop
+  endfacet
+  facet normal -0.098017 -0.995185 0
+    outer loop
+      vertex 2.91473 0.557644 1.8
+      vertex 3.5 0.5 4.5
+      vertex 2.91473 0.557644 4.5
+    endloop
+  endfacet
+  facet normal -0.098017 -0.995185 -0
+    outer loop
+      vertex 3.5 0.5 4.5
+      vertex 2.91473 0.557644 1.8
+      vertex 3.5 0.5 1.8
+    endloop
+  endfacet
+  facet normal 0.098012 0.995185 -0
+    outer loop
+      vertex 7.79263 6.47118 2
+      vertex 7.5 6.5 4.5
+      vertex 7.79263 6.47118 4.5
+    endloop
+  endfacet
+  facet normal 0.098012 0.995185 0
+    outer loop
+      vertex 7.5 6.5 4.5
+      vertex 7.79263 6.47118 2
+      vertex 7.5 6.5 2
+    endloop
+  endfacet
+  facet normal -0.881922 -0.471396 0
+    outer loop
+      vertex 1.00559 1.83329 1.8
+      vertex 0.728361 2.35195 4.5
+      vertex 0.728361 2.35195 1.8
+    endloop
+  endfacet
+  facet normal -0.881922 -0.471396 0
+    outer loop
+      vertex 0.728361 2.35195 4.5
+      vertex 1.00559 1.83329 1.8
+      vertex 1.00559 1.83329 4.5
+    endloop
+  endfacet
+  facet normal -0.773009 0.634395 0
+    outer loop
+      vertex 1.00559 5.16671 3
+      vertex 1.37868 5.62132 4.5
+      vertex 1.37868 5.62132 3
+    endloop
+  endfacet
+  facet normal -0.773009 0.634395 0
+    outer loop
+      vertex 1.37868 5.62132 4.5
+      vertex 1.00559 5.16671 3
+      vertex 1.00559 5.16671 4.5
+    endloop
+  endfacet
+  facet normal 0.290289 0.956939 -0
+    outer loop
+      vertex 8.07402 6.38582 2
+      vertex 7.79263 6.47118 4.5
+      vertex 8.07402 6.38582 4.5
+    endloop
+  endfacet
+  facet normal 0.290289 0.956939 0
+    outer loop
+      vertex 7.79263 6.47118 4.5
+      vertex 8.07402 6.38582 2
+      vertex 7.79263 6.47118 2
+    endloop
+  endfacet
+  facet normal 0.634386 -0.773016 0
+    outer loop
+      vertex 8.33335 0.752795 2
+      vertex 8.56066 0.93934 4.5
+      vertex 8.33335 0.752795 4.5
+    endloop
+  endfacet
+  facet normal 0.634386 -0.773016 0
+    outer loop
+      vertex 8.56066 0.93934 4.5
+      vertex 8.33335 0.752795 2
+      vertex 8.56066 0.93934 2
+    endloop
+  endfacet
+  facet normal 0.956939 -0.290289 0
+    outer loop
+      vertex 8.88582 1.42597 4.5
+      vertex 8.97118 1.70736 2
+      vertex 8.97118 1.70736 4.5
+    endloop
+  endfacet
+  facet normal 0.956939 -0.290289 0
+    outer loop
+      vertex 8.97118 1.70736 2
+      vertex 8.88582 1.42597 4.5
+      vertex 8.88582 1.42597 2
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980188 0
+    outer loop
+      vertex 0.513922 3.35865 1.8
+      vertex 0.5 3.5 3
+      vertex 0.5 3.5 0
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980188 -0
+    outer loop
+      vertex 0.513922 3.35865 1.8
+      vertex 0.5 3.5 0
+      vertex 0.513922 3.35865 0
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980165 -2.79367e-07
+    outer loop
+      vertex 0.557644 2.91473 1.8
+      vertex 0.5 3.5 3
+      vertex 0.513922 3.35865 1.8
+    endloop
+  endfacet
+  facet normal -0.995185 -0.098017 0
+    outer loop
+      vertex 0.5 3.5 3
+      vertex 0.557644 2.91473 1.8
+      vertex 0.557644 2.91473 4.5
+    endloop
+  endfacet
+  facet normal -0.995185 -0.098017 0
+    outer loop
+      vertex 0.5 3.5 3
+      vertex 0.557644 2.91473 4.5
+      vertex 0.5 3.5 4.5
+    endloop
+  endfacet
+  facet normal -0.471397 0.881921 0
+    outer loop
+      vertex 2.35195 6.27164 3
+      vertex 1.83329 5.99441 4.5
+      vertex 2.35195 6.27164 4.5
+    endloop
+  endfacet
+  facet normal -0.471397 0.881921 0
+    outer loop
+      vertex 1.83329 5.99441 4.5
+      vertex 2.35195 6.27164 3
+      vertex 1.83329 5.99441 3
+    endloop
+  endfacet
+  facet normal 0.995186 -0.0980086 0
+    outer loop
+      vertex 8.97118 1.70736 4.5
+      vertex 9 2 2
+      vertex 9 2 4.5
+    endloop
+  endfacet
+  facet normal 0.995186 -0.0980086 0
+    outer loop
+      vertex 9 2 2
+      vertex 8.97118 1.70736 4.5
+      vertex 8.97118 1.70736 2
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 9 2 4.5
+      vertex 9 5 2
+      vertex 9 5 4.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 9 5 2
+      vertex 9 2 4.5
+      vertex 9 2 2
+    endloop
+  endfacet
+  facet normal -0.471396 -0.881922 0
+    outer loop
+      vertex 1.83329 1.00559 1.8
+      vertex 2.35195 0.728361 4.5
+      vertex 1.83329 1.00559 4.5
+    endloop
+  endfacet
+  facet normal -0.471396 -0.881922 -0
+    outer loop
+      vertex 2.35195 0.728361 4.5
+      vertex 1.83329 1.00559 1.8
+      vertex 2.35195 0.728361 1.8
+    endloop
+  endfacet
+  facet normal 0.471411 0.881914 -0
+    outer loop
+      vertex 8.33335 6.2472 2
+      vertex 8.07402 6.38582 4.5
+      vertex 8.33335 6.2472 4.5
+    endloop
+  endfacet
+  facet normal 0.471411 0.881914 0
+    outer loop
+      vertex 8.07402 6.38582 4.5
+      vertex 8.33335 6.2472 2
+      vertex 8.07402 6.38582 2
+    endloop
+  endfacet
+  facet normal -0.773009 -0.634395 0
+    outer loop
+      vertex 1.37868 1.37868 1.8
+      vertex 1.00559 1.83329 4.5
+      vertex 1.00559 1.83329 1.8
+    endloop
+  endfacet
+  facet normal -0.773009 -0.634395 0
+    outer loop
+      vertex 1.00559 1.83329 4.5
+      vertex 1.37868 1.37868 1.8
+      vertex 1.37868 1.37868 4.5
+    endloop
+  endfacet
+  facet normal 0.471395 -0.881922 0
+    outer loop
+      vertex 8.07402 0.614181 2
+      vertex 8.33335 0.752795 4.5
+      vertex 8.07402 0.614181 4.5
+    endloop
+  endfacet
+  facet normal 0.471395 -0.881922 0
+    outer loop
+      vertex 8.33335 0.752795 4.5
+      vertex 8.07402 0.614181 2
+      vertex 8.33335 0.752795 2
+    endloop
+  endfacet
+  facet normal 0.881914 -0.471411 0
+    outer loop
+      vertex 8.7472 1.16664 4.5
+      vertex 8.88582 1.42597 2
+      vertex 8.88582 1.42597 4.5
+    endloop
+  endfacet
+  facet normal 0.881914 -0.471411 0
+    outer loop
+      vertex 8.88582 1.42597 2
+      vertex 8.7472 1.16664 4.5
+      vertex 8.7472 1.16664 2
+    endloop
+  endfacet
+  facet normal -0.881922 0.471396 0
+    outer loop
+      vertex 0.728361 4.64805 3
+      vertex 1.00559 5.16671 4.5
+      vertex 1.00559 5.16671 3
+    endloop
+  endfacet
+  facet normal -0.881922 0.471396 0
+    outer loop
+      vertex 1.00559 5.16671 4.5
+      vertex 0.728361 4.64805 3
+      vertex 0.728361 4.64805 4.5
+    endloop
+  endfacet
+  facet normal -0.995185 0.098017 0
+    outer loop
+      vertex 0.5 3.5 3
+      vertex 0.557644 4.08527 4.5
+      vertex 0.557644 4.08527 3
+    endloop
+  endfacet
+  facet normal -0.995185 0.098017 0
+    outer loop
+      vertex 0.557644 4.08527 4.5
+      vertex 0.5 3.5 3
+      vertex 0.5 3.5 4.5
+    endloop
+  endfacet
+  facet normal -0.290284 -0.956941 0
+    outer loop
+      vertex 2.35195 0.728361 1.8
+      vertex 2.91473 0.557644 4.5
+      vertex 2.35195 0.728361 4.5
+    endloop
+  endfacet
+  facet normal -0.290284 -0.956941 -0
+    outer loop
+      vertex 2.91473 0.557644 4.5
+      vertex 2.35195 0.728361 1.8
+      vertex 2.91473 0.557644 1.8
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9 5 4.5
+      vertex 4.82406 3.76337 4.5
+      vertex 4.85 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 6.5 4.5
+      vertex 4.74724 4.01662 4.5
+      vertex 4.82406 3.76337 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 6.5 4.5
+      vertex 4.62248 4.25002 4.5
+      vertex 4.74724 4.01662 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 6.5 4.5
+      vertex 4.45459 4.45459 4.5
+      vertex 4.62248 4.25002 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 6.5 4.5
+      vertex 4.25002 4.62248 4.5
+      vertex 4.45459 4.45459 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.5 6.5 4.5
+      vertex 4.25002 4.62248 4.5
+      vertex 6.5 6.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.25002 4.62248 4.5
+      vertex 3.5 6.5 4.5
+      vertex 4.01662 4.74724 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01662 4.74724 4.5
+      vertex 3.5 6.5 4.5
+      vertex 3.76337 4.82406 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 6.5 4.5
+      vertex 3.5 4.85 4.5
+      vertex 3.76337 4.82406 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 6.5 4.5
+      vertex 3.23663 4.82406 4.5
+      vertex 3.5 4.85 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.91473 6.44236 4.5
+      vertex 3.23663 4.82406 4.5
+      vertex 3.5 6.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23663 4.82406 4.5
+      vertex 2.91473 6.44236 4.5
+      vertex 2.98338 4.74724 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.35195 6.27164 4.5
+      vertex 2.98338 4.74724 4.5
+      vertex 2.91473 6.44236 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98338 4.74724 4.5
+      vertex 2.35195 6.27164 4.5
+      vertex 2.74998 4.62248 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.83329 5.99441 4.5
+      vertex 2.74998 4.62248 4.5
+      vertex 2.35195 6.27164 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.74998 4.62248 4.5
+      vertex 1.83329 5.99441 4.5
+      vertex 2.54541 4.45459 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.37868 5.62132 4.5
+      vertex 2.54541 4.45459 4.5
+      vertex 1.83329 5.99441 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54541 4.45459 4.5
+      vertex 1.37868 5.62132 4.5
+      vertex 2.37752 4.25002 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.00559 5.16671 4.5
+      vertex 2.37752 4.25002 4.5
+      vertex 1.37868 5.62132 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.37752 4.25002 4.5
+      vertex 1.00559 5.16671 4.5
+      vertex 2.25276 4.01662 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 6.5 4.5
+      vertex 9 5 4.5
+      vertex 8.97118 5.29263 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9 5 4.5
+      vertex 4.85 3.5 4.5
+      vertex 9 2 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 6.5 4.5
+      vertex 8.97118 5.29263 4.5
+      vertex 8.88582 5.57402 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.82406 3.23663 4.5
+      vertex 9 2 4.5
+      vertex 4.85 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.5 6.5 4.5
+      vertex 8.88582 5.57402 4.5
+      vertex 8.7472 5.83335 4.5
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex 56.7773 -23.2599 1.5
-      vertex 56.7773 -22.7401 1.5
-      vertex 56.75 -23 1.5
+      vertex 7.5 0.5 4.5
+      vertex 9 2 4.5
+      vertex 4.82406 3.23663 4.5
     endloop
   endfacet
-  facet normal -0.994523 -0.10452 0
+  facet normal 0 0 1
     outer loop
-      vertex 56.7773 -23.2599 2.84851e-15
-      vertex 56.75 -23 1.5
-      vertex 56.75 -23 2.81669e-15
+      vertex 7.5 6.5 4.5
+      vertex 8.7472 5.83335 4.5
+      vertex 8.56066 6.06066 4.5
     endloop
   endfacet
-  facet normal -0.994523 -0.10452 0
+  facet normal 0 0 1
     outer loop
-      vertex 56.75 -23 1.5
-      vertex 56.7773 -23.2599 2.84851e-15
-      vertex 56.7773 -23.2599 1.5
+      vertex 9 2 4.5
+      vertex 7.5 0.5 4.5
+      vertex 8.97118 1.70736 4.5
     endloop
   endfacet
-  facet normal -0.743146 -0.669129 0
+  facet normal 0 0 1
     outer loop
-      vertex 57.1636 -23.9289 2.93045e-15
-      vertex 56.9887 -23.7347 1.5
-      vertex 56.9887 -23.7347 2.90667e-15
+      vertex 7.5 6.5 4.5
+      vertex 8.56066 6.06066 4.5
+      vertex 8.33335 6.2472 4.5
     endloop
   endfacet
-  facet normal -0.743146 -0.669129 0
+  facet normal 0 0 1
     outer loop
-      vertex 56.9887 -23.7347 1.5
-      vertex 57.1636 -23.9289 2.93045e-15
-      vertex 57.1636 -23.9289 1.5
+      vertex 8.97118 1.70736 4.5
+      vertex 7.5 0.5 4.5
+      vertex 8.88582 1.42597 4.5
     endloop
   endfacet
-  facet normal -0.406738 -0.913545 0
+  facet normal 0 0 1
     outer loop
-      vertex 57.375 -24.0825 1.5
-      vertex 57.6137 -24.1888 2.96228e-15
-      vertex 57.6137 -24.1888 1.5
+      vertex 7.5 6.5 4.5
+      vertex 8.33335 6.2472 4.5
+      vertex 8.07402 6.38582 4.5
     endloop
   endfacet
-  facet normal -0.406738 -0.913545 0
+  facet normal 0 0 1
     outer loop
-      vertex 57.6137 -24.1888 2.96228e-15
-      vertex 57.375 -24.0825 1.5
-      vertex 57.375 -24.0825 2.94926e-15
+      vertex 8.88582 1.42597 4.5
+      vertex 7.5 0.5 4.5
+      vertex 8.7472 1.16664 4.5
     endloop
   endfacet
-  facet normal 0.994521 0.104534 0
+  facet normal 0 0 1
     outer loop
-      vertex 59.25 -23 1.5
-      vertex 59.2227 -22.7401 2.78486e-15
-      vertex 59.2227 -22.7401 1.5
+      vertex 7.5 6.5 4.5
+      vertex 8.07402 6.38582 4.5
+      vertex 7.79263 6.47118 4.5
     endloop
   endfacet
-  facet normal 0.994521 0.104534 0
+  facet normal 0 0 1
     outer loop
-      vertex 59.2227 -22.7401 2.78486e-15
-      vertex 59.25 -23 1.5
-      vertex 59.25 -23 2.81669e-15
+      vertex 8.7472 1.16664 4.5
+      vertex 7.5 0.5 4.5
+      vertex 8.56066 0.93934 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9 5 4.5
+      vertex 7.5 6.5 4.5
+      vertex 6.5 6.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.56066 0.93934 4.5
+      vertex 7.5 0.5 4.5
+      vertex 8.33335 0.752795 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.82406 3.76337 4.5
+      vertex 9 5 4.5
+      vertex 6.5 6.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.33335 0.752795 4.5
+      vertex 7.5 0.5 4.5
+      vertex 8.07402 0.614181 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.07402 0.614181 4.5
+      vertex 7.5 0.5 4.5
+      vertex 7.79263 0.528822 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.74724 2.98338 4.5
+      vertex 7.5 0.5 4.5
+      vertex 4.82406 3.23663 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.62248 2.74998 4.5
+      vertex 7.5 0.5 4.5
+      vertex 4.74724 2.98338 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.45459 2.54541 4.5
+      vertex 7.5 0.5 4.5
+      vertex 4.62248 2.74998 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.25002 2.37752 4.5
+      vertex 7.5 0.5 4.5
+      vertex 4.45459 2.54541 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 0.5 4.5
+      vertex 4.25002 2.37752 4.5
+      vertex 4.01662 2.25276 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 0.5 4.5
+      vertex 4.01662 2.25276 4.5
+      vertex 3.76337 2.17594 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 0.5 4.5
+      vertex 3.76337 2.17594 4.5
+      vertex 3.5 2.15 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.25002 2.37752 4.5
+      vertex 3.5 0.5 4.5
+      vertex 7.5 0.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23663 2.17594 4.5
+      vertex 3.5 0.5 4.5
+      vertex 3.5 2.15 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.91473 0.557644 4.5
+      vertex 3.23663 2.17594 4.5
+      vertex 2.98338 2.25276 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23663 2.17594 4.5
+      vertex 2.91473 0.557644 4.5
+      vertex 3.5 0.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.35195 0.728361 4.5
+      vertex 2.98338 2.25276 4.5
+      vertex 2.74998 2.37752 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.83329 1.00559 4.5
+      vertex 2.74998 2.37752 4.5
+      vertex 2.54541 2.54541 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.37868 1.37868 4.5
+      vertex 2.54541 2.54541 4.5
+      vertex 2.37752 2.74998 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98338 2.25276 4.5
+      vertex 2.35195 0.728361 4.5
+      vertex 2.91473 0.557644 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.00559 1.83329 4.5
+      vertex 2.37752 2.74998 4.5
+      vertex 2.25276 2.98338 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.728361 2.35195 4.5
+      vertex 2.25276 2.98338 4.5
+      vertex 2.17594 3.23663 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.557644 2.91473 4.5
+      vertex 2.17594 3.23663 4.5
+      vertex 2.15 3.5 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.728361 4.64805 4.5
+      vertex 2.25276 4.01662 4.5
+      vertex 1.00559 5.16671 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.74998 2.37752 4.5
+      vertex 1.83329 1.00559 4.5
+      vertex 2.35195 0.728361 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.25276 4.01662 4.5
+      vertex 0.728361 4.64805 4.5
+      vertex 2.17594 3.76337 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54541 2.54541 4.5
+      vertex 1.37868 1.37868 4.5
+      vertex 1.83329 1.00559 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.557644 4.08527 4.5
+      vertex 2.17594 3.76337 4.5
+      vertex 0.728361 4.64805 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.37752 2.74998 4.5
+      vertex 1.00559 1.83329 4.5
+      vertex 1.37868 1.37868 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.17594 3.76337 4.5
+      vertex 0.557644 4.08527 4.5
+      vertex 2.15 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.25276 2.98338 4.5
+      vertex 0.728361 2.35195 4.5
+      vertex 1.00559 1.83329 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 3.5 4.5
+      vertex 2.15 3.5 4.5
+      vertex 0.557644 4.08527 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.17594 3.23663 4.5
+      vertex 0.557644 2.91473 4.5
+      vertex 0.728361 2.35195 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.15 3.5 4.5
+      vertex 0.5 3.5 4.5
+      vertex 0.557644 2.91473 4.5
+    endloop
+  endfacet
+  facet normal -0.0980103 0.995185 0
+    outer loop
+      vertex 3.5 6.5 3
+      vertex 2.91473 6.44236 4.5
+      vertex 3.5 6.5 4.5
+    endloop
+  endfacet
+  facet normal -0.0980103 0.995185 0
+    outer loop
+      vertex 2.91473 6.44236 4.5
+      vertex 3.5 6.5 3
+      vertex 2.91473 6.44236 3
+    endloop
+  endfacet
+  facet normal 0.773011 -0.634393 0
+    outer loop
+      vertex 8.56066 0.93934 4.5
+      vertex 8.7472 1.16664 2
+      vertex 8.7472 1.16664 4.5
+    endloop
+  endfacet
+  facet normal 0.773011 -0.634393 0
+    outer loop
+      vertex 8.7472 1.16664 2
+      vertex 8.56066 0.93934 4.5
+      vertex 8.56066 0.93934 2
+    endloop
+  endfacet
+  facet normal 0.634376 0.773025 -0
+    outer loop
+      vertex 8.56066 6.06066 2
+      vertex 8.33335 6.2472 4.5
+      vertex 8.56066 6.06066 4.5
+    endloop
+  endfacet
+  facet normal 0.634376 0.773025 0
+    outer loop
+      vertex 8.33335 6.2472 4.5
+      vertex 8.56066 6.06066 2
+      vertex 8.33335 6.2472 2
+    endloop
+  endfacet
+  facet normal 0.290286 -0.95694 0
+    outer loop
+      vertex 7.79263 0.528822 2
+      vertex 8.07402 0.614181 4.5
+      vertex 7.79263 0.528822 4.5
+    endloop
+  endfacet
+  facet normal 0.290286 -0.95694 0
+    outer loop
+      vertex 8.07402 0.614181 4.5
+      vertex 7.79263 0.528822 2
+      vertex 8.07402 0.614181 2
+    endloop
+  endfacet
+  facet normal -0.290289 0.956939 0
+    outer loop
+      vertex 2.91473 6.44236 3
+      vertex 2.35195 6.27164 4.5
+      vertex 2.91473 6.44236 4.5
+    endloop
+  endfacet
+  facet normal -0.290289 0.956939 0
+    outer loop
+      vertex 2.35195 6.27164 4.5
+      vertex 2.91473 6.44236 3
+      vertex 2.35195 6.27164 3
+    endloop
+  endfacet
+  facet normal 0.097938 0.995193 0
+    outer loop
+      vertex 62.0853 29.4424 4.5
+      vertex 61.5 29.5 2.4
+      vertex 61.5 29.5 4.5
+    endloop
+  endfacet
+  facet normal 0.097938 0.995193 -0
+    outer loop
+      vertex 62.0853 29.4424 0
+      vertex 61.5 29.5 2.4
+      vertex 62.0853 29.4424 4.5
+    endloop
+  endfacet
+  facet normal 0.097938 0.995193 0
+    outer loop
+      vertex 61.5 29.5 2.4
+      vertex 62.0853 29.4424 0
+      vertex 61.5 29.5 0
+    endloop
+  endfacet
+  facet normal 0.097938 -0.995193 0
+    outer loop
+      vertex 61.5 23.5 3.3
+      vertex 62.0853 23.5576 4.5
+      vertex 61.5 23.5 4.5
+    endloop
+  endfacet
+  facet normal 0.097938 -0.995193 0
+    outer loop
+      vertex 62.0853 23.5576 4.5
+      vertex 61.5 23.5 3.3
+      vertex 62.0853 23.5576 3.3
+    endloop
+  endfacet
+  facet normal -0.0979877 -0.995188 0
+    outer loop
+      vertex 25.9025 23.5096 2
+      vertex 26 23.5 2.4
+      vertex 25.9025 23.5096 2.4
+    endloop
+  endfacet
+  facet normal -0.0979877 -0.995188 -0
+    outer loop
+      vertex 26 23.5 2.4
+      vertex 25.9025 23.5096 2
+      vertex 26 23.5 2
+    endloop
+  endfacet
+  facet normal 0.290451 -0.95689 0
+    outer loop
+      vertex 62.0853 23.5576 3.3
+      vertex 62.648 23.7284 4.5
+      vertex 62.0853 23.5576 4.5
+    endloop
+  endfacet
+  facet normal 0.290451 -0.95689 0
+    outer loop
+      vertex 62.648 23.7284 4.5
+      vertex 62.0853 23.5576 3.3
+      vertex 62.648 23.7284 3.3
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 58.1307 -21.7568 2.66445e-15
-      vertex 57.8693 -21.7568 1.5
-      vertex 58.1307 -21.7568 1.5
+      vertex 51.7 29.5 0
+      vertex 37.7 29.5 2.1
+      vertex 51.7 29.5 2.1
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 57.8693 -21.7568 1.5
-      vertex 58.1307 -21.7568 2.66445e-15
-      vertex 57.8693 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal -0.951055 0.309021 0
-    outer loop
-      vertex 56.7773 -22.7401 2.78486e-15
-      vertex 56.8581 -22.4916 1.5
-      vertex 56.8581 -22.4916 2.75442e-15
-    endloop
-  endfacet
-  facet normal -0.951055 0.309021 0
-    outer loop
-      vertex 56.8581 -22.4916 1.5
-      vertex 56.7773 -22.7401 2.78486e-15
-      vertex 56.7773 -22.7401 1.5
-    endloop
-  endfacet
-  facet normal 0.406733 0.913547 -1.16164e-06
-    outer loop
-      vertex 58.625 -21.9175 2.68412e-15
-      vertex 58.3863 -21.8112 1.5
-      vertex 58.625 -21.9175 1.5
-    endloop
-  endfacet
-  facet normal 0.406733 0.913547 -1.16164e-06
-    outer loop
-      vertex 58.3863 -21.8112 1.5
-      vertex 58.625 -21.9175 2.68412e-15
-      vertex 58.3863 -21.8112 2.6711e-15
-    endloop
-  endfacet
-  facet normal 0.951055 0.309021 0
-    outer loop
-      vertex 59.2227 -22.7401 1.5
-      vertex 59.1419 -22.4916 2.75442e-15
-      vertex 59.1419 -22.4916 1.5
-    endloop
-  endfacet
-  facet normal 0.951055 0.309021 0
-    outer loop
-      vertex 59.1419 -22.4916 2.75442e-15
-      vertex 59.2227 -22.7401 1.5
-      vertex 59.2227 -22.7401 2.78486e-15
-    endloop
-  endfacet
-  facet normal -0.994523 0.104519 0
-    outer loop
-      vertex 56.75 -23 2.81669e-15
-      vertex 56.7773 -22.7401 1.5
-      vertex 56.7773 -22.7401 2.78486e-15
-    endloop
-  endfacet
-  facet normal -0.994523 0.104519 0
-    outer loop
-      vertex 56.7773 -22.7401 1.5
-      vertex 56.75 -23 2.81669e-15
-      vertex 56.75 -23 1.5
-    endloop
-  endfacet
-  facet normal -0.743146 0.669129 0
-    outer loop
-      vertex 56.9887 -22.2653 2.72671e-15
-      vertex 57.1636 -22.0711 1.5
-      vertex 57.1636 -22.0711 2.70293e-15
-    endloop
-  endfacet
-  facet normal -0.743146 0.669129 0
-    outer loop
-      vertex 57.1636 -22.0711 1.5
-      vertex 56.9887 -22.2653 2.72671e-15
-      vertex 56.9887 -22.2653 1.5
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex 56.8581 -22.4916 2.75442e-15
-      vertex 56.9887 -22.2653 1.5
-      vertex 56.9887 -22.2653 2.72671e-15
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex 56.9887 -22.2653 1.5
-      vertex 56.8581 -22.4916 2.75442e-15
-      vertex 56.8581 -22.4916 1.5
-    endloop
-  endfacet
-  facet normal 0.743146 0.669129 0
-    outer loop
-      vertex 59.0113 -22.2653 1.5
-      vertex 58.8364 -22.0711 2.70293e-15
-      vertex 58.8364 -22.0711 1.5
-    endloop
-  endfacet
-  facet normal 0.743146 0.669129 0
-    outer loop
-      vertex 58.8364 -22.0711 2.70293e-15
-      vertex 59.0113 -22.2653 1.5
-      vertex 59.0113 -22.2653 2.72671e-15
-    endloop
-  endfacet
-  facet normal 0.58779 0.809013 -0
-    outer loop
-      vertex 58.8364 -22.0711 2.70293e-15
-      vertex 58.625 -21.9175 1.5
-      vertex 58.8364 -22.0711 1.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 -1.02872e-06
-    outer loop
-      vertex 58.625 -21.9175 1.5
-      vertex 58.8364 -22.0711 2.70293e-15
-      vertex 58.625 -21.9175 2.68412e-15
-    endloop
-  endfacet
-  facet normal 0.207911 0.978148 -1.24378e-06
-    outer loop
-      vertex 58.3863 -21.8112 2.6711e-15
-      vertex 58.1307 -21.7568 1.5
-      vertex 58.3863 -21.8112 1.5
-    endloop
-  endfacet
-  facet normal 0.207918 0.978146 0
-    outer loop
-      vertex 58.1307 -21.7568 1.5
-      vertex 58.3863 -21.8112 2.6711e-15
-      vertex 58.1307 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal -0.207908 0.978148 -1.24378e-06
-    outer loop
-      vertex 57.8693 -21.7568 1.5
-      vertex 57.6137 -21.8112 2.6711e-15
-      vertex 57.6137 -21.8112 1.5
-    endloop
-  endfacet
-  facet normal -0.207915 0.978147 0
-    outer loop
-      vertex 57.6137 -21.8112 2.6711e-15
-      vertex 57.8693 -21.7568 1.5
-      vertex 57.8693 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal -0.587783 0.809018 0
-    outer loop
-      vertex 57.375 -21.9175 1.5
-      vertex 57.1636 -22.0711 2.70293e-15
-      vertex 57.1636 -22.0711 1.5
-    endloop
-  endfacet
-  facet normal -0.587778 0.809022 -1.02872e-06
-    outer loop
-      vertex 57.1636 -22.0711 2.70293e-15
-      vertex 57.375 -21.9175 1.5
-      vertex 57.375 -21.9175 2.68412e-15
-    endloop
-  endfacet
-  facet normal -0.406738 0.913545 -1.16163e-06
-    outer loop
-      vertex 57.6137 -21.8112 1.5
-      vertex 57.375 -21.9175 2.68412e-15
-      vertex 57.375 -21.9175 1.5
-    endloop
-  endfacet
-  facet normal -0.406738 0.913545 -1.16163e-06
-    outer loop
-      vertex 57.375 -21.9175 2.68412e-15
-      vertex 57.6137 -21.8112 1.5
-      vertex 57.6137 -21.8112 2.6711e-15
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 1.10638e-17
-    outer loop
-      vertex 2.93444 -0.623734 7.63854e-17
-      vertex 3 -2.44929e-16 -2
-      vertex 3 0 0
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 3 -2.44929e-16 -2
-      vertex 2.93444 -0.623734 7.63854e-17
-      vertex 2.93444 -0.623734 -2
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 1.10638e-17
-    outer loop
-      vertex -2.93444 -0.623734 -2
-      vertex -3 0 0
-      vertex -3 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex -3 0 0
-      vertex -2.93444 -0.623734 -2
-      vertex -2.93444 -0.623734 7.63854e-17
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.313585 -2.98357 -2
-      vertex 0.313585 -2.98357 3.65381e-16
-      vertex -0.313585 -2.98357 3.65381e-16
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 0.313585 -2.98357 3.65381e-16
-      vertex -0.313585 -2.98357 -2
-      vertex 0.313585 -2.98357 -2
+      vertex 26 29.5 2
+      vertex 18.5 29.5 1.1
+      vertex 18.5 29.5 2
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0 2.98357 -3
-      vertex 0.313585 2.98357 -3.65381e-16
-      vertex 0.313585 2.98357 -3
+      vertex 37.7 29.5 2.1
+      vertex 51.7 29.5 0
+      vertex 26 29.5 2
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0.313585 2.98357 -3.65381e-16
-      vertex 0 2.98357 -3
-      vertex -0.313585 2.98357 -3.65381e-16
+      vertex 3.5 29.5 0
+      vertex 18.5 29.5 1.1
+      vertex 51.7 29.5 0
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.313585 2.98357 -4.5
-      vertex 0 2.98357 -3
-      vertex 0 2.98357 -4.5
+      vertex 26 29.5 2
+      vertex 51.7 29.5 0
+      vertex 18.5 29.5 1.1
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0 2.98357 -3
-      vertex -0.313585 2.98357 -4.5
-      vertex -0.313585 2.98357 -3.65381e-16
-    endloop
-  endfacet
-  facet normal 0.587786 -0.809016 0
-    outer loop
-      vertex 1.5 -2.59808 -2
-      vertex 2.00739 -2.22943 2.73027e-16
-      vertex 1.5 -2.59808 3.18173e-16
-    endloop
-  endfacet
-  facet normal 0.587786 -0.809016 0
-    outer loop
-      vertex 2.00739 -2.22943 2.73027e-16
-      vertex 1.5 -2.59808 -2
-      vertex 2.00739 -2.22943 -2
-    endloop
-  endfacet
-  facet normal 0.406737 -0.913545 0
-    outer loop
-      vertex 0.927051 -2.85317 -2
-      vertex 1.5 -2.59808 3.18173e-16
-      vertex 0.927051 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal 0.406737 -0.913545 0
-    outer loop
-      vertex 1.5 -2.59808 3.18173e-16
-      vertex 0.927051 -2.85317 -2
-      vertex 1.5 -2.59808 -2
-    endloop
-  endfacet
-  facet normal -0.743144 -0.669131 0
-    outer loop
-      vertex -2.00739 -2.22943 -2
-      vertex -2.42705 -1.76336 2.15949e-16
-      vertex -2.42705 -1.76336 -2
-    endloop
-  endfacet
-  facet normal -0.743144 -0.669131 0
-    outer loop
-      vertex -2.42705 -1.76336 2.15949e-16
-      vertex -2.00739 -2.22943 -2
-      vertex -2.00739 -2.22943 2.73027e-16
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.3475 -14.2347 -4.5
-      vertex 3 -14.1749 -4.5
-      vertex 2.94613 -14.2347 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.54312 -4.52281 -4.5
-      vertex 3 -3 -4.5
-      vertex -2.48551 -4.70152 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex -2.48551 -2.55602 -4.5
-      vertex -2.465 -2.36949 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.54312 -2.7357 -4.5
-      vertex 3 -3 -4.5
-      vertex -2.54312 -4.52281 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex -2.54312 -2.7357 -4.5
-      vertex -2.48551 -2.55602 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.63687 -4.35973 -4.5
-      vertex -2.54312 -2.7357 -4.5
-      vertex -2.54312 -4.52281 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.63687 -4.35973 -4.5
-      vertex -2.63687 -2.89781 -4.5
-      vertex -2.54312 -2.7357 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.76285 -4.22008 -4.5
-      vertex -2.63687 -2.89781 -4.5
-      vertex -2.63687 -4.35973 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.76285 -4.22008 -4.5
-      vertex -2.76285 -3.03844 -4.5
-      vertex -2.63687 -2.89781 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.91519 -4.10973 -4.5
-      vertex -2.76285 -3.03844 -4.5
-      vertex -2.76285 -4.22008 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.91519 -4.10973 -4.5
-      vertex -2.91519 -3.14879 -4.5
-      vertex -2.76285 -3.03844 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -4.07166 -4.5
-      vertex -2.91519 -3.14879 -4.5
-      vertex -2.91519 -4.10973 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.91519 -3.14879 -4.5
-      vertex -3 -4.07166 -4.5
-      vertex -3 -3.18637 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.574062 -14.0482 -4.5
-      vertex -0.360507 -14.0482 -4.5
-      vertex 0.777187 -13.9007 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.563632 -13.9007 -4.5
-      vertex 0.777187 -13.9007 -4.5
-      vertex -0.360507 -14.0482 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.48551 -4.70152 -4.5
-      vertex 3 -3 -4.5
-      vertex -2.465 -4.88902 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.792148 -13.7982 -4.5
-      vertex 0.777187 -13.9007 -4.5
-      vertex -0.563632 -13.9007 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.777187 -13.9007 -4.5
-      vertex -2.63687 -5.41832 -4.5
-      vertex 3 -3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.76285 -5.55797 -4.5
-      vertex 0.777187 -13.9007 -4.5
-      vertex -0.792148 -13.7982 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.48551 -2.18199 -4.5
-      vertex 3 -3 -4.5
-      vertex -2.465 -2.36949 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.76285 -5.55797 -4.5
-      vertex -0.792148 -13.7982 -4.5
-      vertex -1.03726 -13.7464 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.91519 -5.66832 -4.5
-      vertex -1.03726 -13.7464 -4.5
-      vertex -1.28824 -13.7464 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.54312 -2.00328 -4.5
-      vertex 3 -3 -4.5
-      vertex -2.48551 -2.18199 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -5.7059 -4.5
-      vertex -1.28824 -13.7464 -4.5
-      vertex -1.53434 -13.7982 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -5.7059 -4.5
-      vertex -1.53434 -13.7982 -4.5
-      vertex -1.76285 -13.9007 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -14.3 -4.5
-      vertex -1.76285 -13.9007 -4.5
-      vertex -1.96598 -14.0482 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex -2.54312 -2.00328 -4.5
-      vertex 0 2.98357 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -14.3 -4.5
-      vertex -1.96598 -14.0482 -4.5
-      vertex -2.13394 -14.2347 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -14.3 -4.5
-      vertex -2.13394 -14.2347 -4.5
-      vertex -2.17187 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -5.51091e-16 -4.5
-      vertex 0 2.98357 -4.5
-      vertex -2.54312 -2.00328 -4.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -1.5 2.59808 -4.5
-      vertex 0 2.98357 -4.5
-      vertex -3 -5.51091e-16 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex -2.48551 -5.07555 -4.5
-      vertex -2.465 -4.88902 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex -2.54312 -5.25523 -4.5
-      vertex -2.48551 -5.07555 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex -2.63687 -5.41832 -4.5
-      vertex -2.54312 -5.25523 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.777187 -13.9007 -4.5
-      vertex -2.76285 -5.55797 -4.5
-      vertex -2.63687 -5.41832 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.03726 -13.7464 -4.5
-      vertex -2.91519 -5.66832 -4.5
-      vertex -2.76285 -5.55797 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.76285 -13.9007 -4.5
-      vertex -3 -14.3 -4.5
-      vertex -3 -5.7059 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.28824 -13.7464 -4.5
-      vertex -3 -5.7059 -4.5
-      vertex -2.91519 -5.66832 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0 2.98357 -4.5
-      vertex -0.927051 2.85317 -4.5
-      vertex -0.313585 2.98357 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 2.98357 -4.5
-      vertex -1.5 2.59808 -4.5
-      vertex -0.927051 2.85317 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.5 2.59808 -4.5
-      vertex -3 -5.51091e-16 -4.5
-      vertex -2.00739 2.22943 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -5.51091e-16 -4.5
-      vertex -2.54312 -2.00328 -4.5
-      vertex -2.63687 -1.84019 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.00739 2.22943 -4.5
-      vertex -3 -5.51091e-16 -4.5
-      vertex -2.42705 1.76336 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -5.51091e-16 -4.5
-      vertex -2.63687 -1.84019 -4.5
-      vertex -2.76285 -1.70055 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -5.51091e-16 -4.5
-      vertex -2.76285 -1.70055 -4.5
-      vertex -2.91519 -1.59019 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.42705 1.76336 -4.5
-      vertex -3 -5.51091e-16 -4.5
-      vertex -2.74064 1.22021 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -5.51091e-16 -4.5
-      vertex -2.91519 -1.59019 -4.5
-      vertex -3 -1.55213 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.74064 1.22021 -4.5
-      vertex -3 -5.51091e-16 -4.5
-      vertex -2.93444 0.623734 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.9793 -0.16539 -4.5
-      vertex 49.9969 1.5143 -4.5
-      vertex 46.1053 -0.382187 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9705 1.76332 -4.5
-      vertex 46.1825 4.23891 -4.5
-      vertex 46.2088 4.48891 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 49.9969 1.5143 -4.5
-      vertex 45.9793 -0.16539 -4.5
-      vertex 49.9705 1.76332 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9705 1.76332 -4.5
-      vertex 46.1053 4.00062 -4.5
-      vertex 46.1825 4.23891 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.8123 0.0211325 -4.5
-      vertex 49.9705 1.76332 -4.5
-      vertex 45.9793 -0.16539 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9705 1.76332 -4.5
-      vertex 45.9793 3.78383 -4.5
-      vertex 46.1053 4.00062 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.8123 3.5973 -4.5
-      vertex 49.9705 1.76332 -4.5
-      vertex 45.8123 0.0211325 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9705 1.76332 -4.5
-      vertex 45.8123 3.5973 -4.5
-      vertex 45.9793 3.78383 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 0.168593 -4.5
-      vertex 45.8123 3.5973 -4.5
-      vertex 45.8123 0.0211325 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 0.168593 -4.5
-      vertex 45.6092 3.44984 -4.5
-      vertex 45.8123 3.5973 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 3 -4.5
-      vertex 45.6092 0.168593 -4.5
-      vertex 45.3797 0.271132 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 0.168593 -4.5
-      vertex 45 3 -4.5
-      vertex 45.6092 3.44984 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 3 -4.5
-      vertex 45.3797 0.271132 -4.5
-      vertex 45.1346 0.32289 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 3.44984 -4.5
-      vertex 45 3 -4.5
-      vertex 45.3797 3.3473 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.3797 3.3473 -4.5
-      vertex 45 3 -4.5
-      vertex 45.1346 3.29555 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.8836 0.32289 -4.5
-      vertex 45 3 -4.5
-      vertex 45.1346 0.32289 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.6385 0.271132 -4.5
-      vertex 45 3 -4.5
-      vertex 44.8836 0.32289 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.409 0.168593 -4.5
-      vertex 45 3 -4.5
-      vertex 44.6385 0.271132 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.2059 0.0211325 -4.5
-      vertex 45 3 -4.5
-      vertex 44.409 0.168593 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.0379 -0.16539 -4.5
-      vertex 45 3 -4.5
-      vertex 44.2059 0.0211325 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.9129 -0.382187 -4.5
-      vertex 45 3 -4.5
-      vertex 44.0379 -0.16539 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex 43.9129 -0.382187 -4.5
-      vertex 43.8348 -0.621445 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex 43.8348 -0.621445 -4.5
-      vertex 43.8094 -0.870468 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 43.9129 -0.382187 -4.5
-      vertex 3 -3 -4.5
-      vertex 45 3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.3475 -14.2347 -4.5
-      vertex 2.94613 -14.2347 -4.5
-      vertex 2.9082 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.3475 -14.2347 -4.5
-      vertex 2.9082 -14.3 -4.5
-      vertex 2.38543 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 3 -14.1749 -4.5
-      vertex 2.3475 -14.2347 -4.5
-      vertex 2.17953 -14.0482 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -14.1749 -4.5
-      vertex 2.17953 -14.0482 -4.5
-      vertex 1.97641 -13.9007 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.74789 -13.7982 -4.5
-      vertex 3 -14.1749 -4.5
-      vertex 1.97641 -13.9007 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -14.1749 -4.5
-      vertex 1.74789 -13.7982 -4.5
-      vertex 3 -3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.5018 -13.7464 -4.5
-      vertex 3 -3 -4.5
-      vertex 1.74789 -13.7982 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.2518 -13.7464 -4.5
-      vertex 3 -3 -4.5
-      vertex 1.5018 -13.7464 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.0057 -13.7982 -4.5
-      vertex 3 -3 -4.5
-      vertex 1.2518 -13.7464 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.777187 -13.9007 -4.5
-      vertex 3 -3 -4.5
-      vertex 1.0057 -13.7982 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.406094 -14.2347 -4.5
-      vertex -0.192538 -14.2347 -4.5
-      vertex 0.574062 -14.0482 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.192538 -14.2347 -4.5
-      vertex 0.406094 -14.2347 -4.5
-      vertex -0.154609 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.154609 -14.3 -4.5
-      vertex 0.406094 -14.2347 -4.5
-      vertex 0.368165 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.360507 -14.0482 -4.5
-      vertex 0.574062 -14.0482 -4.5
-      vertex -0.192538 -14.2347 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0 3 -4.5
-      vertex 3 -3 -4.5
-      vertex 0 2.98357 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -3 -4.5
-      vertex 0 3 -4.5
-      vertex 45 3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 2.2516 -4.5
-      vertex 55 3 -4.5
-      vertex 52.3446 2.01332 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 3 -4.5
-      vertex 52.3446 4.05434 -4.5
-      vertex 52.3709 4.30336 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 3.81508 -4.5
-      vertex 55 3 -4.5
-      vertex 52.2674 2.2516 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 3 -4.5
-      vertex 52.2674 3.81508 -4.5
-      vertex 52.3446 4.05434 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 2.4684 -4.5
-      vertex 52.2674 3.81508 -4.5
-      vertex 52.2674 2.2516 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 2.4684 -4.5
-      vertex 52.1414 3.59828 -4.5
-      vertex 52.2674 3.81508 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 2.65492 -4.5
-      vertex 52.1414 3.59828 -4.5
-      vertex 52.1414 2.4684 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 2.65492 -4.5
-      vertex 51.9735 3.41176 -4.5
-      vertex 52.1414 3.59828 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 2.80238 -4.5
-      vertex 51.9735 3.41176 -4.5
-      vertex 51.9735 2.65492 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 2.80238 -4.5
-      vertex 51.7713 3.2643 -4.5
-      vertex 51.9735 3.41176 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 2.90492 -4.5
-      vertex 51.7713 3.2643 -4.5
-      vertex 51.7713 2.80238 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 2.90492 -4.5
-      vertex 51.5418 3.16176 -4.5
-      vertex 51.7713 3.2643 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 2.95668 -4.5
-      vertex 51.5418 3.16176 -4.5
-      vertex 51.5418 2.90492 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 2.95668 -4.5
-      vertex 51.2967 3.11 -4.5
-      vertex 51.5418 3.16176 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 2.95668 -4.5
-      vertex 51.2967 3.11 -4.5
-      vertex 51.2967 2.95668 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 2.95668 -4.5
-      vertex 51.0457 3.11 -4.5
-      vertex 51.2967 3.11 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 2.90492 -4.5
-      vertex 51.0457 3.11 -4.5
-      vertex 51.0457 2.95668 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 2.90492 -4.5
-      vertex 50.8006 3.16176 -4.5
-      vertex 51.0457 3.11 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 2.80238 -4.5
-      vertex 50.8006 3.16176 -4.5
-      vertex 50.8006 2.90492 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 2.80238 -4.5
-      vertex 50.5711 3.2643 -4.5
-      vertex 50.8006 3.16176 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 2.65492 -4.5
-      vertex 50.5711 3.2643 -4.5
-      vertex 50.5711 2.80238 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 2.65492 -4.5
-      vertex 50.368 3.41176 -4.5
-      vertex 50.5711 3.2643 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 2.4684 -4.5
-      vertex 50.368 3.41176 -4.5
-      vertex 50.368 2.65492 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 2.4684 -4.5
-      vertex 50.2 3.59828 -4.5
-      vertex 50.368 3.41176 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 2.2516 -4.5
-      vertex 50.2 3.59828 -4.5
-      vertex 50.2 2.4684 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 2.2516 -4.5
-      vertex 50.075 3.81508 -4.5
-      vertex 50.2 3.59828 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.2088 4.48891 -4.5
-      vertex 50.075 2.2516 -4.5
-      vertex 49.9969 2.01332 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 2.2516 -4.5
-      vertex 46.2088 4.48891 -4.5
-      vertex 50.075 3.81508 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.2088 4.48891 -4.5
-      vertex 49.9969 2.01332 -4.5
-      vertex 49.9705 1.76332 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 3.81508 -4.5
-      vertex 46.2088 4.48891 -4.5
-      vertex 49.9969 4.05434 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 -0.288437 -4.5
-      vertex 55 3 -4.5
-      vertex 52.3446 -0.526718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 3 -4.5
-      vertex 52.3446 1.5143 -4.5
-      vertex 52.3709 1.76332 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 1.27504 -4.5
-      vertex 55 3 -4.5
-      vertex 52.2674 -0.288437 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 3 -4.5
-      vertex 52.2674 1.27504 -4.5
-      vertex 52.3446 1.5143 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 -0.07164 -4.5
-      vertex 52.2674 1.27504 -4.5
-      vertex 52.2674 -0.288437 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 -0.07164 -4.5
-      vertex 52.1414 1.05824 -4.5
-      vertex 52.2674 1.27504 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 0.114882 -4.5
-      vertex 52.1414 1.05824 -4.5
-      vertex 52.1414 -0.07164 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 0.114882 -4.5
-      vertex 51.9735 0.871718 -4.5
-      vertex 52.1414 1.05824 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 0.262343 -4.5
-      vertex 51.9735 0.871718 -4.5
-      vertex 51.9735 0.114882 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 0.262343 -4.5
-      vertex 51.7713 0.724257 -4.5
-      vertex 51.9735 0.871718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 0.364882 -4.5
-      vertex 51.7713 0.724257 -4.5
-      vertex 51.7713 0.262343 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 0.364882 -4.5
-      vertex 51.5418 0.621718 -4.5
-      vertex 51.7713 0.724257 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 0.41664 -4.5
-      vertex 51.5418 0.621718 -4.5
-      vertex 51.5418 0.364882 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 0.41664 -4.5
-      vertex 51.2967 0.569961 -4.5
-      vertex 51.5418 0.621718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 0.41664 -4.5
-      vertex 51.2967 0.569961 -4.5
-      vertex 51.2967 0.41664 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 0.41664 -4.5
-      vertex 51.0457 0.569961 -4.5
-      vertex 51.2967 0.569961 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 0.364882 -4.5
-      vertex 51.0457 0.569961 -4.5
-      vertex 51.0457 0.41664 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 0.364882 -4.5
-      vertex 50.8006 0.621718 -4.5
-      vertex 51.0457 0.569961 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 0.262343 -4.5
-      vertex 50.8006 0.621718 -4.5
-      vertex 50.8006 0.364882 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 0.262343 -4.5
-      vertex 50.5711 0.724257 -4.5
-      vertex 50.8006 0.621718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 0.114882 -4.5
-      vertex 50.5711 0.724257 -4.5
-      vertex 50.5711 0.262343 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 0.114882 -4.5
-      vertex 50.368 0.871718 -4.5
-      vertex 50.5711 0.724257 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 -0.07164 -4.5
-      vertex 50.368 0.871718 -4.5
-      vertex 50.368 0.114882 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 -0.07164 -4.5
-      vertex 50.2 1.05824 -4.5
-      vertex 50.368 0.871718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 -0.288437 -4.5
-      vertex 50.2 1.05824 -4.5
-      vertex 50.2 -0.07164 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 -0.288437 -4.5
-      vertex 50.075 1.27504 -4.5
-      vertex 50.2 1.05824 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9705 -0.776718 -4.5
-      vertex 46.1825 -0.621445 -4.5
-      vertex 49.9969 -0.526718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1053 -0.382187 -4.5
-      vertex 49.9969 -0.526718 -4.5
-      vertex 46.1825 -0.621445 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1825 -0.621445 -4.5
-      vertex 49.9705 -0.776718 -4.5
-      vertex 46.2088 -0.870468 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 -0.526718 -4.5
-      vertex 46.1053 -0.382187 -4.5
-      vertex 50.075 -0.288437 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.869 -22.3558 -4.5
-      vertex 55 -20 -4.5
-      vertex 52.9471 -22.5951 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -20 -4.5
-      vertex 52.9471 -20.5541 -4.5
-      vertex 52.9725 -20.3041 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.869 -20.7923 -4.5
-      vertex 55 -20 -4.5
-      vertex 52.869 -22.3558 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -20 -4.5
-      vertex 52.869 -20.7923 -4.5
-      vertex 52.9471 -20.5541 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.744 -22.139 -4.5
-      vertex 52.869 -20.7923 -4.5
-      vertex 52.869 -22.3558 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.744 -22.139 -4.5
-      vertex 52.744 -21.0091 -4.5
-      vertex 52.869 -20.7923 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.576 -21.9525 -4.5
-      vertex 52.744 -21.0091 -4.5
-      vertex 52.744 -22.139 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.576 -21.9525 -4.5
-      vertex 52.576 -21.1957 -4.5
-      vertex 52.744 -21.0091 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.5 -21.8973 -4.5
-      vertex 52.576 -21.1957 -4.5
-      vertex 52.576 -21.9525 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.576 -21.1957 -4.5
-      vertex 52.5 -21.8973 -4.5
-      vertex 52.5 -21.2508 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.9471 -23.0931 -4.5
-      vertex 58 -25.9836 -4.5
-      vertex 52.9471 -25.1341 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 52.9471 -23.0931 -4.5
-      vertex 52.9725 -22.8441 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.869 -24.8959 -4.5
-      vertex 52.9471 -23.0931 -4.5
-      vertex 52.9471 -25.1341 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.869 -24.8959 -4.5
-      vertex 52.869 -23.3324 -4.5
-      vertex 52.9471 -23.0931 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.744 -24.6791 -4.5
-      vertex 52.869 -23.3324 -4.5
-      vertex 52.869 -24.8959 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.744 -24.6791 -4.5
-      vertex 52.744 -23.5492 -4.5
-      vertex 52.869 -23.3324 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.576 -24.4925 -4.5
-      vertex 52.744 -23.5492 -4.5
-      vertex 52.744 -24.6791 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.576 -24.4925 -4.5
-      vertex 52.576 -23.7357 -4.5
-      vertex 52.744 -23.5492 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.5 -24.4374 -4.5
-      vertex 52.576 -23.7357 -4.5
-      vertex 52.576 -24.4925 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.576 -23.7357 -4.5
-      vertex 52.5 -24.4374 -4.5
-      vertex 52.5 -23.7909 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.9471 -25.6332 -4.5
-      vertex 58 -25.9836 -4.5
-      vertex 58 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 55 -20 -4.5
-      vertex 58 2.98357 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 55 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.9471 -25.1341 -4.5
-      vertex 58 -25.9836 -4.5
-      vertex 52.9725 -25.3841 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 52.9471 -25.6332 -4.5
-      vertex 52.9725 -25.3841 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -26 -4.5
-      vertex 52.869 -25.8724 -4.5
-      vertex 52.9471 -25.6332 -4.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 52.869 -25.8724 -4.5
-      vertex 58 -26 -4.5
-      vertex 52.7954 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 61 -23 -4.5
-      vertex 60.9344 -23.6237 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 61 -23 -4.5
-      vertex 58 -25.9836 -4.5
-      vertex 61 -5.51091e-16 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 60.9344 -23.6237 -4.5
-      vertex 60.7406 -24.2202 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 2.98357 -4.5
-      vertex 61 -5.51091e-16 -4.5
-      vertex 58 -25.9836 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 60.7406 -24.2202 -4.5
-      vertex 60.4271 -24.7634 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 61 -5.51091e-16 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 60.9344 0.623734 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 60.4271 -24.7634 -4.5
-      vertex 60.0074 -25.2294 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 60.9344 0.623734 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 60.7406 1.22021 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 60.0074 -25.2294 -4.5
-      vertex 59.5 -25.5981 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 60.7406 1.22021 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 60.4271 1.76336 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 59.5 -25.5981 -4.5
-      vertex 58.9271 -25.8532 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 60.4271 1.76336 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 60.0074 2.22943 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 58.9271 -25.8532 -4.5
-      vertex 58.3136 -25.9836 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 60.0074 2.22943 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 59.5 2.59808 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 59.5 2.59808 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 58.9271 2.85317 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58.9271 2.85317 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 58.3136 2.98357 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 3 -4.5
-      vertex 58 2.98357 -4.5
-      vertex 55 -3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 2.98357 -4.5
-      vertex 55 3 -4.5
-      vertex 58 3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3446 -0.526718 -4.5
-      vertex 55 -3 -4.5
-      vertex 52.3709 -0.776718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 52.3446 -0.526718 -4.5
-      vertex 55 3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 52.3446 -1.02574 -4.5
-      vertex 52.3709 -0.776718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 52.2674 -1.265 -4.5
-      vertex 52.3446 -1.02574 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 52.1414 -1.4818 -4.5
-      vertex 52.2674 -1.265 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 51.9735 -1.66832 -4.5
-      vertex 52.1414 -1.4818 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 51.7713 -1.81578 -4.5
-      vertex 51.9735 -1.66832 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 51.5418 -1.91832 -4.5
-      vertex 51.7713 -1.81578 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 51.2967 -1.97008 -4.5
-      vertex 51.5418 -1.91832 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 51.0457 -1.97008 -4.5
-      vertex 51.2967 -1.97008 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1304 -3 -4.5
-      vertex 51.0457 -1.97008 -4.5
-      vertex 55 -3 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 50.075 -0.288437 -4.5
-      vertex 46.1053 -0.382187 -4.5
-      vertex 50.075 1.27504 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 50.075 1.27504 -4.5
-      vertex 46.1053 -0.382187 -4.5
-      vertex 49.9969 1.5143 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 -1.02574 -4.5
-      vertex 46.2088 -0.870468 -4.5
-      vertex 49.9705 -0.776718 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1825 -1.12047 -4.5
-      vertex 49.9969 -1.02574 -4.5
-      vertex 50.075 -1.265 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1304 -3 -4.5
-      vertex 50.075 -1.265 -4.5
-      vertex 50.2 -1.4818 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1304 -3 -4.5
-      vertex 50.2 -1.4818 -4.5
-      vertex 50.368 -1.66832 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1304 -3 -4.5
-      vertex 50.368 -1.66832 -4.5
-      vertex 50.5711 -1.81578 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1304 -3 -4.5
-      vertex 50.5711 -1.81578 -4.5
-      vertex 50.8006 -1.91832 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 51.0457 -1.97008 -4.5
-      vertex 46.1304 -3 -4.5
-      vertex 50.8006 -1.91832 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 49.9969 -1.02574 -4.5
-      vertex 46.1825 -1.12047 -4.5
-      vertex 46.2088 -0.870468 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 -1.265 -4.5
-      vertex 46.1304 -3 -4.5
-      vertex 46.1053 -2.92223 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 -1.265 -4.5
-      vertex 46.1053 -2.92223 -4.5
-      vertex 46.1053 -1.35875 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 50.075 -1.265 -4.5
-      vertex 46.1053 -1.35875 -4.5
-      vertex 46.1825 -1.12047 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.9793 -2.70543 -4.5
-      vertex 46.1053 -1.35875 -4.5
-      vertex 46.1053 -2.92223 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.9793 -2.70543 -4.5
-      vertex 45.9793 -1.57555 -4.5
-      vertex 46.1053 -1.35875 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.8123 -2.51891 -4.5
-      vertex 45.9793 -1.57555 -4.5
-      vertex 45.9793 -2.70543 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.8123 -2.51891 -4.5
-      vertex 45.8123 -1.76207 -4.5
-      vertex 45.9793 -1.57555 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 -2.37144 -4.5
-      vertex 45.8123 -1.76207 -4.5
-      vertex 45.8123 -2.51891 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 -2.37144 -4.5
-      vertex 45.6092 -1.90953 -4.5
-      vertex 45.8123 -1.76207 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.3797 -2.26891 -4.5
-      vertex 45.6092 -1.90953 -4.5
-      vertex 45.6092 -2.37144 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.3797 -2.26891 -4.5
-      vertex 45.3797 -2.01207 -4.5
-      vertex 45.6092 -1.90953 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.1346 -2.21715 -4.5
-      vertex 45.3797 -2.01207 -4.5
-      vertex 45.3797 -2.26891 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.1346 -2.21715 -4.5
-      vertex 45.1346 -2.06383 -4.5
-      vertex 45.3797 -2.01207 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.8836 -2.21715 -4.5
-      vertex 45.1346 -2.06383 -4.5
-      vertex 45.1346 -2.21715 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.8836 -2.21715 -4.5
-      vertex 44.8836 -2.06383 -4.5
-      vertex 45.1346 -2.06383 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.6385 -2.26891 -4.5
-      vertex 44.8836 -2.06383 -4.5
-      vertex 44.8836 -2.21715 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.6385 -2.26891 -4.5
-      vertex 44.6385 -2.01207 -4.5
-      vertex 44.8836 -2.06383 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.409 -2.37144 -4.5
-      vertex 44.6385 -2.01207 -4.5
-      vertex 44.6385 -2.26891 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.409 -2.37144 -4.5
-      vertex 44.409 -1.90953 -4.5
-      vertex 44.6385 -2.01207 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.2059 -2.51891 -4.5
-      vertex 44.409 -1.90953 -4.5
-      vertex 44.409 -2.37144 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.2059 -2.51891 -4.5
-      vertex 44.2059 -1.76207 -4.5
-      vertex 44.409 -1.90953 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.0379 -2.70543 -4.5
-      vertex 44.2059 -1.76207 -4.5
-      vertex 44.2059 -2.51891 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 44.0379 -2.70543 -4.5
-      vertex 44.0379 -1.57555 -4.5
-      vertex 44.2059 -1.76207 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.9129 -2.92223 -4.5
-      vertex 44.0379 -1.57555 -4.5
-      vertex 44.0379 -2.70543 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.9129 -2.92223 -4.5
-      vertex 43.9129 -1.35875 -4.5
-      vertex 44.0379 -1.57555 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.8875 -3 -4.5
-      vertex 43.9129 -1.35875 -4.5
-      vertex 43.9129 -2.92223 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.8875 -3 -4.5
-      vertex 43.8348 -1.12047 -4.5
-      vertex 43.9129 -1.35875 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.8875 -3 -4.5
-      vertex 43.8094 -0.870468 -4.5
-      vertex 43.8348 -1.12047 -4.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 43.8094 -0.870468 -4.5
-      vertex 43.8875 -3 -4.5
-      vertex 3 -3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 52.9725 -22.8441 -4.5
-      vertex 55 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.9471 -22.5951 -4.5
-      vertex 55 -20 -4.5
-      vertex 52.9725 -22.8441 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.9471 -20.055 -4.5
-      vertex 55 -20 -4.5
-      vertex 52.9725 -20.3041 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 55 -20 -4.5
-      vertex 52.9471 -20.055 -4.5
-      vertex 52.9291 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3446 2.01332 -4.5
-      vertex 55 3 -4.5
-      vertex 52.3709 1.76332 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 55 3 -4.5
-      vertex 52.3709 4.30336 -4.5
-      vertex 55 6 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3446 4.55336 -4.5
-      vertex 55 6 -4.5
-      vertex 52.3709 4.30336 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 4.79164 -4.5
-      vertex 55 6 -4.5
-      vertex 52.3446 4.55336 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 5.00844 -4.5
-      vertex 55 6 -4.5
-      vertex 52.2674 4.79164 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 5.19496 -4.5
-      vertex 55 6 -4.5
-      vertex 52.1414 5.00844 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 5.34242 -4.5
-      vertex 55 6 -4.5
-      vertex 51.9735 5.19496 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 5.44496 -4.5
-      vertex 55 6 -4.5
-      vertex 51.7713 5.34242 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 5.49672 -4.5
-      vertex 55 6 -4.5
-      vertex 51.5418 5.44496 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 5.49672 -4.5
-      vertex 55 6 -4.5
-      vertex 51.2967 5.49672 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 4.05434 -4.5
-      vertex 46.2088 4.48891 -4.5
-      vertex 49.9705 4.30336 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9705 4.30336 -4.5
-      vertex 46.2088 4.48891 -4.5
-      vertex 49.9969 4.55336 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1825 4.73793 -4.5
-      vertex 49.9969 4.55336 -4.5
-      vertex 46.2088 4.48891 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 4.55336 -4.5
-      vertex 46.1825 4.73793 -4.5
-      vertex 50.075 4.79164 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1053 4.97719 -4.5
-      vertex 50.075 4.79164 -4.5
-      vertex 46.1825 4.73793 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 4.79164 -4.5
-      vertex 46.1053 4.97719 -4.5
-      vertex 50.2 5.00844 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.9793 5.19398 -4.5
-      vertex 50.2 5.00844 -4.5
-      vertex 46.1053 4.97719 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 5.00844 -4.5
-      vertex 45.9793 5.19398 -4.5
-      vertex 50.368 5.19496 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.8123 5.38051 -4.5
-      vertex 50.368 5.19496 -4.5
-      vertex 45.9793 5.19398 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 5.19496 -4.5
-      vertex 45.8123 5.38051 -4.5
-      vertex 50.5711 5.34242 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 5.52797 -4.5
-      vertex 50.5711 5.34242 -4.5
-      vertex 45.8123 5.38051 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 6 -4.5
-      vertex 50.5711 5.34242 -4.5
-      vertex 45.6092 5.52797 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 5.34242 -4.5
-      vertex 45 6 -4.5
-      vertex 50.8006 5.44496 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 5.44496 -4.5
-      vertex 45 6 -4.5
-      vertex 51.0457 5.49672 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 6 -4.5
-      vertex 45.6092 5.52797 -4.5
-      vertex 45.3797 5.63051 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 6 -4.5
-      vertex 45.3797 5.63051 -4.5
-      vertex 45.1346 5.68227 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 6 -4.5
-      vertex 45.1346 5.68227 -4.5
-      vertex 45 5.68227 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 5.49672 -4.5
-      vertex 45 6 -4.5
-      vertex 55 6 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 45.1346 3.29555 -4.5
-      vertex 45 3 -4.5
-      vertex 45 3.29555 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.5435 -23.8683 -4.5
-      vertex 29.1688 -22.6712 -4.5
-      vertex 23.6081 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1688 -22.6712 -4.5
-      vertex 23.6081 -21.9429 -4.5
-      vertex 23.63 -21.735 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.5435 -22.1417 -4.5
-      vertex 29.1688 -22.6712 -4.5
-      vertex 23.5435 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1688 -22.6712 -4.5
-      vertex 23.5435 -22.1417 -4.5
-      vertex 23.6081 -21.9429 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.439 -23.6872 -4.5
-      vertex 23.5435 -22.1417 -4.5
-      vertex 23.5435 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.439 -23.6872 -4.5
-      vertex 23.439 -22.3228 -4.5
-      vertex 23.5435 -22.1417 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.2991 -23.5319 -4.5
-      vertex 23.439 -22.3228 -4.5
-      vertex 23.439 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.2991 -23.5319 -4.5
-      vertex 23.2991 -22.4781 -4.5
-      vertex 23.439 -22.3228 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.13 -23.409 -4.5
-      vertex 23.2991 -22.4781 -4.5
-      vertex 23.2991 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.13 -23.409 -4.5
-      vertex 23.13 -22.601 -4.5
-      vertex 23.2991 -22.4781 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.939 -23.3239 -4.5
-      vertex 23.13 -22.601 -4.5
-      vertex 23.13 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.939 -23.3239 -4.5
-      vertex 22.939 -22.6861 -4.5
-      vertex 23.13 -22.601 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.7345 -23.2805 -4.5
-      vertex 22.939 -22.6861 -4.5
-      vertex 22.939 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.7345 -23.2805 -4.5
-      vertex 22.7345 -22.7295 -4.5
-      vertex 22.939 -22.6861 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.5255 -23.2805 -4.5
-      vertex 22.7345 -22.7295 -4.5
-      vertex 22.7345 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.5255 -23.2805 -4.5
-      vertex 22.5255 -22.7295 -4.5
-      vertex 22.7345 -22.7295 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.321 -23.3239 -4.5
-      vertex 22.5255 -22.7295 -4.5
-      vertex 22.5255 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.321 -23.3239 -4.5
-      vertex 22.321 -22.6861 -4.5
-      vertex 22.5255 -22.7295 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.13 -23.409 -4.5
-      vertex 22.321 -22.6861 -4.5
-      vertex 22.321 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.13 -23.409 -4.5
-      vertex 22.13 -22.601 -4.5
-      vertex 22.321 -22.6861 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.9609 -23.5319 -4.5
-      vertex 22.13 -22.601 -4.5
-      vertex 22.13 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.9609 -23.5319 -4.5
-      vertex 21.9609 -22.4781 -4.5
-      vertex 22.13 -22.601 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.821 -23.6872 -4.5
-      vertex 21.9609 -22.4781 -4.5
-      vertex 21.9609 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.821 -23.6872 -4.5
-      vertex 21.821 -22.3228 -4.5
-      vertex 21.9609 -22.4781 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.7165 -23.8683 -4.5
-      vertex 21.821 -22.3228 -4.5
-      vertex 21.821 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.7165 -23.8683 -4.5
-      vertex 21.7165 -22.1417 -4.5
-      vertex 21.821 -22.3228 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9235 -23.8683 -4.5
-      vertex 21.7165 -23.8683 -4.5
-      vertex 21.6519 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.7165 -23.8683 -4.5
-      vertex 15.9235 -23.8683 -4.5
-      vertex 21.7165 -22.1417 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9881 -24.0671 -4.5
-      vertex 21.6519 -24.0671 -4.5
-      vertex 21.63 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9235 -23.8683 -4.5
-      vertex 21.6519 -24.0671 -4.5
-      vertex 15.9881 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -20.5541 -4.5
-      vertex 41.7284 -20.1312 -4.5
-      vertex 48.033 -20.3041 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -20.5541 -4.5
-      vertex 41.702 -20.3812 -4.5
-      vertex 41.7284 -20.1312 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.6248 -22.183 -4.5
-      vertex 41.702 -20.3812 -4.5
-      vertex 41.702 -22.4222 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.6248 -22.183 -4.5
-      vertex 41.6248 -20.6195 -4.5
-      vertex 41.702 -20.3812 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.4989 -21.9662 -4.5
-      vertex 41.6248 -20.6195 -4.5
-      vertex 41.6248 -22.183 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.4989 -21.9662 -4.5
-      vertex 41.4989 -20.8363 -4.5
-      vertex 41.6248 -20.6195 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.3309 -21.7796 -4.5
-      vertex 41.4989 -20.8363 -4.5
-      vertex 41.4989 -21.9662 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.3309 -21.7796 -4.5
-      vertex 41.3309 -21.0228 -4.5
-      vertex 41.4989 -20.8363 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.1287 -21.6322 -4.5
-      vertex 41.3309 -21.0228 -4.5
-      vertex 41.3309 -21.7796 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.1287 -21.6322 -4.5
-      vertex 41.1287 -21.1703 -4.5
-      vertex 41.3309 -21.0228 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41 -21.5747 -4.5
-      vertex 41.1287 -21.1703 -4.5
-      vertex 41.1287 -21.6322 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.1287 -21.1703 -4.5
-      vertex 41 -21.5747 -4.5
-      vertex 41 -21.2278 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -23.0931 -4.5
-      vertex 41.702 -22.9212 -4.5
-      vertex 48.033 -22.8441 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.702 -22.4222 -4.5
-      vertex 48.033 -22.8441 -4.5
-      vertex 41.7284 -22.6712 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.4989 -23.3763 -4.5
-      vertex 48.033 -25.3841 -4.5
-      vertex 48.0594 -25.6332 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.3309 -23.5629 -4.5
-      vertex 48.0594 -25.6332 -4.5
-      vertex 48.1366 -25.8724 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.1287 -23.7103 -4.5
-      vertex 48.1366 -25.8724 -4.5
-      vertex 48.2107 -26 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 48.033 -22.8441 -4.5
-      vertex 41.702 -22.9212 -4.5
-      vertex 41.7284 -22.6712 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.033 -25.3841 -4.5
-      vertex 41.6248 -23.1595 -4.5
-      vertex 41.702 -22.9212 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.033 -25.3841 -4.5
-      vertex 41.4989 -23.3763 -4.5
-      vertex 41.6248 -23.1595 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -25.6332 -4.5
-      vertex 41.3309 -23.5629 -4.5
-      vertex 41.4989 -23.3763 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.1366 -25.8724 -4.5
-      vertex 41.1287 -23.7103 -4.5
-      vertex 41.3309 -23.5629 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2107 -26 -4.5
-      vertex 40.8993 -23.8129 -4.5
-      vertex 41.1287 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2107 -26 -4.5
-      vertex 40.6541 -23.8646 -4.5
-      vertex 40.8993 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2107 -26 -4.5
-      vertex 40.4032 -23.8646 -4.5
-      vertex 40.6541 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 38.1141 -23.8646 -4.5
-      vertex 40.4032 -23.8646 -4.5
-      vertex 48.2107 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 39.7254 -23.5629 -4.5
-      vertex 38.8475 -23.5 -4.5
-      vertex 39.6688 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 38.7909 -23.5629 -4.5
-      vertex 39.7254 -23.5629 -4.5
-      vertex 39.9286 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 38.5887 -23.7103 -4.5
-      vertex 39.9286 -23.7103 -4.5
-      vertex 40.158 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 40.4032 -23.8646 -4.5
-      vertex 38.1141 -23.8646 -4.5
-      vertex 40.158 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 39.7254 -23.5629 -4.5
-      vertex 38.7909 -23.5629 -4.5
-      vertex 38.8475 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 39.9286 -23.7103 -4.5
-      vertex 38.5887 -23.7103 -4.5
-      vertex 38.7909 -23.5629 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 40.158 -23.8129 -4.5
-      vertex 38.3592 -23.8129 -4.5
-      vertex 38.5887 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 40.158 -23.8129 -4.5
-      vertex 38.1141 -23.8646 -4.5
-      vertex 38.3592 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2107 -26 -4.5
-      vertex 37.8631 -23.8646 -4.5
-      vertex 38.1141 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 37.1854 -23.5629 -4.5
-      vertex 36.3081 -23.5 -4.5
-      vertex 37.1288 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 36.2518 -23.5629 -4.5
-      vertex 37.1854 -23.5629 -4.5
-      vertex 37.3885 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 36.0487 -23.7103 -4.5
-      vertex 37.3885 -23.7103 -4.5
-      vertex 37.618 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 37.1854 -23.5629 -4.5
-      vertex 36.2518 -23.5629 -4.5
-      vertex 36.3081 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.8192 -23.8129 -4.5
-      vertex 37.618 -23.8129 -4.5
-      vertex 37.8631 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.5741 -23.8646 -4.5
-      vertex 37.8631 -23.8646 -4.5
-      vertex 48.2107 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 37.3885 -23.7103 -4.5
-      vertex 36.0487 -23.7103 -4.5
-      vertex 36.2518 -23.5629 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 37.618 -23.8129 -4.5
-      vertex 35.8192 -23.8129 -4.5
-      vertex 36.0487 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 37.8631 -23.8646 -4.5
-      vertex 35.5741 -23.8646 -4.5
-      vertex 35.8192 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2107 -26 -4.5
-      vertex 35.3231 -23.8646 -4.5
-      vertex 35.5741 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.6454 -23.5629 -4.5
-      vertex 33.768 -23.5 -4.5
-      vertex 34.5888 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 33.7118 -23.5629 -4.5
-      vertex 34.6454 -23.5629 -4.5
-      vertex 34.8485 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 33.5086 -23.7103 -4.5
-      vertex 34.8485 -23.7103 -4.5
-      vertex 35.078 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.6454 -23.5629 -4.5
-      vertex 33.7118 -23.5629 -4.5
-      vertex 33.768 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 33.2791 -23.8129 -4.5
-      vertex 35.078 -23.8129 -4.5
-      vertex 35.3231 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.8485 -23.7103 -4.5
-      vertex 33.5086 -23.7103 -4.5
-      vertex 33.7118 -23.5629 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 33.034 -23.8646 -4.5
-      vertex 35.3231 -23.8646 -4.5
-      vertex 48.2107 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.078 -23.8129 -4.5
-      vertex 33.2791 -23.8129 -4.5
-      vertex 33.5086 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.3231 -23.8646 -4.5
-      vertex 33.034 -23.8646 -4.5
-      vertex 33.2791 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.939 -25.2261 -4.5
-      vertex 33.034 -23.8646 -4.5
-      vertex 48.2107 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.1053 -23.5629 -4.5
-      vertex 31.2283 -23.5 -4.5
-      vertex 32.0487 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 31.1717 -23.5629 -4.5
-      vertex 32.1053 -23.5629 -4.5
-      vertex 32.3084 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30.9686 -23.7103 -4.5
-      vertex 32.3084 -23.7103 -4.5
-      vertex 32.5379 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.1053 -23.5629 -4.5
-      vertex 31.1717 -23.5629 -4.5
-      vertex 31.2283 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30.7391 -23.8129 -4.5
-      vertex 32.5379 -23.8129 -4.5
-      vertex 32.783 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.3084 -23.7103 -4.5
-      vertex 30.9686 -23.7103 -4.5
-      vertex 31.1717 -23.5629 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 33.034 -23.8646 -4.5
-      vertex 22.939 -25.2261 -4.5
-      vertex 32.783 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.5379 -23.8129 -4.5
-      vertex 30.7391 -23.8129 -4.5
-      vertex 30.9686 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.783 -23.8646 -4.5
-      vertex 30.494 -23.8646 -4.5
-      vertex 30.7391 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 32.783 -23.8646 -4.5
-      vertex 22.939 -25.2261 -4.5
-      vertex 30.494 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1942 -22.4222 -4.5
-      vertex 23.63 -21.735 -4.5
-      vertex 29.1942 -20.3812 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.6081 -24.0671 -4.5
-      vertex 29.1942 -22.9212 -4.5
-      vertex 23.63 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 29.2723 -23.1595 -4.5
-      vertex 23.63 -24.275 -4.5
-      vertex 29.1942 -22.9212 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.6081 -24.4829 -4.5
-      vertex 29.2723 -23.1595 -4.5
-      vertex 29.3973 -23.3763 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.5435 -24.6817 -4.5
-      vertex 29.3973 -23.3763 -4.5
-      vertex 29.5653 -23.5629 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.439 -24.8628 -4.5
-      vertex 29.5653 -23.5629 -4.5
-      vertex 29.7684 -23.7103 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.2991 -25.0181 -4.5
-      vertex 29.7684 -23.7103 -4.5
-      vertex 29.9979 -23.8129 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.13 -25.141 -4.5
-      vertex 29.9979 -23.8129 -4.5
-      vertex 30.243 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 30.494 -23.8646 -4.5
-      vertex 22.939 -25.2261 -4.5
-      vertex 30.243 -23.8646 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.2723 -23.1595 -4.5
-      vertex 23.6081 -24.4829 -4.5
-      vertex 23.63 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.3973 -23.3763 -4.5
-      vertex 23.5435 -24.6817 -4.5
-      vertex 23.6081 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.5653 -23.5629 -4.5
-      vertex 23.439 -24.8628 -4.5
-      vertex 23.5435 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.7684 -23.7103 -4.5
-      vertex 23.2991 -25.0181 -4.5
-      vertex 23.439 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.9979 -23.8129 -4.5
-      vertex 23.13 -25.141 -4.5
-      vertex 23.2991 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30.243 -23.8646 -4.5
-      vertex 22.939 -25.2261 -4.5
-      vertex 23.13 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2107 -26 -4.5
-      vertex 22.7345 -25.2695 -4.5
-      vertex 22.939 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2107 -26 -4.5
-      vertex 22.5255 -25.2695 -4.5
-      vertex 22.7345 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9881 -24.0671 -4.5
-      vertex 21.63 -24.275 -4.5
-      vertex 16.01 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.6519 -24.4829 -4.5
-      vertex 16.01 -24.275 -4.5
-      vertex 21.63 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9881 -24.4829 -4.5
-      vertex 21.6519 -24.4829 -4.5
-      vertex 21.7165 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9235 -24.6817 -4.5
-      vertex 21.7165 -24.6817 -4.5
-      vertex 21.821 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.819 -24.8628 -4.5
-      vertex 21.821 -24.8628 -4.5
-      vertex 21.9609 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.6791 -25.0181 -4.5
-      vertex 21.9609 -25.0181 -4.5
-      vertex 22.13 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.51 -25.141 -4.5
-      vertex 22.13 -25.141 -4.5
-      vertex 22.321 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.319 -25.2261 -4.5
-      vertex 22.321 -25.2261 -4.5
-      vertex 22.5255 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.6519 -24.4829 -4.5
-      vertex 15.9881 -24.4829 -4.5
-      vertex 16.01 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.7165 -24.6817 -4.5
-      vertex 15.9235 -24.6817 -4.5
-      vertex 15.9881 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.821 -24.8628 -4.5
-      vertex 15.819 -24.8628 -4.5
-      vertex 15.9235 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.9609 -25.0181 -4.5
-      vertex 15.6791 -25.0181 -4.5
-      vertex 15.819 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.13 -25.141 -4.5
-      vertex 15.51 -25.141 -4.5
-      vertex 15.6791 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -26 -4.5
-      vertex 22.5255 -25.2695 -4.5
-      vertex 48.2107 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.321 -25.2261 -4.5
-      vertex 15.319 -25.2261 -4.5
-      vertex 15.51 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.5255 -25.2695 -4.5
-      vertex 15.1145 -25.2695 -4.5
-      vertex 15.319 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 22.5255 -25.2695 -4.5
-      vertex 1 -26 -4.5
-      vertex 15.1145 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0319 -24.4829 -4.5
-      vertex 13.47 -24.275 -4.5
-      vertex 14.01 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.4481 -24.4829 -4.5
-      vertex 14.0319 -24.4829 -4.5
-      vertex 14.0965 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.3835 -24.6817 -4.5
-      vertex 14.0965 -24.6817 -4.5
-      vertex 14.201 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.279 -24.8628 -4.5
-      vertex 14.201 -24.8628 -4.5
-      vertex 14.3409 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0319 -24.4829 -4.5
-      vertex 13.4481 -24.4829 -4.5
-      vertex 13.47 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.1391 -25.0181 -4.5
-      vertex 14.3409 -25.0181 -4.5
-      vertex 14.51 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0965 -24.6817 -4.5
-      vertex 13.3835 -24.6817 -4.5
-      vertex 13.4481 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.97 -25.141 -4.5
-      vertex 14.51 -25.141 -4.5
-      vertex 14.701 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.201 -24.8628 -4.5
-      vertex 13.279 -24.8628 -4.5
-      vertex 13.3835 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.3409 -25.0181 -4.5
-      vertex 13.1391 -25.0181 -4.5
-      vertex 13.279 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.779 -25.2261 -4.5
-      vertex 14.701 -25.2261 -4.5
-      vertex 14.9055 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.51 -25.141 -4.5
-      vertex 12.97 -25.141 -4.5
-      vertex 13.1391 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.701 -25.2261 -4.5
-      vertex 12.779 -25.2261 -4.5
-      vertex 12.97 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 15.1145 -25.2695 -4.5
-      vertex 1 -26 -4.5
-      vertex 14.9055 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.9055 -25.2695 -4.5
-      vertex 12.5745 -25.2695 -4.5
-      vertex 12.779 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 14.9055 -25.2695 -4.5
-      vertex 1 -26 -4.5
-      vertex 12.5745 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.4919 -24.4829 -4.5
-      vertex 10.93 -24.275 -4.5
-      vertex 11.47 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.9081 -24.4829 -4.5
-      vertex 11.4919 -24.4829 -4.5
-      vertex 11.5565 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.8435 -24.6817 -4.5
-      vertex 11.5565 -24.6817 -4.5
-      vertex 11.661 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.739 -24.8628 -4.5
-      vertex 11.661 -24.8628 -4.5
-      vertex 11.8009 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.4919 -24.4829 -4.5
-      vertex 10.9081 -24.4829 -4.5
-      vertex 10.93 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.5991 -25.0181 -4.5
-      vertex 11.8009 -25.0181 -4.5
-      vertex 11.97 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.5565 -24.6817 -4.5
-      vertex 10.8435 -24.6817 -4.5
-      vertex 10.9081 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.43 -25.141 -4.5
-      vertex 11.97 -25.141 -4.5
-      vertex 12.161 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.661 -24.8628 -4.5
-      vertex 10.739 -24.8628 -4.5
-      vertex 10.8435 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.8009 -25.0181 -4.5
-      vertex 10.5991 -25.0181 -4.5
-      vertex 10.739 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.239 -25.2261 -4.5
-      vertex 12.161 -25.2261 -4.5
-      vertex 12.3655 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.97 -25.141 -4.5
-      vertex 10.43 -25.141 -4.5
-      vertex 10.5991 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.161 -25.2261 -4.5
-      vertex 10.239 -25.2261 -4.5
-      vertex 10.43 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.3655 -25.2695 -4.5
-      vertex 10.0345 -25.2695 -4.5
-      vertex 10.239 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.5745 -25.2695 -4.5
-      vertex 1 -26 -4.5
-      vertex 12.3655 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 12.3655 -25.2695 -4.5
-      vertex 1 -26 -4.5
-      vertex 10.0345 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.95185 -24.4829 -4.5
-      vertex 8.39 -24.275 -4.5
-      vertex 8.93 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.36815 -24.4829 -4.5
-      vertex 8.95185 -24.4829 -4.5
-      vertex 9.01645 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.30354 -24.6817 -4.5
-      vertex 9.01645 -24.6817 -4.5
-      vertex 9.12098 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.19902 -24.8628 -4.5
-      vertex 9.12098 -24.8628 -4.5
-      vertex 9.26087 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.95185 -24.4829 -4.5
-      vertex 8.36815 -24.4829 -4.5
-      vertex 8.39 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.05913 -25.0181 -4.5
-      vertex 9.26087 -25.0181 -4.5
-      vertex 9.43 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.01645 -24.6817 -4.5
-      vertex 8.30354 -24.6817 -4.5
-      vertex 8.36815 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 7.89 -25.141 -4.5
-      vertex 9.43 -25.141 -4.5
-      vertex 9.62098 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.12098 -24.8628 -4.5
-      vertex 8.19902 -24.8628 -4.5
-      vertex 8.30354 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.26087 -25.0181 -4.5
-      vertex 8.05913 -25.0181 -4.5
-      vertex 8.19902 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 7.69902 -25.2261 -4.5
-      vertex 9.62098 -25.2261 -4.5
-      vertex 9.82547 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.43 -25.141 -4.5
-      vertex 7.89 -25.141 -4.5
-      vertex 8.05913 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.62098 -25.2261 -4.5
-      vertex 7.69902 -25.2261 -4.5
-      vertex 7.89 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.82547 -25.2695 -4.5
-      vertex 7.49453 -25.2695 -4.5
-      vertex 7.69902 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 10.0345 -25.2695 -4.5
-      vertex 1 -26 -4.5
-      vertex 9.82547 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 9.82547 -25.2695 -4.5
-      vertex 1 -26 -4.5
-      vertex 7.49453 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.17172 -24.5082 -4.5
-      vertex 6.39 -24.275 -4.5
-      vertex 6.41185 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.14633 -24.7572 -4.5
-      vertex 6.41185 -24.4829 -4.5
-      vertex 6.47645 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -26 -4.5
-      vertex 6.47645 -24.6817 -4.5
-      vertex 6.58098 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.17953 -18.3714 -4.5
-      vertex 3 -18.3 -4.5
-      vertex 3 -20 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 3 -18.3 -4.5
-      vertex 2.17953 -18.3714 -4.5
-      vertex 2.24387 -18.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 1.97641 -18.5189 -4.5
-      vertex 2.17953 -18.3714 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 1.74789 -18.6205 -4.5
-      vertex 1.97641 -18.5189 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.39 -24.275 -4.5
-      vertex 1 -23 -4.5
-      vertex 3 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 1.2518 -18.6732 -4.5
-      vertex 3 -20 -4.5
-      vertex 1 -23 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 1.5018 -18.6732 -4.5
-      vertex 1.74789 -18.6205 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 6.39 -24.275 -4.5
-      vertex 1.17172 -24.5082 -4.5
-      vertex 1.14633 -24.2582 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -26 -4.5
-      vertex 6.58098 -24.8628 -4.5
-      vertex 6.72087 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -26 -4.5
-      vertex 6.72087 -25.0181 -4.5
-      vertex 6.89 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -26 -4.5
-      vertex 6.89 -25.141 -4.5
-      vertex 7.08098 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -26 -4.5
-      vertex 7.08098 -25.2261 -4.5
-      vertex 7.28547 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.41185 -24.4829 -4.5
-      vertex 1.14633 -24.7572 -4.5
-      vertex 1.17172 -24.5082 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.47645 -24.6817 -4.5
-      vertex 1 -26 -4.5
-      vertex 1.14633 -24.7572 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 7.49453 -25.2695 -4.5
-      vertex 1 -26 -4.5
-      vertex 7.28547 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.14633 -24.7572 -4.5
-      vertex 1 -26 -4.5
-      vertex 1.0682 -24.9955 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.0682 -24.9955 -4.5
-      vertex 1 -26 -4.5
-      vertex 1 -25.1143 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.4295 -24.4925 -4.5
-      vertex 48.5 -23.7869 -4.5
-      vertex 48.5 -24.4414 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.4295 -24.4925 -4.5
-      vertex 48.4295 -23.7357 -4.5
-      vertex 48.5 -23.7869 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2625 -24.6791 -4.5
-      vertex 48.4295 -23.7357 -4.5
-      vertex 48.4295 -24.4925 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2625 -24.6791 -4.5
-      vertex 48.2625 -23.5492 -4.5
-      vertex 48.4295 -23.7357 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.1366 -24.8959 -4.5
-      vertex 48.2625 -23.5492 -4.5
-      vertex 48.2625 -24.6791 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.1366 -24.8959 -4.5
-      vertex 48.1366 -23.3324 -4.5
-      vertex 48.2625 -23.5492 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -25.1341 -4.5
-      vertex 48.1366 -23.3324 -4.5
-      vertex 48.1366 -24.8959 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -25.1341 -4.5
-      vertex 48.0594 -23.0931 -4.5
-      vertex 48.1366 -23.3324 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.702 -22.9212 -4.5
-      vertex 48.0594 -25.1341 -4.5
-      vertex 48.033 -25.3841 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -25.1341 -4.5
-      vertex 41.702 -22.9212 -4.5
-      vertex 48.0594 -23.0931 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.4295 -21.9525 -4.5
-      vertex 48.5 -21.2468 -4.5
-      vertex 48.5 -21.9013 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.4295 -21.9525 -4.5
-      vertex 48.4295 -21.1957 -4.5
-      vertex 48.5 -21.2468 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2625 -22.139 -4.5
-      vertex 48.4295 -21.1957 -4.5
-      vertex 48.4295 -21.9525 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2625 -22.139 -4.5
-      vertex 48.2625 -21.0091 -4.5
-      vertex 48.4295 -21.1957 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.1366 -22.3558 -4.5
-      vertex 48.2625 -21.0091 -4.5
-      vertex 48.2625 -22.139 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.1366 -22.3558 -4.5
-      vertex 48.1366 -20.7923 -4.5
-      vertex 48.2625 -21.0091 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -22.5951 -4.5
-      vertex 48.1366 -20.7923 -4.5
-      vertex 48.1366 -22.3558 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -22.5951 -4.5
-      vertex 48.0594 -20.5541 -4.5
-      vertex 48.1366 -20.7923 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.702 -22.4222 -4.5
-      vertex 48.0594 -22.5951 -4.5
-      vertex 48.033 -22.8441 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -22.5951 -4.5
-      vertex 41.702 -22.4222 -4.5
-      vertex 48.0594 -20.5541 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.702 -20.3812 -4.5
-      vertex 48.0594 -20.5541 -4.5
-      vertex 41.702 -22.4222 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.033 -20.3041 -4.5
-      vertex 41.7284 -20.1312 -4.5
-      vertex 48.0594 -20.055 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.7145 -20 -4.5
-      vertex 48.0594 -20.055 -4.5
-      vertex 41.7284 -20.1312 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -20.055 -4.5
-      vertex 41.7145 -20 -4.5
-      vertex 48.0772 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.9979 -21.5296 -4.5
-      vertex 30 -21.2733 -4.5
-      vertex 30 -21.5292 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.9979 -21.5296 -4.5
-      vertex 29.9979 -21.2728 -4.5
-      vertex 30 -21.2733 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.7684 -21.6322 -4.5
-      vertex 29.9979 -21.2728 -4.5
-      vertex 29.9979 -21.5296 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.7684 -21.6322 -4.5
-      vertex 29.7684 -21.1703 -4.5
-      vertex 29.9979 -21.2728 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.5653 -21.7796 -4.5
-      vertex 29.7684 -21.1703 -4.5
-      vertex 29.7684 -21.6322 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.5653 -21.7796 -4.5
-      vertex 29.5653 -21.0228 -4.5
-      vertex 29.7684 -21.1703 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.3973 -21.9662 -4.5
-      vertex 29.5653 -21.0228 -4.5
-      vertex 29.5653 -21.7796 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.3973 -21.9662 -4.5
-      vertex 29.3973 -20.8363 -4.5
-      vertex 29.5653 -21.0228 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.2723 -22.183 -4.5
-      vertex 29.3973 -20.8363 -4.5
-      vertex 29.3973 -21.9662 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.2723 -22.183 -4.5
-      vertex 29.2723 -20.6195 -4.5
-      vertex 29.3973 -20.8363 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1942 -22.4222 -4.5
-      vertex 29.2723 -20.6195 -4.5
-      vertex 29.2723 -22.183 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1942 -22.4222 -4.5
-      vertex 29.1942 -20.3812 -4.5
-      vertex 29.2723 -20.6195 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 29.1942 -22.9212 -4.5
-      vertex 23.6081 -24.0671 -4.5
-      vertex 29.1688 -22.6712 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1688 -22.6712 -4.5
-      vertex 23.63 -21.735 -4.5
-      vertex 29.1942 -22.4222 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.6081 -21.5271 -4.5
-      vertex 29.1942 -20.3812 -4.5
-      vertex 23.63 -21.735 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 29.1942 -20.3812 -4.5
-      vertex 23.6081 -21.5271 -4.5
-      vertex 29.1688 -20.1312 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.5435 -21.3283 -4.5
-      vertex 29.1688 -20.1312 -4.5
-      vertex 23.6081 -21.5271 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 29.1688 -20.1312 -4.5
-      vertex 23.5435 -21.3283 -4.5
-      vertex 29.1822 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.439 -21.1472 -4.5
-      vertex 29.1822 -20 -4.5
-      vertex 23.5435 -21.3283 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.2991 -20.9919 -4.5
-      vertex 29.1822 -20 -4.5
-      vertex 23.439 -21.1472 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 23.13 -20.869 -4.5
-      vertex 29.1822 -20 -4.5
-      vertex 23.2991 -20.9919 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.939 -20.7839 -4.5
-      vertex 29.1822 -20 -4.5
-      vertex 23.13 -20.869 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.7345 -20.7405 -4.5
-      vertex 29.1822 -20 -4.5
-      vertex 22.939 -20.7839 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.5255 -20.7405 -4.5
-      vertex 29.1822 -20 -4.5
-      vertex 22.7345 -20.7405 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.7165 -22.1417 -4.5
-      vertex 15.9235 -23.8683 -4.5
-      vertex 21.6519 -21.9429 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.819 -23.6872 -4.5
-      vertex 21.6519 -21.9429 -4.5
-      vertex 15.9235 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.6519 -21.9429 -4.5
-      vertex 15.819 -23.6872 -4.5
-      vertex 21.63 -21.735 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.6791 -23.5319 -4.5
-      vertex 21.63 -21.735 -4.5
-      vertex 15.819 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.63 -21.735 -4.5
-      vertex 15.6791 -23.5319 -4.5
-      vertex 21.6519 -21.5271 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.51 -23.409 -4.5
-      vertex 21.6519 -21.5271 -4.5
-      vertex 15.6791 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.6519 -21.5271 -4.5
-      vertex 15.51 -23.409 -4.5
-      vertex 21.7165 -21.3283 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.319 -23.3239 -4.5
-      vertex 21.7165 -21.3283 -4.5
-      vertex 15.51 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.7165 -21.3283 -4.5
-      vertex 15.319 -23.3239 -4.5
-      vertex 21.821 -21.1472 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.1145 -23.2805 -4.5
-      vertex 21.821 -21.1472 -4.5
-      vertex 15.319 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.821 -21.1472 -4.5
-      vertex 15.1145 -23.2805 -4.5
-      vertex 21.9609 -20.9919 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.9055 -23.2805 -4.5
-      vertex 21.9609 -20.9919 -4.5
-      vertex 15.1145 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21.9609 -20.9919 -4.5
-      vertex 14.9055 -23.2805 -4.5
-      vertex 22.13 -20.869 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.5745 -23.2805 -4.5
-      vertex 22.13 -20.869 -4.5
-      vertex 14.9055 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.5745 -23.2805 -4.5
-      vertex 14.9055 -23.2805 -4.5
-      vertex 14.701 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.47 -24.275 -4.5
-      vertex 14.0319 -24.0671 -4.5
-      vertex 14.01 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.4481 -24.0671 -4.5
-      vertex 14.0319 -24.0671 -4.5
-      vertex 13.47 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0319 -24.0671 -4.5
-      vertex 13.4481 -24.0671 -4.5
-      vertex 14.0965 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.3835 -23.8683 -4.5
-      vertex 14.0965 -23.8683 -4.5
-      vertex 13.4481 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.0965 -23.8683 -4.5
-      vertex 13.3835 -23.8683 -4.5
-      vertex 14.201 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.279 -23.6872 -4.5
-      vertex 14.201 -23.6872 -4.5
-      vertex 13.3835 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.201 -23.6872 -4.5
-      vertex 13.279 -23.6872 -4.5
-      vertex 14.3409 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.1391 -23.5319 -4.5
-      vertex 14.3409 -23.5319 -4.5
-      vertex 13.279 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.3409 -23.5319 -4.5
-      vertex 13.1391 -23.5319 -4.5
-      vertex 14.51 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.97 -23.409 -4.5
-      vertex 14.51 -23.409 -4.5
-      vertex 13.1391 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.51 -23.409 -4.5
-      vertex 12.97 -23.409 -4.5
-      vertex 14.701 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.779 -23.3239 -4.5
-      vertex 14.701 -23.3239 -4.5
-      vertex 12.97 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.5745 -23.2805 -4.5
-      vertex 14.701 -23.3239 -4.5
-      vertex 12.779 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 22.13 -20.869 -4.5
-      vertex 12.5745 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 12.5745 -23.2805 -4.5
-      vertex 12.3655 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.0345 -23.2805 -4.5
-      vertex 12.3655 -23.2805 -4.5
-      vertex 12.161 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.93 -24.275 -4.5
-      vertex 11.4919 -24.0671 -4.5
-      vertex 11.47 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.9081 -24.0671 -4.5
-      vertex 11.4919 -24.0671 -4.5
-      vertex 10.93 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.4919 -24.0671 -4.5
-      vertex 10.9081 -24.0671 -4.5
-      vertex 11.5565 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.8435 -23.8683 -4.5
-      vertex 11.5565 -23.8683 -4.5
-      vertex 10.9081 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.5565 -23.8683 -4.5
-      vertex 10.8435 -23.8683 -4.5
-      vertex 11.661 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.739 -23.6872 -4.5
-      vertex 11.661 -23.6872 -4.5
-      vertex 10.8435 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.661 -23.6872 -4.5
-      vertex 10.739 -23.6872 -4.5
-      vertex 11.8009 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.5991 -23.5319 -4.5
-      vertex 11.8009 -23.5319 -4.5
-      vertex 10.739 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.8009 -23.5319 -4.5
-      vertex 10.5991 -23.5319 -4.5
-      vertex 11.97 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.43 -23.409 -4.5
-      vertex 11.97 -23.409 -4.5
-      vertex 10.5991 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 11.97 -23.409 -4.5
-      vertex 10.43 -23.409 -4.5
-      vertex 12.161 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.239 -23.3239 -4.5
-      vertex 12.161 -23.3239 -4.5
-      vertex 10.43 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 10.0345 -23.2805 -4.5
-      vertex 12.161 -23.3239 -4.5
-      vertex 10.239 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 12.3655 -23.2805 -4.5
-      vertex 10.0345 -23.2805 -4.5
-      vertex 3 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.13 -20.869 -4.5
-      vertex 3 -20 -4.5
-      vertex 22.321 -20.7839 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 10.0345 -23.2805 -4.5
-      vertex 9.82547 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.39 -24.275 -4.5
-      vertex 8.95185 -24.0671 -4.5
-      vertex 8.93 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.36815 -24.0671 -4.5
-      vertex 8.95185 -24.0671 -4.5
-      vertex 8.39 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.95185 -24.0671 -4.5
-      vertex 8.36815 -24.0671 -4.5
-      vertex 9.01645 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.30354 -23.8683 -4.5
-      vertex 9.01645 -23.8683 -4.5
-      vertex 8.36815 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.01645 -23.8683 -4.5
-      vertex 8.30354 -23.8683 -4.5
-      vertex 9.12098 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.19902 -23.6872 -4.5
-      vertex 9.12098 -23.6872 -4.5
-      vertex 8.30354 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.12098 -23.6872 -4.5
-      vertex 8.19902 -23.6872 -4.5
-      vertex 9.26087 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 8.05913 -23.5319 -4.5
-      vertex 9.26087 -23.5319 -4.5
-      vertex 8.19902 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.26087 -23.5319 -4.5
-      vertex 8.05913 -23.5319 -4.5
-      vertex 9.43 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 7.89 -23.409 -4.5
-      vertex 9.43 -23.409 -4.5
-      vertex 8.05913 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.43 -23.409 -4.5
-      vertex 7.89 -23.409 -4.5
-      vertex 9.62098 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 7.69902 -23.3239 -4.5
-      vertex 9.62098 -23.3239 -4.5
-      vertex 7.89 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.62098 -23.3239 -4.5
-      vertex 7.69902 -23.3239 -4.5
-      vertex 9.82547 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 7.49453 -23.2805 -4.5
-      vertex 9.82547 -23.2805 -4.5
-      vertex 7.69902 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 9.82547 -23.2805 -4.5
-      vertex 7.49453 -23.2805 -4.5
-      vertex 3 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 7.49453 -23.2805 -4.5
-      vertex 7.28547 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.5255 -20.7405 -4.5
-      vertex 3 -20 -4.5
-      vertex 29.1822 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 22.321 -20.7839 -4.5
-      vertex 3 -20 -4.5
-      vertex 22.5255 -20.7405 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 7.08098 -23.3239 -4.5
-      vertex 3 -20 -4.5
-      vertex 7.28547 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.89 -23.409 -4.5
-      vertex 3 -20 -4.5
-      vertex 7.08098 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.72087 -23.5319 -4.5
-      vertex 3 -20 -4.5
-      vertex 6.89 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.58098 -23.6872 -4.5
-      vertex 3 -20 -4.5
-      vertex 6.72087 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.47645 -23.8683 -4.5
-      vertex 3 -20 -4.5
-      vertex 6.58098 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.41185 -24.0671 -4.5
-      vertex 3 -20 -4.5
-      vertex 6.47645 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 6.41185 -24.0671 -4.5
-      vertex 6.39 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 6.39 -24.275 -4.5
-      vertex 1.14633 -24.2582 -4.5
-      vertex 1 -23 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -23 -4.5
-      vertex 1.14633 -24.2582 -4.5
-      vertex 1.0682 -24.0199 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 1.2518 -18.6732 -4.5
-      vertex 1.5018 -18.6732 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -23 -4.5
-      vertex 1.0682 -24.0199 -4.5
-      vertex 1 -23.9011 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1.2518 -18.6732 -4.5
-      vertex 1 -23 -4.5
-      vertex 1.0057 -18.6205 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.792148 -18.6205 -4.5
-      vertex 1.0057 -18.6205 -4.5
-      vertex 1 -23 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.0057 -18.6205 -4.5
-      vertex -0.792148 -18.6205 -4.5
-      vertex 0.777187 -18.5189 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.777187 -18.5189 -4.5
-      vertex -0.563632 -18.5189 -4.5
-      vertex 0.574062 -18.3714 -4.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -0.360507 -18.3714 -4.5
-      vertex 0.574062 -18.3714 -4.5
-      vertex -0.563632 -18.5189 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0.509724 -18.3 -4.5
-      vertex -0.360507 -18.3714 -4.5
-      vertex -0.296169 -18.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.574062 -18.3714 -4.5
-      vertex -0.360507 -18.3714 -4.5
-      vertex 0.509724 -18.3 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 0.777187 -18.5189 -4.5
-      vertex -0.792148 -18.6205 -4.5
-      vertex -0.563632 -18.5189 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -23 -4.5
-      vertex -1.03726 -18.6732 -4.5
-      vertex -0.792148 -18.6205 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -23 -4.5
-      vertex -1.03726 -18.6732 -4.5
-      vertex 1 -23 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.03726 -18.6732 -4.5
-      vertex -3 -23 -4.5
-      vertex -1.28824 -18.6732 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.28824 -18.6732 -4.5
-      vertex -3 -23 -4.5
-      vertex -1.53434 -18.6205 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.53434 -18.6205 -4.5
-      vertex -3 -23 -4.5
-      vertex -1.76285 -18.5189 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 -18.3 -4.5
-      vertex -1.76285 -18.5189 -4.5
-      vertex -3 -23 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.76285 -18.5189 -4.5
-      vertex -3 -18.3 -4.5
-      vertex -1.96598 -18.3714 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -1.96598 -18.3714 -4.5
-      vertex -3 -18.3 -4.5
-      vertex -2.03031 -18.3 -4.5
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 0
-    outer loop
-      vertex -1.5 -2.59808 -2
-      vertex -0.927051 -2.85317 3.49412e-16
-      vertex -1.5 -2.59808 3.18173e-16
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 -0
-    outer loop
-      vertex -0.927051 -2.85317 3.49412e-16
-      vertex -1.5 -2.59808 -2
-      vertex -0.927051 -2.85317 -2
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 2.93444 0.623734 -7.63854e-17
-      vertex 2.74064 1.22021 -3
-      vertex 2.74064 1.22021 -1.49433e-16
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 2.74064 1.22021 -3
-      vertex 2.93444 0.623734 -7.63854e-17
-      vertex 2.93444 0.623734 -3
-    endloop
-  endfacet
-  facet normal 0.866026 -0.5 0
-    outer loop
-      vertex 2.42705 -1.76336 2.15949e-16
-      vertex 2.74064 -1.22021 -2
-      vertex 2.74064 -1.22021 1.49433e-16
-    endloop
-  endfacet
-  facet normal 0.866026 -0.5 0
-    outer loop
-      vertex 2.74064 -1.22021 -2
-      vertex 2.42705 -1.76336 2.15949e-16
-      vertex 2.42705 -1.76336 -2
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 2.74064 -1.22021 1.49433e-16
-      vertex 2.93444 -0.623734 -2
-      vertex 2.93444 -0.623734 7.63854e-17
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 2.93444 -0.623734 -2
-      vertex 2.74064 -1.22021 1.49433e-16
-      vertex 2.74064 -1.22021 -2
-    endloop
-  endfacet
-  facet normal 0.743144 -0.669131 0
-    outer loop
-      vertex 2.00739 -2.22943 2.73027e-16
-      vertex 2.42705 -1.76336 -2
-      vertex 2.42705 -1.76336 2.15949e-16
-    endloop
-  endfacet
-  facet normal 0.743144 -0.669131 0
-    outer loop
-      vertex 2.42705 -1.76336 -2
-      vertex 2.00739 -2.22943 2.73027e-16
-      vertex 2.00739 -2.22943 -2
-    endloop
-  endfacet
-  facet normal 0.207911 -0.978148 0
-    outer loop
-      vertex 0.313585 -2.98357 -2
-      vertex 0.927051 -2.85317 3.49412e-16
-      vertex 0.313585 -2.98357 3.65381e-16
-    endloop
-  endfacet
-  facet normal 0.207911 -0.978148 0
-    outer loop
-      vertex 0.927051 -2.85317 3.49412e-16
-      vertex 0.313585 -2.98357 -2
-      vertex 0.927051 -2.85317 -2
-    endloop
-  endfacet
-  facet normal -0.866026 -0.5 0
-    outer loop
-      vertex -2.42705 -1.76336 -2
-      vertex -2.74064 -1.22021 1.49433e-16
-      vertex -2.74064 -1.22021 -2
-    endloop
-  endfacet
-  facet normal -0.866026 -0.5 0
-    outer loop
-      vertex -2.74064 -1.22021 1.49433e-16
-      vertex -2.42705 -1.76336 -2
-      vertex -2.42705 -1.76336 2.15949e-16
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex -2.74064 -1.22021 -2
-      vertex -2.93444 -0.623734 7.63854e-17
-      vertex -2.93444 -0.623734 -2
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex -2.93444 -0.623734 7.63854e-17
-      vertex -2.74064 -1.22021 -2
-      vertex -2.74064 -1.22021 1.49433e-16
-    endloop
-  endfacet
-  facet normal -0.587785 -0.809017 0
-    outer loop
-      vertex -2.00739 -2.22943 -2
-      vertex -1.5 -2.59808 3.18173e-16
-      vertex -2.00739 -2.22943 2.73027e-16
-    endloop
-  endfacet
-  facet normal -0.587785 -0.809017 -0
-    outer loop
-      vertex -1.5 -2.59808 3.18173e-16
-      vertex -2.00739 -2.22943 -2
-      vertex -1.5 -2.59808 -2
-    endloop
-  endfacet
-  facet normal -0.207911 -0.978148 0
-    outer loop
-      vertex -0.927051 -2.85317 -2
-      vertex -0.313585 -2.98357 3.65381e-16
-      vertex -0.927051 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal -0.207911 -0.978148 -0
-    outer loop
-      vertex -0.313585 -2.98357 3.65381e-16
-      vertex -0.927051 -2.85317 -2
-      vertex -0.313585 -2.98357 -2
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 -1.28011e-17
-    outer loop
-      vertex 3 -2.44929e-16 -2
-      vertex 2.93444 0.623734 -7.63854e-17
-      vertex 3 0 0
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 2.93444 0.623734 -7.63854e-17
-      vertex 3 -2.44929e-16 -2
-      vertex 2.93444 0.623734 -3
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 -1.10638e-17
-    outer loop
-      vertex 2.93444 0.623734 -3
-      vertex 3 -2.44929e-16 -2
-      vertex 3 -3.67394e-16 -3
-    endloop
-  endfacet
-  facet normal 0.207911 0.978148 -0
-    outer loop
-      vertex 0.927051 2.85317 -3
-      vertex 0.313585 2.98357 -3.65381e-16
-      vertex 0.927051 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal 0.207911 0.978148 0
-    outer loop
-      vertex 0.313585 2.98357 -3.65381e-16
-      vertex 0.927051 2.85317 -3
-      vertex 0.313585 2.98357 -3
-    endloop
-  endfacet
-  facet normal 0.866026 0.5 0
-    outer loop
-      vertex 2.74064 1.22021 -1.49433e-16
-      vertex 2.42705 1.76336 -3
-      vertex 2.42705 1.76336 -2.15949e-16
-    endloop
-  endfacet
-  facet normal 0.866026 0.5 0
-    outer loop
-      vertex 2.42705 1.76336 -3
-      vertex 2.74064 1.22021 -1.49433e-16
-      vertex 2.74064 1.22021 -3
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex 1.25 0 0
-      vertex 3 0 0
-      vertex 2.93444 0.623734 -7.63854e-17
-    endloop
-  endfacet
-  facet normal 1.74915e-24 1.22465e-16 1
-    outer loop
-      vertex 1.22268 0.25989 -3.18273e-17
-      vertex 2.93444 0.623734 -7.63854e-17
-      vertex 2.74064 1.22021 -1.49433e-16
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 3 0 0
-      vertex 1.25 0 0
-      vertex 2.93444 -0.623734 7.63854e-17
-    endloop
-  endfacet
-  facet normal 2.17413e-24 1.22465e-16 1
-    outer loop
-      vertex 1.14193 0.50842 -6.22635e-17
-      vertex 2.74064 1.22021 -1.49433e-16
-      vertex 2.42705 1.76336 -2.15949e-16
-    endloop
-  endfacet
-  facet normal -2.2288e-24 1.22465e-16 1
-    outer loop
-      vertex 1.22268 -0.25989 3.18273e-17
-      vertex 2.93444 -0.623734 7.63854e-17
-      vertex 1.25 0 0
-    endloop
-  endfacet
-  facet normal -1.65498e-23 1.22465e-16 1
-    outer loop
-      vertex 1.01127 0.734731 -8.99786e-17
-      vertex 2.42705 1.76336 -2.15949e-16
-      vertex 2.00739 2.22943 -2.73027e-16
-    endloop
-  endfacet
-  facet normal -1.74915e-24 1.22465e-16 1
-    outer loop
-      vertex 2.93444 -0.623734 7.63854e-17
-      vertex 1.22268 -0.25989 3.18273e-17
-      vertex 2.74064 -1.22021 1.49433e-16
-    endloop
-  endfacet
-  facet normal 3.13997e-23 1.22465e-16 1
-    outer loop
-      vertex 0.836412 0.92893 -1.13761e-16
-      vertex 2.00739 2.22943 -2.73027e-16
-      vertex 1.5 2.59808 -3.18173e-16
-    endloop
-  endfacet
-  facet normal 3.88788e-24 1.22465e-16 1
-    outer loop
-      vertex 1.14193 -0.50842 6.22635e-17
-      vertex 2.74064 -1.22021 1.49433e-16
-      vertex 1.22268 -0.25989 3.18273e-17
-    endloop
-  endfacet
-  facet normal -2.17413e-24 1.22465e-16 1
-    outer loop
-      vertex 2.74064 -1.22021 1.49433e-16
-      vertex 1.14193 -0.50842 6.22635e-17
-      vertex 2.42705 -1.76336 2.15949e-16
-    endloop
-  endfacet
-  facet normal 2.2288e-24 1.22465e-16 1
-    outer loop
-      vertex 2.93444 0.623734 -7.63854e-17
-      vertex 1.22268 0.25989 -3.18273e-17
-      vertex 1.25 0 0
-    endloop
-  endfacet
-  facet normal -3.88788e-24 1.22465e-16 1
-    outer loop
-      vertex 2.74064 1.22021 -1.49433e-16
-      vertex 1.14193 0.50842 -6.22635e-17
-      vertex 1.22268 0.25989 -3.18273e-17
-    endloop
-  endfacet
-  facet normal 1.99023e-25 1.22465e-16 1
-    outer loop
-      vertex 2.42705 1.76336 -2.15949e-16
-      vertex 1.01127 0.734731 -8.99786e-17
-      vertex 1.14193 0.50842 -6.22635e-17
-    endloop
-  endfacet
-  facet normal -8.3176e-25 1.22465e-16 1
-    outer loop
-      vertex 0.625 1.08253 -1.32572e-16
-      vertex 1.5 2.59808 -3.18173e-16
-      vertex 0.927051 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal 2.631e-23 1.22465e-16 1
-    outer loop
-      vertex 2.00739 2.22943 -2.73027e-16
-      vertex 0.836412 0.92893 -1.13761e-16
-      vertex 1.01127 0.734731 -8.99786e-17
-    endloop
-  endfacet
-  facet normal -3.67007e-23 1.22465e-16 1
-    outer loop
-      vertex 1.5 2.59808 -3.18173e-16
-      vertex 0.625 1.08253 -1.32572e-16
-      vertex 0.836412 0.92893 -1.13761e-16
-    endloop
-  endfacet
-  facet normal 1.28031e-23 1.22465e-16 1
-    outer loop
-      vertex 0.927051 2.85317 -3.49412e-16
-      vertex 0.386271 1.18882 -1.45588e-16
-      vertex 0.625 1.08253 -1.32572e-16
-    endloop
-  endfacet
-  facet normal -1.56872e-23 1.22465e-16 1
-    outer loop
-      vertex 0.313585 2.98357 -3.65381e-16
-      vertex 0.386271 1.18882 -1.45588e-16
-      vertex 0.927051 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal 8.89886e-24 1.22465e-16 1
-    outer loop
-      vertex 0.313585 2.98357 -3.65381e-16
-      vertex 0.13066 1.24315 -1.52242e-16
-      vertex 0.386271 1.18882 -1.45588e-16
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 0.313585 2.98357 -3.65381e-16
-      vertex -0.13066 1.24315 -1.52242e-16
-      vertex 0.13066 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex -0.313585 2.98357 -3.65381e-16
-      vertex -0.13066 1.24315 -1.52242e-16
-      vertex 0.313585 2.98357 -3.65381e-16
-    endloop
-  endfacet
-  facet normal -8.89886e-24 1.22465e-16 1
-    outer loop
-      vertex -0.313585 2.98357 -3.65381e-16
-      vertex -0.386271 1.18882 -1.45588e-16
-      vertex -0.13066 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal 1.56872e-23 1.22465e-16 1
-    outer loop
-      vertex -0.927051 2.85317 -3.49412e-16
-      vertex -0.386271 1.18882 -1.45588e-16
-      vertex -0.313585 2.98357 -3.65381e-16
-    endloop
-  endfacet
-  facet normal -1.28031e-23 1.22465e-16 1
-    outer loop
-      vertex -0.386271 1.18882 -1.45588e-16
-      vertex -0.927051 2.85317 -3.49412e-16
-      vertex -0.625 1.08253 -1.32572e-16
-    endloop
-  endfacet
-  facet normal 8.3176e-25 1.22465e-16 1
-    outer loop
-      vertex -1.5 2.59808 -3.18173e-16
-      vertex -0.625 1.08253 -1.32572e-16
-      vertex -0.927051 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal 3.67007e-23 1.22465e-16 1
-    outer loop
-      vertex -0.625 1.08253 -1.32572e-16
-      vertex -1.5 2.59808 -3.18173e-16
-      vertex -0.836412 0.92893 -1.13761e-16
-    endloop
-  endfacet
-  facet normal -3.13997e-23 1.22465e-16 1
-    outer loop
-      vertex -2.00739 2.22943 -2.73027e-16
-      vertex -0.836412 0.92893 -1.13761e-16
-      vertex -1.5 2.59808 -3.18173e-16
-    endloop
-  endfacet
-  facet normal -2.631e-23 1.22465e-16 1
-    outer loop
-      vertex -0.836412 0.92893 -1.13761e-16
-      vertex -2.00739 2.22943 -2.73027e-16
-      vertex -1.01127 0.734731 -8.99786e-17
-    endloop
-  endfacet
-  facet normal 1.65498e-23 1.22465e-16 1
-    outer loop
-      vertex -2.42705 1.76336 -2.15949e-16
-      vertex -1.01127 0.734731 -8.99786e-17
-      vertex -2.00739 2.22943 -2.73027e-16
-    endloop
-  endfacet
-  facet normal -1.99023e-25 1.22465e-16 1
-    outer loop
-      vertex -1.01127 0.734731 -8.99786e-17
-      vertex -2.42705 1.76336 -2.15949e-16
-      vertex -1.14193 0.50842 -6.22635e-17
-    endloop
-  endfacet
-  facet normal -2.17413e-24 1.22465e-16 1
-    outer loop
-      vertex -2.74064 1.22021 -1.49433e-16
-      vertex -1.14193 0.50842 -6.22635e-17
-      vertex -2.42705 1.76336 -2.15949e-16
-    endloop
-  endfacet
-  facet normal 3.88788e-24 1.22465e-16 1
-    outer loop
-      vertex -1.14193 0.50842 -6.22635e-17
-      vertex -2.74064 1.22021 -1.49433e-16
-      vertex -1.22268 0.25989 -3.18273e-17
-    endloop
-  endfacet
-  facet normal 3.66038e-23 1.22465e-16 1
-    outer loop
-      vertex -1.25 0 0
-      vertex -2.00739 -2.22943 2.73027e-16
-      vertex -1.5 -2.59808 3.18173e-16
-    endloop
-  endfacet
-  facet normal -1.74915e-24 1.22465e-16 1
-    outer loop
-      vertex -2.93444 0.623734 -7.63854e-17
-      vertex -1.22268 0.25989 -3.18273e-17
-      vertex -2.74064 1.22021 -1.49433e-16
-    endloop
-  endfacet
-  facet normal -2.29407e-23 1.22465e-16 1
-    outer loop
-      vertex -1.25 0 0
-      vertex -2.42705 -1.76336 2.15949e-16
-      vertex -2.00739 -2.22943 2.73027e-16
-    endloop
-  endfacet
-  facet normal -2.2288e-24 1.22465e-16 1
-    outer loop
-      vertex -1.22268 0.25989 -3.18273e-17
-      vertex -2.93444 0.623734 -7.63854e-17
-      vertex -1.25 0 0
-    endloop
-  endfacet
-  facet normal 4.2279e-24 1.22465e-16 1
-    outer loop
-      vertex -1.25 0 0
-      vertex -2.74064 -1.22021 1.49433e-16
-      vertex -2.42705 -1.76336 2.15949e-16
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex -3 0 0
-      vertex -1.25 0 0
-      vertex -2.93444 0.623734 -7.63854e-17
-    endloop
-  endfacet
-  facet normal 1.43144e-24 1.22465e-16 1
-    outer loop
-      vertex -1.25 0 0
-      vertex -2.93444 -0.623734 7.63854e-17
-      vertex -2.74064 -1.22021 1.49433e-16
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex -1.25 0 0
-      vertex -3 0 0
-      vertex -2.93444 -0.623734 7.63854e-17
-    endloop
-  endfacet
-  facet normal -1.99023e-25 1.22465e-16 1
-    outer loop
-      vertex 1.01127 -0.734731 8.99786e-17
-      vertex 2.42705 -1.76336 2.15949e-16
-      vertex 1.14193 -0.50842 6.22635e-17
-    endloop
-  endfacet
-  facet normal 1.65498e-23 1.22465e-16 1
-    outer loop
-      vertex 2.42705 -1.76336 2.15949e-16
-      vertex 1.01127 -0.734731 8.99786e-17
-      vertex 2.00739 -2.22943 2.73027e-16
-    endloop
-  endfacet
-  facet normal -2.631e-23 1.22465e-16 1
-    outer loop
-      vertex 0.836412 -0.92893 1.13761e-16
-      vertex 2.00739 -2.22943 2.73027e-16
-      vertex 1.01127 -0.734731 8.99786e-17
-    endloop
-  endfacet
-  facet normal -3.13997e-23 1.22465e-16 1
-    outer loop
-      vertex 2.00739 -2.22943 2.73027e-16
-      vertex 0.836412 -0.92893 1.13761e-16
-      vertex 1.5 -2.59808 3.18173e-16
-    endloop
-  endfacet
-  facet normal 3.67007e-23 1.22465e-16 1
-    outer loop
-      vertex 0.625 -1.08253 1.32572e-16
-      vertex 1.5 -2.59808 3.18173e-16
-      vertex 0.836412 -0.92893 1.13761e-16
-    endloop
-  endfacet
-  facet normal 8.3176e-25 1.22465e-16 1
-    outer loop
-      vertex 1.5 -2.59808 3.18173e-16
-      vertex 0.625 -1.08253 1.32572e-16
-      vertex 0.927051 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal -1.28031e-23 1.22465e-16 1
-    outer loop
-      vertex 0.386271 -1.18882 1.45588e-16
-      vertex 0.927051 -2.85317 3.49412e-16
-      vertex 0.625 -1.08253 1.32572e-16
-    endloop
-  endfacet
-  facet normal 1.56872e-23 1.22465e-16 1
-    outer loop
-      vertex 0.386271 -1.18882 1.45588e-16
-      vertex 0.313585 -2.98357 3.65381e-16
-      vertex 0.927051 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal -8.89886e-24 1.22465e-16 1
-    outer loop
-      vertex 0.13066 -1.24315 1.52242e-16
-      vertex 0.313585 -2.98357 3.65381e-16
-      vertex 0.386271 -1.18882 1.45588e-16
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex -0.13066 -1.24315 1.52242e-16
-      vertex 0.313585 -2.98357 3.65381e-16
-      vertex 0.13066 -1.24315 1.52242e-16
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex -0.13066 -1.24315 1.52242e-16
-      vertex -0.313585 -2.98357 3.65381e-16
-      vertex 0.313585 -2.98357 3.65381e-16
-    endloop
-  endfacet
-  facet normal 8.89886e-24 1.22465e-16 1
-    outer loop
-      vertex -0.386271 -1.18882 1.45588e-16
-      vertex -0.313585 -2.98357 3.65381e-16
-      vertex -0.13066 -1.24315 1.52242e-16
-    endloop
-  endfacet
-  facet normal 1.28032e-23 1.22465e-16 1
-    outer loop
-      vertex -0.927051 -2.85317 3.49412e-16
-      vertex -0.386271 -1.18882 1.45588e-16
-      vertex -0.624999 -1.08253 1.32572e-16
-    endloop
-  endfacet
-  facet normal -3.67005e-23 1.22465e-16 1
-    outer loop
-      vertex -1.5 -2.59808 3.18173e-16
-      vertex -0.624999 -1.08253 1.32572e-16
-      vertex -0.836412 -0.92893 1.13761e-16
-    endloop
-  endfacet
-  facet normal -1.56872e-23 1.22465e-16 1
-    outer loop
-      vertex -0.386271 -1.18882 1.45588e-16
-      vertex -0.927051 -2.85317 3.49412e-16
-      vertex -0.313585 -2.98357 3.65381e-16
-    endloop
-  endfacet
-  facet normal 2.43382e-23 1.22465e-16 1
-    outer loop
-      vertex -1.5 -2.59808 3.18173e-16
-      vertex -0.836412 -0.92893 1.13761e-16
-      vertex -1.01127 -0.734731 8.99786e-17
-    endloop
-  endfacet
-  facet normal -9.37763e-25 1.22465e-16 1
-    outer loop
-      vertex -1.5 -2.59808 3.18173e-16
-      vertex -1.01127 -0.734731 8.99786e-17
-      vertex -1.14193 -0.50842 6.22635e-17
-    endloop
-  endfacet
-  facet normal -2.75517e-23 1.22465e-16 1
-    outer loop
-      vertex -1.5 -2.59808 3.18173e-16
-      vertex -1.14193 -0.50842 6.22635e-17
-      vertex -1.22268 -0.25989 3.18273e-17
-    endloop
-  endfacet
-  facet normal -8.31761e-25 1.22465e-16 1
-    outer loop
-      vertex -0.624999 -1.08253 1.32572e-16
-      vertex -1.5 -2.59808 3.18173e-16
-      vertex -0.927051 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal 1.9873e-24 1.22465e-16 1
-    outer loop
-      vertex -1.5 -2.59808 3.18173e-16
-      vertex -1.22268 -0.25989 3.18273e-17
-      vertex -1.25 0 0
-    endloop
-  endfacet
-  facet normal 0.587786 0.809016 -0
-    outer loop
-      vertex 2.00739 2.22943 -3
-      vertex 1.5 2.59808 -3.18173e-16
-      vertex 2.00739 2.22943 -2.73027e-16
-    endloop
-  endfacet
-  facet normal 0.587786 0.809016 0
-    outer loop
-      vertex 1.5 2.59808 -3.18173e-16
-      vertex 2.00739 2.22943 -3
-      vertex 1.5 2.59808 -3
-    endloop
-  endfacet
-  facet normal 0.406737 0.913545 -0
-    outer loop
-      vertex 1.5 2.59808 -3
-      vertex 0.927051 2.85317 -3.49412e-16
-      vertex 1.5 2.59808 -3.18173e-16
-    endloop
-  endfacet
-  facet normal 0.406737 0.913545 0
-    outer loop
-      vertex 0.927051 2.85317 -3.49412e-16
-      vertex 1.5 2.59808 -3
-      vertex 0.927051 2.85317 -3
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex -0.313585 2.98357 -4.5
-      vertex -0.927051 2.85317 -3.49412e-16
-      vertex -0.313585 2.98357 -3.65381e-16
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex -0.927051 2.85317 -3.49412e-16
-      vertex -0.313585 2.98357 -4.5
-      vertex -0.927051 2.85317 -4.5
-    endloop
-  endfacet
-  facet normal -0.743144 0.669131 0
-    outer loop
-      vertex -2.42705 1.76336 -4.5
-      vertex -2.00739 2.22943 -2.73027e-16
-      vertex -2.00739 2.22943 -4.5
-    endloop
-  endfacet
-  facet normal -0.743144 0.669131 0
-    outer loop
-      vertex -2.00739 2.22943 -2.73027e-16
-      vertex -2.42705 1.76336 -4.5
-      vertex -2.42705 1.76336 -2.15949e-16
-    endloop
-  endfacet
-  facet normal -0.866026 0.5 0
-    outer loop
-      vertex -2.74064 1.22021 -4.5
-      vertex -2.42705 1.76336 -2.15949e-16
-      vertex -2.42705 1.76336 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.5 0
-    outer loop
-      vertex -2.42705 1.76336 -2.15949e-16
-      vertex -2.74064 1.22021 -4.5
-      vertex -2.74064 1.22021 -1.49433e-16
-    endloop
-  endfacet
-  facet normal -0.951056 0.309017 0
-    outer loop
-      vertex -2.93444 0.623734 -4.5
-      vertex -2.74064 1.22021 -1.49433e-16
-      vertex -2.74064 1.22021 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 0.309017 0
-    outer loop
-      vertex -2.74064 1.22021 -1.49433e-16
-      vertex -2.93444 0.623734 -4.5
-      vertex -2.93444 0.623734 -7.63854e-17
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex -3 -2.44929e-16 -2
-      vertex -2.93444 0.623734 -7.63854e-17
-      vertex -2.93444 0.623734 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 -1.10638e-17
-    outer loop
-      vertex -2.93444 0.623734 -7.63854e-17
-      vertex -3 -2.44929e-16 -2
-      vertex -3 0 0
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 -1.28011e-17
-    outer loop
-      vertex -3 -2.44929e-16 -2
-      vertex -2.93444 0.623734 -4.5
-      vertex -3 -5.51091e-16 -4.5
-    endloop
-  endfacet
-  facet normal 0.743144 0.669131 0
-    outer loop
-      vertex 2.42705 1.76336 -2.15949e-16
-      vertex 2.00739 2.22943 -3
-      vertex 2.00739 2.22943 -2.73027e-16
-    endloop
-  endfacet
-  facet normal 0.743144 0.669131 0
-    outer loop
-      vertex 2.00739 2.22943 -3
-      vertex 2.42705 1.76336 -2.15949e-16
-      vertex 2.42705 1.76336 -3
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex -0.927051 2.85317 -4.5
-      vertex -1.5 2.59808 -3.18173e-16
-      vertex -0.927051 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex -1.5 2.59808 -3.18173e-16
-      vertex -0.927051 2.85317 -4.5
-      vertex -1.5 2.59808 -4.5
-    endloop
-  endfacet
-  facet normal -0.587786 0.809016 0
-    outer loop
-      vertex -1.5 2.59808 -4.5
-      vertex -2.00739 2.22943 -2.73027e-16
-      vertex -1.5 2.59808 -3.18173e-16
-    endloop
-  endfacet
-  facet normal -0.587786 0.809016 0
-    outer loop
-      vertex -2.00739 2.22943 -2.73027e-16
-      vertex -1.5 2.59808 -4.5
-      vertex -2.00739 2.22943 -4.5
-    endloop
-  endfacet
-  facet normal 0.866027 -0.499997 0
-    outer loop
-      vertex 60.4271 -1.76336 2.15949e-16
-      vertex 60.7406 -1.22021 -2
-      vertex 60.7406 -1.22021 1.49433e-16
-    endloop
-  endfacet
-  facet normal 0.866027 -0.499997 0
-    outer loop
-      vertex 60.7406 -1.22021 -2
-      vertex 60.4271 -1.76336 2.15949e-16
-      vertex 60.4271 -1.76336 -2
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex 59.25 0 0
-      vertex 61 0 0
-      vertex 60.9344 0.623734 -7.63854e-17
-    endloop
-  endfacet
-  facet normal 1.74915e-24 1.22465e-16 1
-    outer loop
-      vertex 59.2227 0.25989 -3.18273e-17
-      vertex 60.9344 0.623734 -7.63854e-17
-      vertex 60.7406 1.22021 -1.49433e-16
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 61 0 0
-      vertex 59.25 0 0
-      vertex 60.9344 -0.623734 7.63854e-17
-    endloop
-  endfacet
-  facet normal 2.17413e-24 1.22465e-16 1
-    outer loop
-      vertex 59.1419 0.50842 -6.22635e-17
-      vertex 60.7406 1.22021 -1.49433e-16
-      vertex 60.4271 1.76336 -2.15949e-16
-    endloop
-  endfacet
-  facet normal -2.2288e-24 1.22465e-16 1
-    outer loop
-      vertex 59.2227 -0.25989 3.18273e-17
-      vertex 60.9344 -0.623734 7.63854e-17
-      vertex 59.25 0 0
-    endloop
-  endfacet
-  facet normal -1.65498e-23 1.22465e-16 1
-    outer loop
-      vertex 59.0113 0.734731 -8.99786e-17
-      vertex 60.4271 1.76336 -2.15949e-16
-      vertex 60.0074 2.22943 -2.73027e-16
-    endloop
-  endfacet
-  facet normal -1.74915e-24 1.22465e-16 1
-    outer loop
-      vertex 60.9344 -0.623734 7.63854e-17
-      vertex 59.2227 -0.25989 3.18273e-17
-      vertex 60.7406 -1.22021 1.49433e-16
-    endloop
-  endfacet
-  facet normal 3.13996e-23 1.22465e-16 1
-    outer loop
-      vertex 58.8364 0.92893 -1.13761e-16
-      vertex 60.0074 2.22943 -2.73027e-16
-      vertex 59.5 2.59808 -3.18173e-16
-    endloop
-  endfacet
-  facet normal 3.88787e-24 1.22465e-16 1
-    outer loop
-      vertex 59.1419 -0.50842 6.22635e-17
-      vertex 60.7406 -1.22021 1.49433e-16
-      vertex 59.2227 -0.25989 3.18273e-17
-    endloop
-  endfacet
-  facet normal -2.17413e-24 1.22465e-16 1
-    outer loop
-      vertex 60.7406 -1.22021 1.49433e-16
-      vertex 59.1419 -0.50842 6.22635e-17
-      vertex 60.4271 -1.76336 2.15949e-16
-    endloop
-  endfacet
-  facet normal 2.2288e-24 1.22465e-16 1
-    outer loop
-      vertex 60.9344 0.623734 -7.63854e-17
-      vertex 59.2227 0.25989 -3.18273e-17
-      vertex 59.25 0 0
-    endloop
-  endfacet
-  facet normal -3.88787e-24 1.22465e-16 1
-    outer loop
-      vertex 60.7406 1.22021 -1.49433e-16
-      vertex 59.1419 0.50842 -6.22635e-17
-      vertex 59.2227 0.25989 -3.18273e-17
-    endloop
-  endfacet
-  facet normal 1.99023e-25 1.22465e-16 1
-    outer loop
-      vertex 60.4271 1.76336 -2.15949e-16
-      vertex 59.0113 0.734731 -8.99786e-17
-      vertex 59.1419 0.50842 -6.22635e-17
-    endloop
-  endfacet
-  facet normal -8.31761e-25 1.22465e-16 1
-    outer loop
-      vertex 58.625 1.08253 -1.32572e-16
-      vertex 59.5 2.59808 -3.18173e-16
-      vertex 58.9271 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal 2.631e-23 1.22465e-16 1
-    outer loop
-      vertex 60.0074 2.22943 -2.73027e-16
-      vertex 58.8364 0.92893 -1.13761e-16
-      vertex 59.0113 0.734731 -8.99786e-17
-    endloop
-  endfacet
-  facet normal -3.67009e-23 1.22465e-16 1
-    outer loop
-      vertex 59.5 2.59808 -3.18173e-16
-      vertex 58.625 1.08253 -1.32572e-16
-      vertex 58.8364 0.92893 -1.13761e-16
-    endloop
-  endfacet
-  facet normal 1.2803e-23 1.22465e-16 1
-    outer loop
-      vertex 58.9271 2.85317 -3.49412e-16
-      vertex 58.3863 1.18882 -1.45588e-16
-      vertex 58.625 1.08253 -1.32572e-16
-    endloop
-  endfacet
-  facet normal -1.56871e-23 1.22465e-16 1
-    outer loop
-      vertex 58.3136 2.98357 -3.65381e-16
-      vertex 58.3863 1.18882 -1.45588e-16
-      vertex 58.9271 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal 8.89896e-24 1.22465e-16 1
-    outer loop
-      vertex 58.3136 2.98357 -3.65381e-16
-      vertex 58.1307 1.24315 -1.52242e-16
-      vertex 58.3863 1.18882 -1.45588e-16
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 58.3136 2.98357 -3.65381e-16
-      vertex 57.8693 1.24315 -1.52242e-16
-      vertex 58.1307 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex 57.6864 2.98357 -3.65381e-16
-      vertex 57.8693 1.24315 -1.52242e-16
-      vertex 58.3136 2.98357 -3.65381e-16
-    endloop
-  endfacet
-  facet normal -8.89883e-24 1.22465e-16 1
-    outer loop
-      vertex 57.6864 2.98357 -3.65381e-16
-      vertex 57.6137 1.18882 -1.45588e-16
-      vertex 57.8693 1.24315 -1.52242e-16
-    endloop
-  endfacet
-  facet normal 1.56872e-23 1.22465e-16 1
-    outer loop
-      vertex 57.0729 2.85317 -3.49412e-16
-      vertex 57.6137 1.18882 -1.45588e-16
-      vertex 57.6864 2.98357 -3.65381e-16
-    endloop
-  endfacet
-  facet normal -1.28032e-23 1.22465e-16 1
-    outer loop
-      vertex 57.6137 1.18882 -1.45588e-16
-      vertex 57.0729 2.85317 -3.49412e-16
-      vertex 57.375 1.08253 -1.32572e-16
-    endloop
-  endfacet
-  facet normal 8.31761e-25 1.22465e-16 1
-    outer loop
-      vertex 56.5 2.59808 -3.18173e-16
-      vertex 57.375 1.08253 -1.32572e-16
-      vertex 57.0729 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal 3.67004e-23 1.22465e-16 1
-    outer loop
-      vertex 57.375 1.08253 -1.32572e-16
-      vertex 56.5 2.59808 -3.18173e-16
-      vertex 57.1636 0.92893 -1.13761e-16
-    endloop
-  endfacet
-  facet normal -3.13996e-23 1.22465e-16 1
-    outer loop
-      vertex 55.9926 2.22943 -2.73027e-16
-      vertex 57.1636 0.92893 -1.13761e-16
-      vertex 56.5 2.59808 -3.18173e-16
-    endloop
-  endfacet
-  facet normal -2.631e-23 1.22465e-16 1
-    outer loop
-      vertex 57.1636 0.92893 -1.13761e-16
-      vertex 55.9926 2.22943 -2.73027e-16
-      vertex 56.9887 0.734731 -8.99786e-17
-    endloop
-  endfacet
-  facet normal -1.99023e-25 1.22465e-16 1
-    outer loop
-      vertex 56.9887 0.734731 -8.99786e-17
-      vertex 55.5729 1.76336 -2.15949e-16
-      vertex 56.8581 0.50842 -6.22635e-17
-    endloop
-  endfacet
-  facet normal 1.65498e-23 1.22465e-16 1
-    outer loop
-      vertex 55.5729 1.76336 -2.15949e-16
-      vertex 56.9887 0.734731 -8.99786e-17
-      vertex 55.9926 2.22943 -2.73027e-16
-    endloop
-  endfacet
-  facet normal -1.99023e-25 1.22465e-16 1
-    outer loop
-      vertex 59.0113 -0.734731 8.99786e-17
-      vertex 60.4271 -1.76336 2.15949e-16
-      vertex 59.1419 -0.50842 6.22635e-17
-    endloop
-  endfacet
-  facet normal 1.65498e-23 1.22465e-16 1
-    outer loop
-      vertex 60.4271 -1.76336 2.15949e-16
-      vertex 59.0113 -0.734731 8.99786e-17
-      vertex 60.0074 -2.22943 2.73027e-16
-    endloop
-  endfacet
-  facet normal -2.631e-23 1.22465e-16 1
-    outer loop
-      vertex 58.8364 -0.92893 1.13761e-16
-      vertex 60.0074 -2.22943 2.73027e-16
-      vertex 59.0113 -0.734731 8.99786e-17
-    endloop
-  endfacet
-  facet normal -3.13996e-23 1.22465e-16 1
-    outer loop
-      vertex 60.0074 -2.22943 2.73027e-16
-      vertex 58.8364 -0.92893 1.13761e-16
-      vertex 59.5 -2.59808 3.18173e-16
-    endloop
-  endfacet
-  facet normal 3.67009e-23 1.22465e-16 1
-    outer loop
-      vertex 58.625 -1.08253 1.32572e-16
-      vertex 59.5 -2.59808 3.18173e-16
-      vertex 58.8364 -0.92893 1.13761e-16
-    endloop
-  endfacet
-  facet normal 8.31761e-25 1.22465e-16 1
-    outer loop
-      vertex 59.5 -2.59808 3.18173e-16
-      vertex 58.625 -1.08253 1.32572e-16
-      vertex 58.9271 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal -1.2803e-23 1.22465e-16 1
-    outer loop
-      vertex 58.3863 -1.18882 1.45588e-16
-      vertex 58.9271 -2.85317 3.49412e-16
-      vertex 58.625 -1.08253 1.32572e-16
-    endloop
-  endfacet
-  facet normal 1.56871e-23 1.22465e-16 1
-    outer loop
-      vertex 58.3863 -1.18882 1.45588e-16
-      vertex 58.3136 -2.98357 3.65381e-16
-      vertex 58.9271 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal -8.89896e-24 1.22465e-16 1
-    outer loop
-      vertex 58.1307 -1.24315 1.52242e-16
-      vertex 58.3136 -2.98357 3.65381e-16
-      vertex 58.3863 -1.18882 1.45588e-16
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex 57.8693 -1.24315 1.52242e-16
-      vertex 58.3136 -2.98357 3.65381e-16
-      vertex 58.1307 -1.24315 1.52242e-16
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 57.8693 -1.24315 1.52242e-16
-      vertex 57.6864 -2.98357 3.65381e-16
-      vertex 58.3136 -2.98357 3.65381e-16
-    endloop
-  endfacet
-  facet normal 8.89883e-24 1.22465e-16 1
-    outer loop
-      vertex 57.6137 -1.18882 1.45588e-16
-      vertex 57.6864 -2.98357 3.65381e-16
-      vertex 57.8693 -1.24315 1.52242e-16
-    endloop
-  endfacet
-  facet normal 1.28032e-23 1.22465e-16 1
-    outer loop
-      vertex 57.0729 -2.85317 3.49412e-16
-      vertex 57.6137 -1.18882 1.45588e-16
-      vertex 57.375 -1.08253 1.32572e-16
-    endloop
-  endfacet
-  facet normal -3.67004e-23 1.22465e-16 1
-    outer loop
-      vertex 56.5 -2.59808 3.18173e-16
-      vertex 57.375 -1.08253 1.32572e-16
-      vertex 57.1636 -0.92893 1.13761e-16
-    endloop
-  endfacet
-  facet normal -1.56872e-23 1.22465e-16 1
-    outer loop
-      vertex 57.6137 -1.18882 1.45588e-16
-      vertex 57.0729 -2.85317 3.49412e-16
-      vertex 57.6864 -2.98357 3.65381e-16
-    endloop
-  endfacet
-  facet normal 2.631e-23 1.22465e-16 1
-    outer loop
-      vertex 55.9926 -2.22943 2.73027e-16
-      vertex 57.1636 -0.92893 1.13761e-16
-      vertex 56.9887 -0.734731 8.99786e-17
-    endloop
-  endfacet
-  facet normal 1.99023e-25 1.22465e-16 1
-    outer loop
-      vertex 55.5729 -1.76336 2.15949e-16
-      vertex 56.9887 -0.734731 8.99786e-17
-      vertex 56.8581 -0.50842 6.22635e-17
-    endloop
-  endfacet
-  facet normal -3.88787e-24 1.22465e-16 1
-    outer loop
-      vertex 55.2594 -1.22021 1.49433e-16
-      vertex 56.8581 -0.50842 6.22635e-17
-      vertex 56.7773 -0.25989 3.18273e-17
-    endloop
-  endfacet
-  facet normal -8.31761e-25 1.22465e-16 1
-    outer loop
-      vertex 57.375 -1.08253 1.32572e-16
-      vertex 56.5 -2.59808 3.18173e-16
-      vertex 57.0729 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal 2.22881e-24 1.22465e-16 1
-    outer loop
-      vertex 55.0656 -0.623734 7.63854e-17
-      vertex 56.7773 -0.25989 3.18273e-17
-      vertex 56.75 0 0
-    endloop
-  endfacet
-  facet normal -2.17413e-24 1.22465e-16 1
-    outer loop
-      vertex 55.2594 1.22021 -1.49433e-16
-      vertex 56.8581 0.50842 -6.22635e-17
-      vertex 55.5729 1.76336 -2.15949e-16
-    endloop
-  endfacet
-  facet normal 3.88787e-24 1.22465e-16 1
-    outer loop
-      vertex 56.8581 0.50842 -6.22635e-17
-      vertex 55.2594 1.22021 -1.49433e-16
-      vertex 56.7773 0.25989 -3.18273e-17
-    endloop
-  endfacet
-  facet normal 3.13996e-23 1.22465e-16 1
-    outer loop
-      vertex 57.1636 -0.92893 1.13761e-16
-      vertex 55.9926 -2.22943 2.73027e-16
-      vertex 56.5 -2.59808 3.18173e-16
-    endloop
-  endfacet
-  facet normal -1.74915e-24 1.22465e-16 1
-    outer loop
-      vertex 55.0656 0.623734 -7.63854e-17
-      vertex 56.7773 0.25989 -3.18273e-17
-      vertex 55.2594 1.22021 -1.49433e-16
-    endloop
-  endfacet
-  facet normal -1.65498e-23 1.22465e-16 1
-    outer loop
-      vertex 56.9887 -0.734731 8.99786e-17
-      vertex 55.5729 -1.76336 2.15949e-16
-      vertex 55.9926 -2.22943 2.73027e-16
-    endloop
-  endfacet
-  facet normal -2.22881e-24 1.22465e-16 1
-    outer loop
-      vertex 56.7773 0.25989 -3.18273e-17
-      vertex 55.0656 0.623734 -7.63854e-17
-      vertex 56.75 0 0
-    endloop
-  endfacet
-  facet normal 2.17413e-24 1.22465e-16 1
-    outer loop
-      vertex 56.8581 -0.50842 6.22635e-17
-      vertex 55.2594 -1.22021 1.49433e-16
-      vertex 55.5729 -1.76336 2.15949e-16
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex 55 0 0
-      vertex 56.75 0 0
-      vertex 55.0656 0.623734 -7.63854e-17
-    endloop
-  endfacet
-  facet normal 1.74915e-24 1.22465e-16 1
-    outer loop
-      vertex 56.7773 -0.25989 3.18273e-17
-      vertex 55.0656 -0.623734 7.63854e-17
-      vertex 55.2594 -1.22021 1.49433e-16
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 56.75 0 0
-      vertex 55 0 0
-      vertex 55.0656 -0.623734 7.63854e-17
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 60.0074 -2.22943 2.73027e-16
-      vertex 60.4271 -1.76336 -2
-      vertex 60.4271 -1.76336 2.15949e-16
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 60.4271 -1.76336 -2
-      vertex 60.0074 -2.22943 2.73027e-16
-      vertex 60.0074 -2.22943 -2
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 57.6864 -2.98357 -2
-      vertex 58.3136 -2.98357 3.65381e-16
-      vertex 57.6864 -2.98357 3.65381e-16
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 58.3136 -2.98357 3.65381e-16
-      vertex 57.6864 -2.98357 -2
-      vertex 58.3136 -2.98357 -2
-    endloop
-  endfacet
-  facet normal 0.20791 -0.978148 0
-    outer loop
-      vertex 58.3136 -2.98357 -2
-      vertex 58.9271 -2.85317 3.49412e-16
-      vertex 58.3136 -2.98357 3.65381e-16
-    endloop
-  endfacet
-  facet normal 0.20791 -0.978148 0
-    outer loop
-      vertex 58.9271 -2.85317 3.49412e-16
-      vertex 58.3136 -2.98357 -2
-      vertex 58.9271 -2.85317 -2
-    endloop
-  endfacet
-  facet normal -0.587785 -0.809017 0
-    outer loop
-      vertex 55.9926 -2.22943 -2
-      vertex 56.5 -2.59808 3.18173e-16
-      vertex 55.9926 -2.22943 2.73027e-16
-    endloop
-  endfacet
-  facet normal -0.587785 -0.809017 -0
-    outer loop
-      vertex 56.5 -2.59808 3.18173e-16
-      vertex 55.9926 -2.22943 -2
-      vertex 56.5 -2.59808 -2
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309016 0
-    outer loop
-      vertex 55.2594 -1.22021 -2
-      vertex 55.0656 -0.623734 7.63854e-17
-      vertex 55.0656 -0.623734 -2
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309016 0
-    outer loop
-      vertex 55.0656 -0.623734 7.63854e-17
-      vertex 55.2594 -1.22021 -2
-      vertex 55.2594 -1.22021 1.49433e-16
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 55.9926 -2.22943 -2
-      vertex 55.5729 -1.76336 2.15949e-16
-      vertex 55.5729 -1.76336 -2
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 55.5729 -1.76336 2.15949e-16
-      vertex 55.9926 -2.22943 -2
-      vertex 55.9926 -2.22943 2.73027e-16
-    endloop
-  endfacet
-  facet normal 0.994522 0.104532 -1.28015e-17
-    outer loop
-      vertex 61 -2.44929e-16 -2
-      vertex 60.9344 0.623734 -7.63854e-17
-      vertex 61 0 0
-    endloop
-  endfacet
-  facet normal 0.994522 0.104532 0
-    outer loop
-      vertex 60.9344 0.623734 -7.63854e-17
-      vertex 61 -2.44929e-16 -2
-      vertex 60.9344 0.623734 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104532 -1.32766e-17
-    outer loop
-      vertex 60.9344 0.623734 -4.5
-      vertex 61 -2.44929e-16 -2
-      vertex 61 -5.51091e-16 -4.5
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309016 0
-    outer loop
-      vertex 60.7406 -1.22021 1.49433e-16
-      vertex 60.9344 -0.623734 -2
-      vertex 60.9344 -0.623734 7.63854e-17
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309016 0
-    outer loop
-      vertex 60.9344 -0.623734 -2
-      vertex 60.7406 -1.22021 1.49433e-16
-      vertex 60.7406 -1.22021 -2
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 59.5 -2.59808 -2
-      vertex 60.0074 -2.22943 2.73027e-16
-      vertex 59.5 -2.59808 3.18173e-16
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 60.0074 -2.22943 2.73027e-16
-      vertex 59.5 -2.59808 -2
-      vertex 60.0074 -2.22943 -2
-    endloop
-  endfacet
-  facet normal -0.207912 -0.978148 0
-    outer loop
-      vertex 57.0729 -2.85317 -2
-      vertex 57.6864 -2.98357 3.65381e-16
-      vertex 57.0729 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal -0.207912 -0.978148 -0
-    outer loop
-      vertex 57.6864 -2.98357 3.65381e-16
-      vertex 57.0729 -2.85317 -2
-      vertex 57.6864 -2.98357 -2
-    endloop
-  endfacet
-  facet normal 0.406737 -0.913545 0
-    outer loop
-      vertex 58.9271 -2.85317 -2
-      vertex 59.5 -2.59808 3.18173e-16
-      vertex 58.9271 -2.85317 3.49412e-16
-    endloop
-  endfacet
-  facet normal 0.406737 -0.913545 0
-    outer loop
-      vertex 59.5 -2.59808 3.18173e-16
-      vertex 58.9271 -2.85317 -2
-      vertex 59.5 -2.59808 -2
-    endloop
-  endfacet
-  facet normal -0.994522 0.104526 0
-    outer loop
-      vertex 55 -2.44929e-16 -2
-      vertex 55.0656 0.623734 -7.63854e-17
-      vertex 55.0656 0.623734 -2.7
-    endloop
-  endfacet
-  facet normal -0.994522 0.104526 -1.10638e-17
-    outer loop
-      vertex 55.0656 0.623734 -7.63854e-17
-      vertex 55 -2.44929e-16 -2
-      vertex 55 0 0
-    endloop
-  endfacet
-  facet normal -0.994522 0.104526 -1.28007e-17
-    outer loop
-      vertex 55 -2.44929e-16 -2
-      vertex 55.0656 0.623734 -2.7
-      vertex 55 -3.30655e-16 -2.7
-    endloop
-  endfacet
-  facet normal -0.866024 -0.500002 0
-    outer loop
-      vertex 55.5729 -1.76336 -2
-      vertex 55.2594 -1.22021 1.49433e-16
-      vertex 55.2594 -1.22021 -2
-    endloop
-  endfacet
-  facet normal -0.866024 -0.500002 0
-    outer loop
-      vertex 55.2594 -1.22021 1.49433e-16
-      vertex 55.5729 -1.76336 -2
-      vertex 55.5729 -1.76336 2.15949e-16
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 0
-    outer loop
-      vertex 56.5 -2.59808 -2
-      vertex 57.0729 -2.85317 3.49412e-16
-      vertex 56.5 -2.59808 3.18173e-16
-    endloop
-  endfacet
-  facet normal -0.406737 -0.913545 -0
-    outer loop
-      vertex 57.0729 -2.85317 3.49412e-16
-      vertex 56.5 -2.59808 -2
-      vertex 57.0729 -2.85317 -2
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104532 1.10638e-17
-    outer loop
-      vertex 60.9344 -0.623734 7.63854e-17
-      vertex 61 -2.44929e-16 -2
-      vertex 61 0 0
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104532 0
-    outer loop
-      vertex 61 -2.44929e-16 -2
-      vertex 60.9344 -0.623734 7.63854e-17
-      vertex 60.9344 -0.623734 -2
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 -0
-    outer loop
-      vertex 60.0074 2.22943 -4.5
-      vertex 59.5 2.59808 -3.18173e-16
-      vertex 60.0074 2.22943 -2.73027e-16
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 0
-    outer loop
-      vertex 59.5 2.59808 -3.18173e-16
-      vertex 60.0074 2.22943 -4.5
-      vertex 59.5 2.59808 -4.5
-    endloop
-  endfacet
-  facet normal 0.866027 0.499997 0
-    outer loop
-      vertex 60.7406 1.22021 -1.49433e-16
-      vertex 60.4271 1.76336 -4.5
-      vertex 60.4271 1.76336 -2.15949e-16
-    endloop
-  endfacet
-  facet normal 0.866027 0.499997 0
-    outer loop
-      vertex 60.4271 1.76336 -4.5
-      vertex 60.7406 1.22021 -1.49433e-16
-      vertex 60.7406 1.22021 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 58.3136 2.98357 -3.65381e-16
-      vertex 58 2.98357 -2.7
-      vertex 57.6864 2.98357 -3.65381e-16
+      vertex 37.7 29.5 2.4
+      vertex 37.7 29.5 2.1
+      vertex 28 29.5 2.4
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 58.3136 2.98357 -4.5
-      vertex 58 2.98357 -2.7
-      vertex 58.3136 2.98357 -3.65381e-16
+      vertex 28 29.5 2.4
+      vertex 26 29.5 4.5
+      vertex 28 29.5 4.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 58 2.98357 -2.7
-      vertex 58.3136 2.98357 -4.5
-      vertex 58 2.98357 -4.5
+      vertex 28 29.5 2.4
+      vertex 26 29.5 2
+      vertex 26 29.5 4.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 57.6864 2.98357 -3.65381e-16
-      vertex 58 2.98357 -2.7
-      vertex 57.6864 2.98357 -2.7
+      vertex 26 29.5 2
+      vertex 28 29.5 2.4
+      vertex 37.7 29.5 2.1
     endloop
   endfacet
-  facet normal 0.406737 0.913545 -0
+  facet normal 0 1 0
     outer loop
-      vertex 59.5 2.59808 -4.5
-      vertex 58.9271 2.85317 -3.49412e-16
-      vertex 59.5 2.59808 -3.18173e-16
+      vertex 18.5 29.5 1.1
+      vertex 3.5 29.5 0
+      vertex 6.5 29.5 1.1
     endloop
   endfacet
-  facet normal 0.406737 0.913545 0
+  facet normal 0 1 0
     outer loop
-      vertex 58.9271 2.85317 -3.49412e-16
-      vertex 59.5 2.59808 -4.5
-      vertex 58.9271 2.85317 -4.5
+      vertex 6.5 29.5 1.1
+      vertex 3.5 29.5 0
+      vertex 3.5 29.5 1.1
     endloop
   endfacet
-  facet normal -0.994522 -0.104526 1.10638e-17
+  facet normal 0 1 0
     outer loop
-      vertex 55.0656 -0.623734 -2
-      vertex 55 0 0
-      vertex 55 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104526 0
-    outer loop
-      vertex 55 0 0
-      vertex 55.0656 -0.623734 -2
-      vertex 55.0656 -0.623734 7.63854e-17
-    endloop
-  endfacet
-  facet normal -0.951057 0.309016 0
-    outer loop
-      vertex 55.0656 0.623734 -2.7
-      vertex 55.2594 1.22021 -1.49433e-16
-      vertex 55.2594 1.22021 -2.7
-    endloop
-  endfacet
-  facet normal -0.951057 0.309016 0
-    outer loop
-      vertex 55.2594 1.22021 -1.49433e-16
-      vertex 55.0656 0.623734 -2.7
-      vertex 55.0656 0.623734 -7.63854e-17
-    endloop
-  endfacet
-  facet normal 0.951057 0.309016 0
-    outer loop
-      vertex 60.9344 0.623734 -7.63854e-17
-      vertex 60.7406 1.22021 -4.5
-      vertex 60.7406 1.22021 -1.49433e-16
-    endloop
-  endfacet
-  facet normal 0.951057 0.309016 0
-    outer loop
-      vertex 60.7406 1.22021 -4.5
-      vertex 60.9344 0.623734 -7.63854e-17
-      vertex 60.9344 0.623734 -4.5
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 57.0729 2.85317 -2.7
-      vertex 56.5 2.59808 -3.18173e-16
-      vertex 57.0729 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 56.5 2.59808 -3.18173e-16
-      vertex 57.0729 2.85317 -2.7
-      vertex 56.5 2.59808 -2.7
-    endloop
-  endfacet
-  facet normal 0.20791 0.978148 -0
-    outer loop
-      vertex 58.9271 2.85317 -4.5
-      vertex 58.3136 2.98357 -3.65381e-16
-      vertex 58.9271 2.85317 -3.49412e-16
-    endloop
-  endfacet
-  facet normal 0.20791 0.978148 0
-    outer loop
-      vertex 58.3136 2.98357 -3.65381e-16
-      vertex 58.9271 2.85317 -4.5
-      vertex 58.3136 2.98357 -4.5
-    endloop
-  endfacet
-  facet normal -0.866024 0.500002 0
-    outer loop
-      vertex 55.2594 1.22021 -2.7
-      vertex 55.5729 1.76336 -2.15949e-16
-      vertex 55.5729 1.76336 -2.7
-    endloop
-  endfacet
-  facet normal -0.866024 0.500002 0
-    outer loop
-      vertex 55.5729 1.76336 -2.15949e-16
-      vertex 55.2594 1.22021 -2.7
-      vertex 55.2594 1.22021 -1.49433e-16
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex 56.5 2.59808 -2.7
-      vertex 55.9926 2.22943 -2.73027e-16
-      vertex 56.5 2.59808 -3.18173e-16
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex 55.9926 2.22943 -2.73027e-16
-      vertex 56.5 2.59808 -2.7
-      vertex 55.9926 2.22943 -2.7
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 55.5729 1.76336 -2.7
-      vertex 55.9926 2.22943 -2.73027e-16
-      vertex 55.9926 2.22943 -2.7
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 55.9926 2.22943 -2.73027e-16
-      vertex 55.5729 1.76336 -2.7
-      vertex 55.5729 1.76336 -2.15949e-16
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 60.4271 1.76336 -2.15949e-16
-      vertex 60.0074 2.22943 -4.5
-      vertex 60.0074 2.22943 -2.73027e-16
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 60.0074 2.22943 -4.5
-      vertex 60.4271 1.76336 -2.15949e-16
-      vertex 60.4271 1.76336 -4.5
-    endloop
-  endfacet
-  facet normal -0.207912 0.978148 0
-    outer loop
-      vertex 57.6864 2.98357 -2.7
-      vertex 57.0729 2.85317 -3.49412e-16
-      vertex 57.6864 2.98357 -3.65381e-16
-    endloop
-  endfacet
-  facet normal -0.207912 0.978148 0
-    outer loop
-      vertex 57.0729 2.85317 -3.49412e-16
-      vertex 57.6864 2.98357 -2.7
-      vertex 57.0729 2.85317 -2.7
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 2.93444 -23.6237 2.89307e-15
-      vertex 3 -23 -2
-      vertex 3 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 2.93444 -23.6237 -2.5
-      vertex 3 -23 -2
-      vertex 2.93444 -23.6237 2.89307e-15
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 3 -23 -2
-      vertex 2.93444 -23.6237 -2.5
-      vertex 3 -23 -2.5
-    endloop
-  endfacet
-  facet normal -0.207914 -0.978147 0
-    outer loop
-      vertex -0.927051 -25.8532 -2.5
-      vertex -0.313585 -25.9836 3.18207e-15
-      vertex -0.927051 -25.8532 3.1661e-15
-    endloop
-  endfacet
-  facet normal -0.207914 -0.978147 -0
-    outer loop
-      vertex -0.313585 -25.9836 3.18207e-15
-      vertex -0.927051 -25.8532 -2.5
-      vertex -0.313585 -25.9836 -2.5
-    endloop
-  endfacet
-  facet normal 0.207911 0.978148 -0
-    outer loop
-      vertex 0.927051 -20.1468 -2
-      vertex 0.313585 -20.0164 2.45131e-15
-      vertex 0.927051 -20.1468 2.46728e-15
-    endloop
-  endfacet
-  facet normal 0.207911 0.978148 0
-    outer loop
-      vertex 0.313585 -20.0164 2.45131e-15
-      vertex 0.927051 -20.1468 -2
-      vertex 0.313585 -20.0164 -2
-    endloop
-  endfacet
-  facet normal 0.406738 0.913545 -0
-    outer loop
-      vertex 1.5 -20.4019 -2
-      vertex 0.927051 -20.1468 2.46728e-15
-      vertex 1.5 -20.4019 2.49851e-15
-    endloop
-  endfacet
-  facet normal 0.406738 0.913545 0
-    outer loop
-      vertex 0.927051 -20.1468 2.46728e-15
-      vertex 1.5 -20.4019 -2
-      vertex 0.927051 -20.1468 -2
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 1.5 -25.5981 -2.5
-      vertex 2.00739 -25.2294 3.08971e-15
-      vertex 1.5 -25.5981 3.13486e-15
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 2.00739 -25.2294 3.08971e-15
-      vertex 1.5 -25.5981 -2.5
-      vertex 2.00739 -25.2294 -2.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex -2.00739 -25.2294 -2.5
-      vertex -2.42705 -24.7634 3.03264e-15
-      vertex -2.42705 -24.7634 -2.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex -2.42705 -24.7634 3.03264e-15
-      vertex -2.00739 -25.2294 -2.5
-      vertex -2.00739 -25.2294 3.08971e-15
-    endloop
-  endfacet
-  facet normal -0.587784 -0.809018 0
-    outer loop
-      vertex -2.00739 -25.2294 -2.5
-      vertex -1.5 -25.5981 3.13486e-15
-      vertex -2.00739 -25.2294 3.08971e-15
-    endloop
-  endfacet
-  facet normal -0.587784 -0.809018 -0
-    outer loop
-      vertex -1.5 -25.5981 3.13486e-15
-      vertex -2.00739 -25.2294 -2.5
-      vertex -1.5 -25.5981 -2.5
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 2.93444 -22.3763 2.7403e-15
-      vertex 2.74064 -21.7798 -2
-      vertex 2.74064 -21.7798 2.66726e-15
-    endloop
-  endfacet
-  facet normal 0.951057 0.309017 0
-    outer loop
-      vertex 2.74064 -21.7798 -2
-      vertex 2.93444 -22.3763 2.7403e-15
-      vertex 2.93444 -22.3763 -2
-    endloop
-  endfacet
-  facet normal 0.866026 -0.5 0
-    outer loop
-      vertex 2.42705 -24.7634 3.03264e-15
-      vertex 2.74064 -24.2202 -2.5
-      vertex 2.74064 -24.2202 2.96612e-15
-    endloop
-  endfacet
-  facet normal 0.866026 -0.5 0
-    outer loop
-      vertex 2.74064 -24.2202 -2.5
-      vertex 2.42705 -24.7634 3.03264e-15
-      vertex 2.42705 -24.7634 -2.5
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309017 0
-    outer loop
-      vertex 2.74064 -24.2202 2.96612e-15
-      vertex 2.93444 -23.6237 -2.5
-      vertex 2.93444 -23.6237 2.89307e-15
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309017 0
-    outer loop
-      vertex 2.93444 -23.6237 -2.5
-      vertex 2.74064 -24.2202 2.96612e-15
-      vertex 2.74064 -24.2202 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 2.00739 -25.2294 3.08971e-15
-      vertex 2.42705 -24.7634 -2.5
-      vertex 2.42705 -24.7634 3.03264e-15
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 2.42705 -24.7634 -2.5
-      vertex 2.00739 -25.2294 3.08971e-15
-      vertex 2.00739 -25.2294 -2.5
-    endloop
-  endfacet
-  facet normal 0.207914 -0.978147 0
-    outer loop
-      vertex 0.313585 -25.9836 -2.5
-      vertex 0.927051 -25.8532 3.1661e-15
-      vertex 0.313585 -25.9836 3.18207e-15
-    endloop
-  endfacet
-  facet normal 0.207914 -0.978147 0
-    outer loop
-      vertex 0.927051 -25.8532 3.1661e-15
-      vertex 0.313585 -25.9836 -2.5
-      vertex 0.927051 -25.8532 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.313585 -25.9836 -2.5
-      vertex 0.313585 -25.9836 3.18207e-15
-      vertex -0.313585 -25.9836 3.18207e-15
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 0.313585 -25.9836 3.18207e-15
-      vertex -0.313585 -25.9836 -2.5
-      vertex 0.313585 -25.9836 -2.5
-    endloop
-  endfacet
-  facet normal 0.406728 -0.913549 0
-    outer loop
-      vertex 1 -25.8207 -2.5
-      vertex 0.927051 -25.8532 3.1661e-15
-      vertex 0.927051 -25.8532 -2.5
-    endloop
-  endfacet
-  facet normal 0.406735 -0.913546 2.64436e-07
-    outer loop
-      vertex 0.927051 -25.8532 3.1661e-15
-      vertex 1 -25.8207 -2.5
-      vertex 1.5 -25.5981 3.13486e-15
-    endloop
-  endfacet
-  facet normal 0.406737 -0.913545 0
-    outer loop
-      vertex 1.5 -25.5981 3.13486e-15
-      vertex 1 -25.8207 -2.5
-      vertex 1.5 -25.5981 -2.5
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309017 0
-    outer loop
-      vertex -2.74064 -24.2202 -2.5
-      vertex -2.93444 -23.6237 2.89307e-15
-      vertex -2.93444 -23.6237 -2.5
-    endloop
-  endfacet
-  facet normal -0.951057 -0.309017 0
-    outer loop
-      vertex -2.93444 -23.6237 2.89307e-15
-      vertex -2.74064 -24.2202 -2.5
-      vertex -2.74064 -24.2202 2.96612e-15
-    endloop
-  endfacet
-  facet normal -0 1.22464e-16 1
-    outer loop
-      vertex 1.25 -23 2.81669e-15
-      vertex 3 -23 2.81669e-15
-      vertex 2.93444 -22.3763 2.7403e-15
-    endloop
-  endfacet
-  facet normal 1.19761e-22 1.22464e-16 1
-    outer loop
-      vertex 1.22268 -22.7401 2.78486e-15
-      vertex 2.93444 -22.3763 2.7403e-15
-      vertex 2.74064 -21.7798 2.66726e-15
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 3 -23 2.81669e-15
-      vertex 1.25 -23 2.81669e-15
-      vertex 2.93444 -23.6237 2.89307e-15
-    endloop
-  endfacet
-  facet normal -2.26769e-22 1.22465e-16 1
-    outer loop
-      vertex 1.14193 -22.4916 2.75442e-15
-      vertex 2.74064 -21.7798 2.66726e-15
-      vertex 2.42705 -21.2366 2.60074e-15
-    endloop
-  endfacet
-  facet normal -1.06781e-22 1.22465e-16 1
-    outer loop
-      vertex 1.22268 -23.2599 2.84851e-15
-      vertex 2.93444 -23.6237 2.89307e-15
-      vertex 1.25 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal 1.52539e-22 1.22465e-16 1
-    outer loop
-      vertex 1.01127 -22.2653 2.72671e-15
-      vertex 2.42705 -21.2366 2.60074e-15
-      vertex 2.00739 -20.7706 2.54366e-15
-    endloop
-  endfacet
-  facet normal -1.19761e-22 1.22464e-16 1
-    outer loop
-      vertex 2.93444 -23.6237 2.89307e-15
-      vertex 1.22268 -23.2599 2.84851e-15
-      vertex 2.74064 -24.2202 2.96612e-15
-    endloop
-  endfacet
-  facet normal -3.51894e-22 1.22465e-16 1
-    outer loop
-      vertex 0.836412 -22.0711 2.70293e-15
-      vertex 2.00739 -20.7706 2.54366e-15
-      vertex 1.5 -20.4019 2.49851e-15
-    endloop
-  endfacet
-  facet normal 3.02768e-22 1.22465e-16 1
-    outer loop
-      vertex 1.14193 -23.5084 2.87895e-15
-      vertex 2.74064 -24.2202 2.96612e-15
-      vertex 1.22268 -23.2599 2.84851e-15
-    endloop
-  endfacet
-  facet normal 7.44499e-23 1.22465e-16 1
-    outer loop
-      vertex 2.74064 -24.2202 2.96612e-15
-      vertex 1.14193 -23.5084 2.87895e-15
-      vertex 2.42705 -24.7634 3.03264e-15
-    endloop
-  endfacet
-  facet normal 2.93644e-22 1.22464e-16 1
-    outer loop
-      vertex 2.93444 -22.3763 2.7403e-15
-      vertex 1.22268 -22.7401 2.78486e-15
-      vertex 1.25 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal -3.02768e-22 1.22465e-16 1
-    outer loop
-      vertex 2.74064 -21.7798 2.66726e-15
-      vertex 1.14193 -22.4916 2.75442e-15
-      vertex 1.22268 -22.7401 2.78486e-15
-    endloop
-  endfacet
-  facet normal -1.09312e-22 1.22465e-16 1
-    outer loop
-      vertex 2.42705 -21.2366 2.60074e-15
-      vertex 1.01127 -22.2653 2.72671e-15
-      vertex 1.14193 -22.4916 2.75442e-15
-    endloop
-  endfacet
-  facet normal 3.29986e-22 1.22465e-16 1
-    outer loop
-      vertex 0.625 -21.9175 2.68412e-15
-      vertex 1.5 -20.4019 2.49851e-15
-      vertex 0.927051 -20.1468 2.46728e-15
-    endloop
-  endfacet
-  facet normal 4.08425e-22 1.22464e-16 1
-    outer loop
-      vertex 2.00739 -20.7706 2.54366e-15
-      vertex 0.836412 -22.0711 2.70293e-15
-      vertex 1.01127 -22.2653 2.72671e-15
-    endloop
-  endfacet
-  facet normal -8.71987e-22 1.22465e-16 1
-    outer loop
-      vertex 1.5 -20.4019 2.49851e-15
-      vertex 0.625 -21.9175 2.68412e-15
-      vertex 0.836412 -22.0711 2.70293e-15
-    endloop
-  endfacet
-  facet normal 2.40043e-22 1.22465e-16 1
-    outer loop
-      vertex 0.927051 -20.1468 2.46728e-15
-      vertex 0.386271 -21.8112 2.6711e-15
-      vertex 0.625 -21.9175 2.68412e-15
-    endloop
-  endfacet
-  facet normal -2.3315e-23 1.22465e-16 1
-    outer loop
-      vertex 0.313585 -20.0164 2.45131e-15
-      vertex 0.386271 -21.8112 2.6711e-15
-      vertex 0.927051 -20.1468 2.46728e-15
-    endloop
-  endfacet
-  facet normal -1.12349e-22 1.22465e-16 1
-    outer loop
-      vertex 0.313585 -20.0164 2.45131e-15
-      vertex 0.13066 -21.7568 2.66445e-15
-      vertex 0.386271 -21.8112 2.6711e-15
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 0.313585 -20.0164 2.45131e-15
-      vertex -0.13066 -21.7568 2.66445e-15
-      vertex 0.13066 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex -0.313585 -20.0164 2.45131e-15
-      vertex -0.13066 -21.7568 2.66445e-15
-      vertex 0.313585 -20.0164 2.45131e-15
-    endloop
-  endfacet
-  facet normal 1.12349e-22 1.22465e-16 1
-    outer loop
-      vertex -0.313585 -20.0164 2.45131e-15
-      vertex -0.386271 -21.8112 2.6711e-15
-      vertex -0.13066 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal 2.3315e-23 1.22465e-16 1
-    outer loop
-      vertex -0.927051 -20.1468 2.46728e-15
-      vertex -0.386271 -21.8112 2.6711e-15
-      vertex -0.313585 -20.0164 2.45131e-15
-    endloop
-  endfacet
-  facet normal -2.40043e-22 1.22465e-16 1
-    outer loop
-      vertex -0.386271 -21.8112 2.6711e-15
-      vertex -0.927051 -20.1468 2.46728e-15
-      vertex -0.625 -21.9175 2.68412e-15
-    endloop
-  endfacet
-  facet normal -3.29986e-22 1.22465e-16 1
-    outer loop
-      vertex -1.5 -20.4019 2.49851e-15
-      vertex -0.625 -21.9175 2.68412e-15
-      vertex -0.927051 -20.1468 2.46728e-15
-    endloop
-  endfacet
-  facet normal 8.71987e-22 1.22465e-16 1
-    outer loop
-      vertex -0.625 -21.9175 2.68412e-15
-      vertex -1.5 -20.4019 2.49851e-15
-      vertex -0.836412 -22.0711 2.70293e-15
-    endloop
-  endfacet
-  facet normal 3.51894e-22 1.22465e-16 1
-    outer loop
-      vertex -2.00739 -20.7706 2.54366e-15
-      vertex -0.836412 -22.0711 2.70293e-15
-      vertex -1.5 -20.4019 2.49851e-15
-    endloop
-  endfacet
-  facet normal -4.08425e-22 1.22464e-16 1
-    outer loop
-      vertex -0.836412 -22.0711 2.70293e-15
-      vertex -2.00739 -20.7706 2.54366e-15
-      vertex -1.01127 -22.2653 2.72671e-15
-    endloop
-  endfacet
-  facet normal -1.52539e-22 1.22465e-16 1
-    outer loop
-      vertex -2.42705 -21.2366 2.60074e-15
-      vertex -1.01127 -22.2653 2.72671e-15
-      vertex -2.00739 -20.7706 2.54366e-15
-    endloop
-  endfacet
-  facet normal 1.09312e-22 1.22465e-16 1
-    outer loop
-      vertex -1.01127 -22.2653 2.72671e-15
-      vertex -2.42705 -21.2366 2.60074e-15
-      vertex -1.14193 -22.4916 2.75442e-15
-    endloop
-  endfacet
-  facet normal 2.26769e-22 1.22465e-16 1
-    outer loop
-      vertex -2.74064 -21.7798 2.66726e-15
-      vertex -1.14193 -22.4916 2.75442e-15
-      vertex -2.42705 -21.2366 2.60074e-15
-    endloop
-  endfacet
-  facet normal 3.02768e-22 1.22465e-16 1
-    outer loop
-      vertex -1.14193 -22.4916 2.75442e-15
-      vertex -2.74064 -21.7798 2.66726e-15
-      vertex -1.22268 -22.7401 2.78486e-15
-    endloop
-  endfacet
-  facet normal -5.271e-22 1.22465e-16 1
-    outer loop
-      vertex -1.25 -23 2.81669e-15
-      vertex -2.00739 -25.2294 3.08971e-15
-      vertex -1.5 -25.5981 3.13486e-15
-    endloop
-  endfacet
-  facet normal -1.19761e-22 1.22464e-16 1
-    outer loop
-      vertex -2.93444 -22.3763 2.7403e-15
-      vertex -1.22268 -22.7401 2.78486e-15
-      vertex -2.74064 -21.7798 2.66726e-15
-    endloop
-  endfacet
-  facet normal 1.86424e-22 1.22465e-16 1
-    outer loop
-      vertex -1.25 -23 2.81669e-15
-      vertex -2.42705 -24.7634 3.03264e-15
-      vertex -2.00739 -25.2294 3.08971e-15
-    endloop
-  endfacet
-  facet normal -2.93644e-22 1.22464e-16 1
-    outer loop
-      vertex -1.22268 -22.7401 2.78486e-15
-      vertex -2.93444 -22.3763 2.7403e-15
-      vertex -1.25 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal -2.13755e-23 1.22465e-16 1
-    outer loop
-      vertex -1.25 -23 2.81669e-15
-      vertex -2.74064 -24.2202 2.96612e-15
-      vertex -2.42705 -24.7634 3.03264e-15
-    endloop
-  endfacet
-  facet normal -0 1.22464e-16 1
-    outer loop
-      vertex -3 -23 2.81669e-15
-      vertex -1.25 -23 2.81669e-15
-      vertex -2.93444 -22.3763 2.7403e-15
-    endloop
-  endfacet
-  facet normal 1.28359e-22 1.22465e-16 1
-    outer loop
-      vertex -1.25 -23 2.81669e-15
-      vertex -2.93444 -23.6237 2.89307e-15
-      vertex -2.74064 -24.2202 2.96612e-15
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex -1.25 -23 2.81669e-15
-      vertex -3 -23 2.81669e-15
-      vertex -2.93444 -23.6237 2.89307e-15
-    endloop
-  endfacet
-  facet normal 2.25543e-22 1.22465e-16 1
-    outer loop
-      vertex 1.01127 -23.7347 2.90667e-15
-      vertex 2.42705 -24.7634 3.03264e-15
-      vertex 1.14193 -23.5084 2.87895e-15
-    endloop
-  endfacet
-  facet normal -5.28011e-23 1.22464e-16 1
-    outer loop
-      vertex 2.42705 -24.7634 3.03264e-15
-      vertex 1.01127 -23.7347 2.90667e-15
-      vertex 2.00739 -25.2294 3.08971e-15
-    endloop
-  endfacet
-  facet normal -3.08687e-22 1.22464e-16 1
-    outer loop
-      vertex 0.836412 -23.9289 2.93045e-15
-      vertex 2.00739 -25.2294 3.08971e-15
-      vertex 1.01127 -23.7347 2.90667e-15
-    endloop
-  endfacet
-  facet normal 4.30781e-22 1.22465e-16 1
-    outer loop
-      vertex 2.00739 -25.2294 3.08971e-15
-      vertex 0.836412 -23.9289 2.93045e-15
-      vertex 1.5 -25.5981 3.13486e-15
-    endloop
-  endfacet
-  facet normal 9.36171e-23 1.22465e-16 1
-    outer loop
-      vertex 0.625 -24.0825 2.94926e-15
-      vertex 1.5 -25.5981 3.13486e-15
-      vertex 0.836412 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal -5.66806e-24 1.22465e-16 1
-    outer loop
-      vertex 1.5 -25.5981 3.13486e-15
-      vertex 0.625 -24.0825 2.94926e-15
-      vertex 0.927051 -25.8532 3.1661e-15
-    endloop
-  endfacet
-  facet normal -2.94632e-22 1.22465e-16 1
-    outer loop
-      vertex 0.386271 -24.1888 2.96228e-15
-      vertex 0.927051 -25.8532 3.1661e-15
-      vertex 0.625 -24.0825 2.94926e-15
-    endloop
-  endfacet
-  facet normal -3.60751e-22 1.22465e-16 1
-    outer loop
-      vertex 0.386271 -24.1888 2.96228e-15
-      vertex 0.313585 -25.9836 3.18207e-15
-      vertex 0.927051 -25.8532 3.1661e-15
-    endloop
-  endfacet
-  facet normal 1.12349e-22 1.22465e-16 1
-    outer loop
-      vertex 0.13066 -24.2432 2.96893e-15
-      vertex 0.313585 -25.9836 3.18207e-15
-      vertex 0.386271 -24.1888 2.96228e-15
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex -0.13066 -24.2432 2.96893e-15
-      vertex 0.313585 -25.9836 3.18207e-15
-      vertex 0.13066 -24.2432 2.96893e-15
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex -0.13066 -24.2432 2.96893e-15
-      vertex -0.313585 -25.9836 3.18207e-15
-      vertex 0.313585 -25.9836 3.18207e-15
-    endloop
-  endfacet
-  facet normal -1.12349e-22 1.22465e-16 1
-    outer loop
-      vertex -0.386271 -24.1888 2.96228e-15
-      vertex -0.313585 -25.9836 3.18207e-15
-      vertex -0.13066 -24.2432 2.96893e-15
-    endloop
-  endfacet
-  facet normal 2.94633e-22 1.22465e-16 1
-    outer loop
-      vertex -0.927051 -25.8532 3.1661e-15
-      vertex -0.386271 -24.1888 2.96228e-15
-      vertex -0.624999 -24.0825 2.94926e-15
-    endloop
-  endfacet
-  facet normal -9.36168e-23 1.22465e-16 1
-    outer loop
-      vertex -1.5 -25.5981 3.13486e-15
-      vertex -0.624999 -24.0825 2.94926e-15
-      vertex -0.836412 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal 3.60751e-22 1.22465e-16 1
-    outer loop
-      vertex -0.386271 -24.1888 2.96228e-15
-      vertex -0.927051 -25.8532 3.1661e-15
-      vertex -0.313585 -25.9836 3.18207e-15
-    endloop
-  endfacet
-  facet normal 5.95164e-22 1.22465e-16 1
-    outer loop
-      vertex -1.5 -25.5981 3.13486e-15
-      vertex -0.836412 -23.9289 2.93045e-15
-      vertex -1.01127 -23.7347 2.90667e-15
-    endloop
-  endfacet
-  facet normal -3.21339e-22 1.22465e-16 1
-    outer loop
-      vertex -1.5 -25.5981 3.13486e-15
-      vertex -1.01127 -23.7347 2.90667e-15
-      vertex -1.14193 -23.5084 2.87895e-15
-    endloop
-  endfacet
-  facet normal -1.14217e-21 1.22465e-16 1
-    outer loop
-      vertex -1.5 -25.5981 3.13486e-15
-      vertex -1.14193 -23.5084 2.87895e-15
-      vertex -1.22268 -23.2599 2.84851e-15
-    endloop
-  endfacet
-  facet normal 5.66806e-24 1.22465e-16 1
-    outer loop
-      vertex -0.624999 -24.0825 2.94926e-15
-      vertex -1.5 -25.5981 3.13486e-15
-      vertex -0.927051 -25.8532 3.1661e-15
-    endloop
-  endfacet
-  facet normal 9.37967e-22 1.22465e-16 1
-    outer loop
-      vertex -1.5 -25.5981 3.13486e-15
-      vertex -1.22268 -23.2599 2.84851e-15
-      vertex -1.25 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal -0.866026 -0.5 0
-    outer loop
-      vertex -2.42705 -24.7634 -2.5
-      vertex -2.74064 -24.2202 2.96612e-15
-      vertex -2.74064 -24.2202 -2.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.5 0
-    outer loop
-      vertex -2.74064 -24.2202 2.96612e-15
-      vertex -2.42705 -24.7634 -2.5
-      vertex -2.42705 -24.7634 3.03264e-15
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex -2.93444 -23.6237 -2.5
-      vertex -3 -23 -2
-      vertex -3 -23 -2.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 -0
-    outer loop
-      vertex -2.93444 -23.6237 2.89307e-15
-      vertex -3 -23 -2
-      vertex -2.93444 -23.6237 -2.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex -3 -23 -2
-      vertex -2.93444 -23.6237 2.89307e-15
-      vertex -3 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal -0.406736 -0.913546 0
-    outer loop
-      vertex -1.5 -25.5981 -2.5
-      vertex -0.927051 -25.8532 3.1661e-15
-      vertex -1.5 -25.5981 3.13486e-15
-    endloop
-  endfacet
-  facet normal -0.406736 -0.913546 -0
-    outer loop
-      vertex -0.927051 -25.8532 3.1661e-15
-      vertex -1.5 -25.5981 -2.5
-      vertex -0.927051 -25.8532 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 3 -23 2.81669e-15
-      vertex 2.93444 -22.3763 -2
-      vertex 2.93444 -22.3763 2.7403e-15
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 2.93444 -22.3763 -2
-      vertex 3 -23 2.81669e-15
-      vertex 3 -23 -2
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex -3 -23 -2
-      vertex -2.93444 -22.3763 2.7403e-15
-      vertex -2.93444 -22.3763 -2
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex -2.93444 -22.3763 2.7403e-15
-      vertex -3 -23 -2
-      vertex -3 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 2.74064 -21.7798 2.66726e-15
-      vertex 2.42705 -21.2366 -2
-      vertex 2.42705 -21.2366 2.60074e-15
-    endloop
-  endfacet
-  facet normal 0.866025 0.500001 0
-    outer loop
-      vertex 2.42705 -21.2366 -2
-      vertex 2.74064 -21.7798 2.66726e-15
-      vertex 2.74064 -21.7798 -2
-    endloop
-  endfacet
-  facet normal -0.406738 0.913545 0
-    outer loop
-      vertex -0.927051 -20.1468 -2
-      vertex -1.5 -20.4019 2.49851e-15
-      vertex -0.927051 -20.1468 2.46728e-15
-    endloop
-  endfacet
-  facet normal -0.406738 0.913545 0
-    outer loop
-      vertex -1.5 -20.4019 2.49851e-15
-      vertex -0.927051 -20.1468 -2
-      vertex -1.5 -20.4019 -2
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex -2.42705 -21.2366 -2
-      vertex -2.00739 -20.7706 2.54366e-15
-      vertex -2.00739 -20.7706 -2
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex -2.00739 -20.7706 2.54366e-15
-      vertex -2.42705 -21.2366 -2
-      vertex -2.42705 -21.2366 2.60074e-15
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex -1.5 -20.4019 -2
-      vertex -2.00739 -20.7706 2.54366e-15
-      vertex -1.5 -20.4019 2.49851e-15
-    endloop
-  endfacet
-  facet normal -0.587785 0.809017 0
-    outer loop
-      vertex -2.00739 -20.7706 2.54366e-15
-      vertex -1.5 -20.4019 -2
-      vertex -2.00739 -20.7706 -2
-    endloop
-  endfacet
-  facet normal -0.951057 0.309017 0
-    outer loop
-      vertex -2.93444 -22.3763 -2
-      vertex -2.74064 -21.7798 2.66726e-15
-      vertex -2.74064 -21.7798 -2
-    endloop
-  endfacet
-  facet normal -0.951057 0.309017 0
-    outer loop
-      vertex -2.74064 -21.7798 2.66726e-15
-      vertex -2.93444 -22.3763 -2
-      vertex -2.93444 -22.3763 2.7403e-15
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 -0
-    outer loop
-      vertex 2.00739 -20.7706 -2
-      vertex 1.5 -20.4019 2.49851e-15
-      vertex 2.00739 -20.7706 2.54366e-15
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 0
-    outer loop
-      vertex 1.5 -20.4019 2.49851e-15
-      vertex 2.00739 -20.7706 -2
-      vertex 1.5 -20.4019 -2
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex -2.74064 -21.7798 -2
-      vertex -2.42705 -21.2366 2.60074e-15
-      vertex -2.42705 -21.2366 -2
-    endloop
-  endfacet
-  facet normal -0.866025 0.500001 0
-    outer loop
-      vertex -2.42705 -21.2366 2.60074e-15
-      vertex -2.74064 -21.7798 -2
-      vertex -2.74064 -21.7798 2.66726e-15
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 2.42705 -21.2366 2.60074e-15
-      vertex 2.00739 -20.7706 -2
-      vertex 2.00739 -20.7706 2.54366e-15
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 2.00739 -20.7706 -2
-      vertex 2.42705 -21.2366 2.60074e-15
-      vertex 2.42705 -21.2366 -2
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex -0.313585 -20.0164 -2
-      vertex -0.927051 -20.1468 2.46728e-15
-      vertex -0.313585 -20.0164 2.45131e-15
-    endloop
-  endfacet
-  facet normal -0.207911 0.978148 0
-    outer loop
-      vertex -0.927051 -20.1468 2.46728e-15
-      vertex -0.313585 -20.0164 -2
-      vertex -0.927051 -20.1468 -2
+      vertex 61.5 29.5 2.4
+      vertex 57.7 29.5 2.1
+      vertex 57.7 29.5 2.4
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 0.313585 -20.0164 -2
-      vertex -0.313585 -20.0164 2.45131e-15
-      vertex 0.313585 -20.0164 2.45131e-15
+      vertex 61.5 29.5 0
+      vertex 57.7 29.5 2.1
+      vertex 61.5 29.5 2.4
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.313585 -20.0164 2.45131e-15
-      vertex 0.313585 -20.0164 -2
-      vertex -0.313585 -20.0164 -2
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104532 0
-    outer loop
-      vertex 60.9344 -23.6237 2.89307e-15
-      vertex 61 -23 -2
-      vertex 61 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104532 0
-    outer loop
-      vertex 60.9344 -23.6237 -4.5
-      vertex 61 -23 -2
-      vertex 60.9344 -23.6237 2.89307e-15
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104532 0
-    outer loop
-      vertex 61 -23 -2
-      vertex 60.9344 -23.6237 -4.5
-      vertex 61 -23 -4.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 -0
-    outer loop
-      vertex 59.5 -20.4019 -2
-      vertex 58.9271 -20.1468 2.46728e-15
-      vertex 59.5 -20.4019 2.49851e-15
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 0
-    outer loop
-      vertex 58.9271 -20.1468 2.46728e-15
-      vertex 59.5 -20.4019 -2
-      vertex 58.9271 -20.1468 -2
-    endloop
-  endfacet
-  facet normal 0.587784 -0.809018 0
-    outer loop
-      vertex 59.5 -25.5981 -4.5
-      vertex 60.0074 -25.2294 3.08971e-15
-      vertex 59.5 -25.5981 3.13486e-15
-    endloop
-  endfacet
-  facet normal 0.587784 -0.809018 0
-    outer loop
-      vertex 60.0074 -25.2294 3.08971e-15
-      vertex 59.5 -25.5981 -4.5
-      vertex 60.0074 -25.2294 -4.5
-    endloop
-  endfacet
-  facet normal 0.866027 -0.499997 0
-    outer loop
-      vertex 60.4271 -24.7634 3.03264e-15
-      vertex 60.7406 -24.2202 -4.5
-      vertex 60.7406 -24.2202 2.96612e-15
-    endloop
-  endfacet
-  facet normal 0.866027 -0.499997 0
-    outer loop
-      vertex 60.7406 -24.2202 -4.5
-      vertex 60.4271 -24.7634 3.03264e-15
-      vertex 60.4271 -24.7634 -4.5
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309016 0
-    outer loop
-      vertex 60.7406 -24.2202 2.96612e-15
-      vertex 60.9344 -23.6237 -4.5
-      vertex 60.9344 -23.6237 2.89307e-15
-    endloop
-  endfacet
-  facet normal 0.951057 -0.309016 0
-    outer loop
-      vertex 60.9344 -23.6237 -4.5
-      vertex 60.7406 -24.2202 2.96612e-15
-      vertex 60.7406 -24.2202 -4.5
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex 60.0074 -25.2294 3.08971e-15
-      vertex 60.4271 -24.7634 -4.5
-      vertex 60.4271 -24.7634 3.03264e-15
-    endloop
-  endfacet
-  facet normal 0.743146 -0.669129 0
-    outer loop
-      vertex 60.4271 -24.7634 -4.5
-      vertex 60.0074 -25.2294 3.08971e-15
-      vertex 60.0074 -25.2294 -4.5
-    endloop
-  endfacet
-  facet normal 0.207913 -0.978147 0
-    outer loop
-      vertex 58.3136 -25.9836 -4.5
-      vertex 58.9271 -25.8532 3.1661e-15
-      vertex 58.3136 -25.9836 3.18207e-15
-    endloop
-  endfacet
-  facet normal 0.207913 -0.978147 0
-    outer loop
-      vertex 58.9271 -25.8532 3.1661e-15
-      vertex 58.3136 -25.9836 -4.5
-      vertex 58.9271 -25.8532 -4.5
+      vertex 57.7 29.5 2.1
+      vertex 61.5 29.5 0
+      vertex 57.7 29.5 0
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 58.3136 -25.9836 3.18207e-15
-      vertex 58 -25.9836 3.18207e-15
+      vertex 6.5 23.5 1.1
+      vertex 6.5 23.5 0
+      vertex 18.5 23.5 1.1
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 -1 0
     outer loop
-      vertex 58.3136 -25.9836 3.18207e-15
-      vertex 58 -25.9836 -4.5
-      vertex 58.3136 -25.9836 -4.5
+      vertex 18.5 23.5 1.1
+      vertex 26 23.5 2
+      vertex 18.5 23.5 2
     endloop
   endfacet
-  facet normal 0.406736 -0.913546 0
+  facet normal 0 -1 0
     outer loop
-      vertex 58.9271 -25.8532 -4.5
-      vertex 59.5 -25.5981 3.13486e-15
-      vertex 58.9271 -25.8532 3.1661e-15
+      vertex 47.1 23.5 0
+      vertex 26 23.5 2
+      vertex 18.5 23.5 1.1
     endloop
   endfacet
-  facet normal 0.406736 -0.913546 0
+  facet normal 0 -1 0
     outer loop
-      vertex 59.5 -25.5981 3.13486e-15
-      vertex 58.9271 -25.8532 -4.5
-      vertex 59.5 -25.5981 -4.5
+      vertex 47.1 23.5 0
+      vertex 18.5 23.5 1.1
+      vertex 6.5 23.5 0
     endloop
   endfacet
-  facet normal 8.25107e-23 1.22465e-16 1
+  facet normal 0 -1 0
     outer loop
-      vertex 57.1636 -22.0711 2.70293e-15
-      vertex 58 -20.0164 2.45131e-15
-      vertex 58 -20 2.44929e-15
+      vertex 26 23.5 2
+      vertex 47.1 23.5 0
+      vertex 47.1 23.5 1.8
     endloop
   endfacet
-  facet normal 1.16721e-22 1.22465e-16 1
+  facet normal 0 -1 0
     outer loop
-      vertex 58 -20.0164 2.45131e-15
-      vertex 57.6137 -21.8112 2.6711e-15
-      vertex 57.8693 -21.7568 2.66445e-15
+      vertex 47.1 23.5 1.8
+      vertex 26 23.5 2.4
+      vertex 26 23.5 2
     endloop
   endfacet
-  facet normal -3.08086e-22 1.22465e-16 1
+  facet normal 0 -1 0
     outer loop
-      vertex 58 -20.0164 2.45131e-15
-      vertex 57.375 -21.9175 2.68412e-15
-      vertex 57.6137 -21.8112 2.6711e-15
+      vertex 26 23.5 2.4
+      vertex 47.1 23.5 1.8
+      vertex 58.5 23.5 2.4
     endloop
   endfacet
-  facet normal 1.74419e-21 1.22464e-16 1
+  facet normal 0 -1 0
     outer loop
-      vertex 58 -20.0164 2.45131e-15
-      vertex 57.1636 -22.0711 2.70293e-15
-      vertex 57.375 -21.9175 2.68412e-15
+      vertex 49.6 23.5 1.8
+      vertex 58.5 23.5 2.4
+      vertex 47.1 23.5 1.8
     endloop
   endfacet
-  facet normal -1.54742e-21 1.22465e-16 1
+  facet normal 0 -1 0
     outer loop
-      vertex 58 -20 2.44929e-15
-      vertex 56.9887 -22.2653 2.72671e-15
-      vertex 57.1636 -22.0711 2.70293e-15
+      vertex 58.5 23.5 0
+      vertex 49.6 23.5 1.8
+      vertex 49.6 23.5 0
     endloop
   endfacet
-  facet normal 1.98053e-21 1.22464e-16 1
+  facet normal 0 -1 0
     outer loop
-      vertex 58 -20 2.44929e-15
-      vertex 56.8581 -22.4916 2.75442e-15
-      vertex 56.9887 -22.2653 2.72671e-15
+      vertex 49.6 23.5 1.8
+      vertex 58.5 23.5 0
+      vertex 58.5 23.5 2.4
     endloop
   endfacet
-  facet normal -9.4355e-23 1.22464e-16 1
+  facet normal 0.290451 0.95689 -0
     outer loop
-      vertex 56.7773 -22.7401 2.78486e-15
-      vertex 25 -20 2.44929e-15
-      vertex 56.75 -23 2.81669e-15
+      vertex 62.648 29.2716 0
+      vertex 62.0853 29.4424 4.5
+      vertex 62.648 29.2716 4.5
     endloop
   endfacet
-  facet normal 4.28636e-23 1.22465e-16 1
+  facet normal 0.290451 0.95689 0
     outer loop
-      vertex 56.8581 -22.4916 2.75442e-15
-      vertex 25 -20 2.44929e-15
-      vertex 56.7773 -22.7401 2.78486e-15
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex 25 -20 2.44929e-15
-      vertex 56.8581 -22.4916 2.75442e-15
-      vertex 58 -20 2.44929e-15
-    endloop
-  endfacet
-  facet normal -0 1.22464e-16 1
-    outer loop
-      vertex 59.25 -23 2.81669e-15
-      vertex 61 -23 2.81669e-15
-      vertex 60.9344 -22.3763 2.7403e-15
-    endloop
-  endfacet
-  facet normal 1.19761e-22 1.22464e-16 1
-    outer loop
-      vertex 59.2227 -22.7401 2.78486e-15
-      vertex 60.9344 -22.3763 2.7403e-15
-      vertex 60.7406 -21.7798 2.66726e-15
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 61 -23 2.81669e-15
-      vertex 59.25 -23 2.81669e-15
-      vertex 60.9344 -23.6237 2.89307e-15
-    endloop
-  endfacet
-  facet normal -2.2677e-22 1.22465e-16 1
-    outer loop
-      vertex 59.1419 -22.4916 2.75442e-15
-      vertex 60.7406 -21.7798 2.66726e-15
-      vertex 60.4271 -21.2366 2.60074e-15
-    endloop
-  endfacet
-  facet normal -1.06781e-22 1.22465e-16 1
-    outer loop
-      vertex 59.2227 -23.2599 2.84851e-15
-      vertex 60.9344 -23.6237 2.89307e-15
-      vertex 59.25 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal 1.52539e-22 1.22465e-16 1
-    outer loop
-      vertex 59.0113 -22.2653 2.72671e-15
-      vertex 60.4271 -21.2366 2.60074e-15
-      vertex 60.0074 -20.7706 2.54366e-15
-    endloop
-  endfacet
-  facet normal -1.19761e-22 1.22464e-16 1
-    outer loop
-      vertex 60.9344 -23.6237 2.89307e-15
-      vertex 59.2227 -23.2599 2.84851e-15
-      vertex 60.7406 -24.2202 2.96612e-15
-    endloop
-  endfacet
-  facet normal -3.51893e-22 1.22465e-16 1
-    outer loop
-      vertex 58.8364 -22.0711 2.70293e-15
-      vertex 60.0074 -20.7706 2.54366e-15
-      vertex 59.5 -20.4019 2.49851e-15
-    endloop
-  endfacet
-  facet normal 3.02768e-22 1.22465e-16 1
-    outer loop
-      vertex 59.1419 -23.5084 2.87895e-15
-      vertex 60.7406 -24.2202 2.96612e-15
-      vertex 59.2227 -23.2599 2.84851e-15
-    endloop
-  endfacet
-  facet normal 7.445e-23 1.22465e-16 1
-    outer loop
-      vertex 60.7406 -24.2202 2.96612e-15
-      vertex 59.1419 -23.5084 2.87895e-15
-      vertex 60.4271 -24.7634 3.03264e-15
-    endloop
-  endfacet
-  facet normal 2.93644e-22 1.22464e-16 1
-    outer loop
-      vertex 60.9344 -22.3763 2.7403e-15
-      vertex 59.2227 -22.7401 2.78486e-15
-      vertex 59.25 -23 2.81669e-15
-    endloop
-  endfacet
-  facet normal -3.02768e-22 1.22465e-16 1
-    outer loop
-      vertex 60.7406 -21.7798 2.66726e-15
-      vertex 59.1419 -22.4916 2.75442e-15
-      vertex 59.2227 -22.7401 2.78486e-15
-    endloop
-  endfacet
-  facet normal -1.09312e-22 1.22465e-16 1
-    outer loop
-      vertex 60.4271 -21.2366 2.60074e-15
-      vertex 59.0113 -22.2653 2.72671e-15
-      vertex 59.1419 -22.4916 2.75442e-15
-    endloop
-  endfacet
-  facet normal 3.29986e-22 1.22465e-16 1
-    outer loop
-      vertex 58.625 -21.9175 2.68412e-15
-      vertex 59.5 -20.4019 2.49851e-15
-      vertex 58.9271 -20.1468 2.46728e-15
-    endloop
-  endfacet
-  facet normal 4.08424e-22 1.22464e-16 1
-    outer loop
-      vertex 60.0074 -20.7706 2.54366e-15
-      vertex 58.8364 -22.0711 2.70293e-15
-      vertex 59.0113 -22.2653 2.72671e-15
-    endloop
-  endfacet
-  facet normal -8.71992e-22 1.22465e-16 1
-    outer loop
-      vertex 59.5 -20.4019 2.49851e-15
-      vertex 58.625 -21.9175 2.68412e-15
-      vertex 58.8364 -22.0711 2.70293e-15
-    endloop
-  endfacet
-  facet normal 2.40041e-22 1.22465e-16 1
-    outer loop
-      vertex 58.9271 -20.1468 2.46728e-15
-      vertex 58.3863 -21.8112 2.6711e-15
-      vertex 58.625 -21.9175 2.68412e-15
-    endloop
-  endfacet
-  facet normal -2.33148e-23 1.22465e-16 1
-    outer loop
-      vertex 58.3136 -20.0164 2.45131e-15
-      vertex 58.3863 -21.8112 2.6711e-15
-      vertex 58.9271 -20.1468 2.46728e-15
-    endloop
-  endfacet
-  facet normal -1.1235e-22 1.22465e-16 1
-    outer loop
-      vertex 58.3136 -20.0164 2.45131e-15
-      vertex 58.1307 -21.7568 2.66445e-15
-      vertex 58.3863 -21.8112 2.6711e-15
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex 58 -20.0164 2.45131e-15
-      vertex 58.1307 -21.7568 2.66445e-15
-      vertex 58.3136 -20.0164 2.45131e-15
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 58.1307 -21.7568 2.66445e-15
-      vertex 58 -20.0164 2.45131e-15
-      vertex 57.8693 -21.7568 2.66445e-15
-    endloop
-  endfacet
-  facet normal 2.25542e-22 1.22465e-16 1
-    outer loop
-      vertex 59.0113 -23.7347 2.90667e-15
-      vertex 60.4271 -24.7634 3.03264e-15
-      vertex 59.1419 -23.5084 2.87895e-15
-    endloop
-  endfacet
-  facet normal -5.28011e-23 1.22464e-16 1
-    outer loop
-      vertex 60.4271 -24.7634 3.03264e-15
-      vertex 59.0113 -23.7347 2.90667e-15
-      vertex 60.0074 -25.2294 3.08971e-15
-    endloop
-  endfacet
-  facet normal -3.08686e-22 1.22464e-16 1
-    outer loop
-      vertex 58.8364 -23.9289 2.93045e-15
-      vertex 60.0074 -25.2294 3.08971e-15
-      vertex 59.0113 -23.7347 2.90667e-15
-    endloop
-  endfacet
-  facet normal 4.3078e-22 1.22465e-16 1
-    outer loop
-      vertex 60.0074 -25.2294 3.08971e-15
-      vertex 58.8364 -23.9289 2.93045e-15
-      vertex 59.5 -25.5981 3.13486e-15
-    endloop
-  endfacet
-  facet normal 9.36177e-23 1.22465e-16 1
-    outer loop
-      vertex 58.625 -24.0825 2.94926e-15
-      vertex 59.5 -25.5981 3.13486e-15
-      vertex 58.8364 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal -5.66806e-24 1.22465e-16 1
-    outer loop
-      vertex 59.5 -25.5981 3.13486e-15
-      vertex 58.625 -24.0825 2.94926e-15
-      vertex 58.9271 -25.8532 3.1661e-15
-    endloop
-  endfacet
-  facet normal -2.94629e-22 1.22465e-16 1
-    outer loop
-      vertex 58.3863 -24.1888 2.96228e-15
-      vertex 58.9271 -25.8532 3.1661e-15
-      vertex 58.625 -24.0825 2.94926e-15
-    endloop
-  endfacet
-  facet normal -3.60749e-22 1.22465e-16 1
-    outer loop
-      vertex 58.3863 -24.1888 2.96228e-15
-      vertex 58.3136 -25.9836 3.18207e-15
-      vertex 58.9271 -25.8532 3.1661e-15
-    endloop
-  endfacet
-  facet normal 1.1235e-22 1.22465e-16 1
-    outer loop
-      vertex 58.1307 -24.2432 2.96893e-15
-      vertex 58.3136 -25.9836 3.18207e-15
-      vertex 58.3863 -24.1888 2.96228e-15
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 58.1307 -24.2432 2.96893e-15
-      vertex 58 -25.9836 3.18207e-15
-      vertex 58.3136 -25.9836 3.18207e-15
-    endloop
-  endfacet
-  facet normal -0 1.22465e-16 1
-    outer loop
-      vertex 57.8693 -24.2432 2.96893e-15
-      vertex 58 -25.9836 3.18207e-15
-      vertex 58.1307 -24.2432 2.96893e-15
-    endloop
-  endfacet
-  facet normal -1.16721e-22 1.22465e-16 1
-    outer loop
-      vertex 57.6137 -24.1888 2.96228e-15
-      vertex 58 -25.9836 3.18207e-15
-      vertex 57.8693 -24.2432 2.96893e-15
-    endloop
-  endfacet
-  facet normal 3.08086e-22 1.22465e-16 1
-    outer loop
-      vertex 57.375 -24.0825 2.94926e-15
-      vertex 58 -25.9836 3.18207e-15
-      vertex 57.6137 -24.1888 2.96228e-15
-    endloop
-  endfacet
-  facet normal -2.92609e-22 1.22465e-16 1
-    outer loop
-      vertex 57.1636 -23.9289 2.93045e-15
-      vertex 58 -25.9836 3.18207e-15
-      vertex 57.375 -24.0825 2.94926e-15
-    endloop
-  endfacet
-  facet normal 3.185e-20 1.22478e-16 1
-    outer loop
-      vertex 58 -25.9836 3.18207e-15
-      vertex 57.1636 -23.9289 2.93045e-15
-      vertex 58 -26 3.18408e-15
-    endloop
-  endfacet
-  facet normal 1.5262e-21 1.22465e-16 1
-    outer loop
-      vertex 56.9887 -23.7347 2.90667e-15
-      vertex 58 -26 3.18408e-15
-      vertex 57.1636 -23.9289 2.93045e-15
-    endloop
-  endfacet
-  facet normal -2.05411e-21 1.22464e-16 1
-    outer loop
-      vertex 56.8581 -23.5084 2.87895e-15
-      vertex 58 -26 3.18408e-15
-      vertex 56.9887 -23.7347 2.90667e-15
-    endloop
-  endfacet
-  facet normal 3.33478e-24 1.22465e-16 1
-    outer loop
-      vertex 25 -26 3.18408e-15
-      vertex 56.75 -23 2.81669e-15
-      vertex 25 -20 2.44929e-15
-    endloop
-  endfacet
-  facet normal 1.68709e-23 1.22465e-16 1
-    outer loop
-      vertex 56.75 -23 2.81669e-15
-      vertex 25 -26 3.18408e-15
-      vertex 56.7773 -23.2599 2.84851e-15
-    endloop
-  endfacet
-  facet normal -4.35318e-23 1.22465e-16 1
-    outer loop
-      vertex 56.7773 -23.2599 2.84851e-15
-      vertex 25 -26 3.18408e-15
-      vertex 56.8581 -23.5084 2.87895e-15
-    endloop
-  endfacet
-  facet normal 0 1.22465e-16 1
-    outer loop
-      vertex 56.8581 -23.5084 2.87895e-15
-      vertex 25 -26 3.18408e-15
-      vertex 58 -26 3.18408e-15
-    endloop
-  endfacet
-  facet normal 0.994522 0.104532 0
-    outer loop
-      vertex 61 -23 2.81669e-15
-      vertex 60.9344 -22.3763 -2
-      vertex 60.9344 -22.3763 2.7403e-15
-    endloop
-  endfacet
-  facet normal 0.994522 0.104532 0
-    outer loop
-      vertex 60.9344 -22.3763 -2
-      vertex 61 -23 2.81669e-15
-      vertex 61 -23 -2
-    endloop
-  endfacet
-  facet normal 0.866026 0.499999 0
-    outer loop
-      vertex 60.7406 -21.7798 2.66726e-15
-      vertex 60.4271 -21.2366 -2
-      vertex 60.4271 -21.2366 2.60074e-15
-    endloop
-  endfacet
-  facet normal 0.866026 0.499999 0
-    outer loop
-      vertex 60.4271 -21.2366 -2
-      vertex 60.7406 -21.7798 2.66726e-15
-      vertex 60.7406 -21.7798 -2
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 58.3136 -20.0164 -2
-      vertex 58 -20.0164 2.45131e-15
-      vertex 58.3136 -20.0164 2.45131e-15
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 58 -20.0164 2.45131e-15
-      vertex 58.3136 -20.0164 -2
-      vertex 58 -20.0164 -2
-    endloop
-  endfacet
-  facet normal 0.587784 0.809018 -0
-    outer loop
-      vertex 60.0074 -20.7706 -2
-      vertex 59.5 -20.4019 2.49851e-15
-      vertex 60.0074 -20.7706 2.54366e-15
-    endloop
-  endfacet
-  facet normal 0.587784 0.809018 0
-    outer loop
-      vertex 59.5 -20.4019 2.49851e-15
-      vertex 60.0074 -20.7706 -2
-      vertex 59.5 -20.4019 -2
-    endloop
-  endfacet
-  facet normal 0.743146 0.669129 0
-    outer loop
-      vertex 60.4271 -21.2366 2.60074e-15
-      vertex 60.0074 -20.7706 -2
-      vertex 60.0074 -20.7706 2.54366e-15
-    endloop
-  endfacet
-  facet normal 0.743146 0.669129 0
-    outer loop
-      vertex 60.0074 -20.7706 -2
-      vertex 60.4271 -21.2366 2.60074e-15
-      vertex 60.4271 -21.2366 -2
-    endloop
-  endfacet
-  facet normal 0.951057 0.309016 0
-    outer loop
-      vertex 60.9344 -22.3763 2.7403e-15
-      vertex 60.7406 -21.7798 -2
-      vertex 60.7406 -21.7798 2.66726e-15
-    endloop
-  endfacet
-  facet normal 0.951057 0.309016 0
-    outer loop
-      vertex 60.7406 -21.7798 -2
-      vertex 60.9344 -22.3763 2.7403e-15
-      vertex 60.9344 -22.3763 -2
-    endloop
-  endfacet
-  facet normal 0.20791 0.978148 -0
-    outer loop
-      vertex 58.9271 -20.1468 -2
-      vertex 58.3136 -20.0164 2.45131e-15
-      vertex 58.9271 -20.1468 2.46728e-15
-    endloop
-  endfacet
-  facet normal 0.20791 0.978148 0
-    outer loop
-      vertex 58.3136 -20.0164 2.45131e-15
-      vertex 58.9271 -20.1468 -2
-      vertex 58.3136 -20.0164 -2
+      vertex 62.0853 29.4424 4.5
+      vertex 62.648 29.2716 0
+      vertex 62.0853 29.4424 0
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -3 -18.3 -4.5
-      vertex -3 -23 -4.5
-      vertex -3 -18.3 -2.5
+      vertex 25.5 29 2
+      vertex 25.5 26 2.4
+      vertex 25.5 29 4.5
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex -3 -5.7059 -4.5
-      vertex -3 -14.3 -4.5
-      vertex -3 -5.7059 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -3.18637 -4.5
-      vertex -3 -4.07166 -4.5
-      vertex -3 -3.18637 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -1.55213 -2.5
-      vertex -3 -5.51091e-16 -4.5
-      vertex -3 -1.55213 -4.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -5.51091e-16 -4.5
-      vertex -3 -1.55213 -2.5
-      vertex -3 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -3.18637 -2.5
-      vertex -3 -2.44929e-16 -2
-      vertex -3 -1.55213 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -4.07166 -2.5
-      vertex -3 -3.18637 -2.5
-      vertex -3 -4.07166 -4.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -4.07166 -2.5
-      vertex -3 -2.44929e-16 -2
-      vertex -3 -3.18637 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -5.7059 -2.5
-      vertex -3 -2.44929e-16 -2
-      vertex -3 -4.07166 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -14.3 -2.5
-      vertex -3 -5.7059 -2.5
-      vertex -3 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -14.3 -2.5
-      vertex -3 -2.44929e-16 -2
-      vertex -3 -5.7059 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -23 -2
-      vertex -3 -14.3 -2.5
-      vertex -3 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -23 -2.5
-      vertex -3 -18.3 -2.5
-      vertex -3 -23 -4.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -23 -2
-      vertex -3 -18.3 -2.5
-      vertex -3 -23 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 -14.3 -2.5
-      vertex -3 -23 -2
-      vertex -3 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -2.44929e-16 -2
-      vertex 3 -3 -3
-      vertex 3 -3.67394e-16 -3
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -14.1749 -4.5
-      vertex 3 -3 -3
-      vertex 3 -14.1749 -2.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -2.44929e-16 -2
-      vertex 3 -14.1749 -2.5
-      vertex 3 -3 -3
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 3 -23 -2
-      vertex 3 -14.1749 -2.5
-      vertex 3 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -18.3 -2.5
-      vertex 3 -20 -2.5
-      vertex 3 -18.3 -4.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -14.1749 -2.5
-      vertex 3 -23 -2
-      vertex 3 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -18.3 -2.5
-      vertex 3 -23 -2
-      vertex 3 -20 -2.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -20 -2.5
-      vertex 3 -23 -2
-      vertex 3 -23 -2.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -3 -3
-      vertex 3 -14.1749 -4.5
-      vertex 3 -3 -4.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 3 -18.3 -4.5
-      vertex 3 -20 -2.5
-      vertex 3 -20 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.93444 -0.623734 -2
-      vertex 3 -23 -2
-      vertex 3 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.93444 -0.623734 -2
-      vertex 2.93444 -22.3763 -2
-      vertex 3 -23 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.74064 -1.22021 -2
-      vertex 2.93444 -22.3763 -2
-      vertex 2.93444 -0.623734 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.74064 -1.22021 -2
-      vertex 2.74064 -21.7798 -2
-      vertex 2.93444 -22.3763 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.42705 -1.76336 -2
-      vertex 2.74064 -21.7798 -2
-      vertex 2.74064 -1.22021 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.42705 -1.76336 -2
-      vertex 2.42705 -21.2366 -2
-      vertex 2.74064 -21.7798 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 2.00739 -2.22943 -2
-      vertex 2.42705 -21.2366 -2
-      vertex 2.42705 -1.76336 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.00739 -2.22943 -2
-      vertex 2.00739 -20.7706 -2
-      vertex 2.42705 -21.2366 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 1.5 -2.59808 -2
-      vertex 2.00739 -20.7706 -2
-      vertex 2.00739 -2.22943 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 1.5 -2.59808 -2
-      vertex 1.5 -20.4019 -2
-      vertex 2.00739 -20.7706 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.927051 -2.85317 -2
-      vertex 1.5 -20.4019 -2
-      vertex 1.5 -2.59808 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.927051 -2.85317 -2
-      vertex 0.927051 -20.1468 -2
-      vertex 1.5 -20.4019 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0.313585 -2.98357 -2
-      vertex 0.927051 -20.1468 -2
-      vertex 0.927051 -2.85317 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.313585 -2.98357 -2
-      vertex 0.313585 -20.0164 -2
-      vertex 0.927051 -20.1468 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -0.313585 -2.98357 -2
-      vertex 0.313585 -20.0164 -2
-      vertex 0.313585 -2.98357 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.313585 -2.98357 -2
-      vertex -0.313585 -20.0164 -2
-      vertex 0.313585 -20.0164 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.927051 -2.85317 -2
-      vertex -0.313585 -20.0164 -2
-      vertex -0.313585 -2.98357 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.927051 -2.85317 -2
-      vertex -0.927051 -20.1468 -2
-      vertex -0.313585 -20.0164 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.5 -2.59808 -2
-      vertex -0.927051 -20.1468 -2
-      vertex -0.927051 -2.85317 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.5 -2.59808 -2
-      vertex -1.5 -20.4019 -2
-      vertex -0.927051 -20.1468 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.00739 -2.22943 -2
-      vertex -1.5 -20.4019 -2
-      vertex -1.5 -2.59808 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.00739 -2.22943 -2
-      vertex -2.00739 -20.7706 -2
-      vertex -1.5 -20.4019 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.42705 -1.76336 -2
-      vertex -2.00739 -20.7706 -2
-      vertex -2.00739 -2.22943 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.42705 -1.76336 -2
-      vertex -2.42705 -21.2366 -2
-      vertex -2.00739 -20.7706 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.74064 -1.22021 -2
-      vertex -2.42705 -21.2366 -2
-      vertex -2.42705 -1.76336 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.74064 -1.22021 -2
-      vertex -2.74064 -21.7798 -2
-      vertex -2.42705 -21.2366 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.93444 -0.623734 -2
-      vertex -2.74064 -21.7798 -2
-      vertex -2.74064 -1.22021 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.93444 -0.623734 -2
-      vertex -2.93444 -22.3763 -2
-      vertex -2.74064 -21.7798 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -3 -2.44929e-16 -2
-      vertex -2.93444 -22.3763 -2
-      vertex -2.93444 -0.623734 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2.93444 -22.3763 -2
-      vertex -3 -2.44929e-16 -2
-      vertex -3 -23 -2
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 55 -3 -4.5
-      vertex 55 -20 -4.5
-      vertex 55 -3 -3
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 55 -1 -3
-      vertex 55 -3 -3
-      vertex 55 -1 -2.7
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 55 -1 -2.7
-      vertex 55 -2.44929e-16 -2
-      vertex 55 -3.30655e-16 -2.7
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 55 -3 -3
-      vertex 55 -2.44929e-16 -2
-      vertex 55 -1 -2.7
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 55 -20 -2
-      vertex 55 -3 -3
-      vertex 55 -20 -4.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 55 -3 -3
-      vertex 55 -20 -2
-      vertex 55 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 61 -23 -2
-      vertex 61 -5.51091e-16 -4.5
-      vertex 61 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 61 -5.51091e-16 -4.5
-      vertex 61 -23 -2
-      vertex 61 -23 -4.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 60.9344 -0.623734 -2
-      vertex 61 -23 -2
-      vertex 61 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 60.9344 -0.623734 -2
-      vertex 60.9344 -22.3763 -2
-      vertex 61 -23 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 60.7406 -1.22021 -2
-      vertex 60.9344 -22.3763 -2
-      vertex 60.9344 -0.623734 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 60.7406 -1.22021 -2
-      vertex 60.7406 -21.7798 -2
-      vertex 60.9344 -22.3763 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 60.4271 -1.76336 -2
-      vertex 60.7406 -21.7798 -2
-      vertex 60.7406 -1.22021 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 60.4271 -1.76336 -2
-      vertex 60.4271 -21.2366 -2
-      vertex 60.7406 -21.7798 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 60.0074 -2.22943 -2
-      vertex 60.4271 -21.2366 -2
-      vertex 60.4271 -1.76336 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 60.0074 -2.22943 -2
-      vertex 60.0074 -20.7706 -2
-      vertex 60.4271 -21.2366 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 59.5 -2.59808 -2
-      vertex 60.0074 -20.7706 -2
-      vertex 60.0074 -2.22943 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 59.5 -2.59808 -2
-      vertex 59.5 -20.4019 -2
-      vertex 60.0074 -20.7706 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 58.9271 -2.85317 -2
-      vertex 59.5 -20.4019 -2
-      vertex 59.5 -2.59808 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.9271 -2.85317 -2
-      vertex 58.9271 -20.1468 -2
-      vertex 59.5 -20.4019 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 58.3136 -2.98357 -2
-      vertex 58.9271 -20.1468 -2
-      vertex 58.9271 -2.85317 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.3136 -2.98357 -2
-      vertex 58.3136 -20.0164 -2
-      vertex 58.9271 -20.1468 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.3136 -2.98357 -2
-      vertex 58 -20 -2
-      vertex 58.3136 -20.0164 -2
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 57.6864 -2.98357 -2
-      vertex 58 -20 -2
-      vertex 58.3136 -2.98357 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 55 -20 -2
-      vertex 57.6864 -2.98357 -2
-      vertex 57.0729 -2.85317 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 55 -20 -2
-      vertex 57.0729 -2.85317 -2
-      vertex 56.5 -2.59808 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 55 -20 -2
-      vertex 56.5 -2.59808 -2
-      vertex 55.9926 -2.22943 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 55 -20 -2
-      vertex 55.9926 -2.22943 -2
-      vertex 55.5729 -1.76336 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 55 -20 -2
-      vertex 55.5729 -1.76336 -2
-      vertex 55.2594 -1.22021 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 55 -20 -2
-      vertex 55.2594 -1.22021 -2
-      vertex 55.0656 -0.623734 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 57.6864 -2.98357 -2
-      vertex 55 -20 -2
-      vertex 58 -20 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 55 -20 -2
-      vertex 55.0656 -0.623734 -2
-      vertex 55 -2.44929e-16 -2
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 58.3136 -20.0164 -2
-      vertex 58 -20 -2
-      vertex 58 -20.0164 -2
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 0 2.98357 -4.5
-      vertex 0 3 -3
-      vertex 0 3 -4.5
+      vertex 25.5 24 2
+      vertex 25.5 26 2.4
+      vertex 25.5 29 2
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 0 3 -3
-      vertex 0 2.98357 -4.5
-      vertex 0 2.98357 -3
+      vertex 25.5 26 2.4
+      vertex 25.5 24 2
+      vertex 25.5 24 2.4
     endloop
   endfacet
-  facet normal 1 -0 0
+  facet normal -1 -0 0
     outer loop
-      vertex 58 2.98357 -2.7
-      vertex 58 3 -4.5
-      vertex 58 3 -2.7
+      vertex 25.5 29 4.5
+      vertex 25.5 26 2.4
+      vertex 25.5 26 4.5
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal -0.290715 -0.95681 0
     outer loop
-      vertex 58 3 -4.5
-      vertex 58 2.98357 -2.7
-      vertex 58 2.98357 -4.5
+      vertex 25.8087 23.5381 2
+      vertex 25.9025 23.5096 2.4
+      vertex 25.8087 23.5381 2.4
+    endloop
+  endfacet
+  facet normal -0.290715 -0.95681 -0
+    outer loop
+      vertex 25.9025 23.5096 2.4
+      vertex 25.8087 23.5381 2
+      vertex 25.9025 23.5096 2
+    endloop
+  endfacet
+  facet normal -0.995188 0.0979877 0
+    outer loop
+      vertex 25.5 29 2
+      vertex 25.5096 29.0975 4.5
+      vertex 25.5096 29.0975 2
+    endloop
+  endfacet
+  facet normal -0.995188 0.0979877 0
+    outer loop
+      vertex 25.5096 29.0975 4.5
+      vertex 25.5 29 2
+      vertex 25.5 29 4.5
+    endloop
+  endfacet
+  facet normal 0.95689 0.290451 0
+    outer loop
+      vertex 64.4424 27.0853 4.5
+      vertex 64.2716 27.648 0
+      vertex 64.2716 27.648 4.5
+    endloop
+  endfacet
+  facet normal 0.95689 0.290451 0
+    outer loop
+      vertex 64.2716 27.648 0
+      vertex 64.4424 27.0853 4.5
+      vertex 64.4424 27.0853 0
+    endloop
+  endfacet
+  facet normal -0.633738 0.773548 0
+    outer loop
+      vertex 25.7222 29.4157 2
+      vertex 25.6464 29.3536 4.5
+      vertex 25.7222 29.4157 4.5
+    endloop
+  endfacet
+  facet normal -0.633738 0.773548 0
+    outer loop
+      vertex 25.6464 29.3536 4.5
+      vertex 25.7222 29.4157 2
+      vertex 25.6464 29.3536 2
+    endloop
+  endfacet
+  facet normal 0.471329 -0.881957 0
+    outer loop
+      vertex 62.648 23.7284 3.3
+      vertex 63.1667 24.0056 4.5
+      vertex 62.648 23.7284 4.5
+    endloop
+  endfacet
+  facet normal 0.471329 -0.881957 0
+    outer loop
+      vertex 63.1667 24.0056 4.5
+      vertex 62.648 23.7284 3.3
+      vertex 63.1667 24.0056 3.3
+    endloop
+  endfacet
+  facet normal 0.634413 0.772994 -0
+    outer loop
+      vertex 63.6213 28.6213 0
+      vertex 63.1667 28.9944 4.5
+      vertex 63.6213 28.6213 4.5
+    endloop
+  endfacet
+  facet normal 0.634413 0.772994 0
+    outer loop
+      vertex 63.1667 28.9944 4.5
+      vertex 63.6213 28.6213 0
+      vertex 63.1667 28.9944 0
+    endloop
+  endfacet
+  facet normal 0.772994 0.634413 0
+    outer loop
+      vertex 63.9944 28.1667 4.5
+      vertex 63.6213 28.6213 0
+      vertex 63.6213 28.6213 4.5
+    endloop
+  endfacet
+  facet normal 0.772994 0.634413 0
+    outer loop
+      vertex 63.6213 28.6213 0
+      vertex 63.9944 28.1667 4.5
+      vertex 63.9944 28.1667 0
+    endloop
+  endfacet
+  facet normal 0.471329 0.881957 -0
+    outer loop
+      vertex 63.1667 28.9944 0
+      vertex 62.648 29.2716 4.5
+      vertex 63.1667 28.9944 4.5
+    endloop
+  endfacet
+  facet normal 0.471329 0.881957 0
+    outer loop
+      vertex 62.648 29.2716 4.5
+      vertex 63.1667 28.9944 0
+      vertex 62.648 29.2716 0
+    endloop
+  endfacet
+  facet normal -0.290715 0.95681 0
+    outer loop
+      vertex 25.9025 29.4904 2
+      vertex 25.8087 29.4619 4.5
+      vertex 25.9025 29.4904 4.5
+    endloop
+  endfacet
+  facet normal -0.290715 0.95681 0
+    outer loop
+      vertex 25.8087 29.4619 4.5
+      vertex 25.9025 29.4904 2
+      vertex 25.8087 29.4619 2
+    endloop
+  endfacet
+  facet normal 0.995193 0.097938 -0
+    outer loop
+      vertex 64.5 26.5 3.3
+      vertex 64.4424 27.0853 4.5
+      vertex 64.5 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0.995193 0.097938 0
+    outer loop
+      vertex 64.4424 27.0853 4.5
+      vertex 64.5 26.5 3.3
+      vertex 64.4424 27.0853 0
+    endloop
+  endfacet
+  facet normal 0.995193 0.097938 0
+    outer loop
+      vertex 64.4424 27.0853 0
+      vertex 64.5 26.5 3.3
+      vertex 64.5 26.5 0
+    endloop
+  endfacet
+  facet normal 0.956904 -0.290404 0
+    outer loop
+      vertex 64.2716 25.3519 4.5
+      vertex 64.4424 25.9147 3.3
+      vertex 64.4424 25.9147 4.5
+    endloop
+  endfacet
+  facet normal 0.956904 -0.290404 0
+    outer loop
+      vertex 64.4424 25.9147 3.3
+      vertex 64.2716 25.3519 4.5
+      vertex 64.2716 25.3519 3.3
+    endloop
+  endfacet
+  facet normal -0.95681 0.290715 0
+    outer loop
+      vertex 25.5096 29.0975 2
+      vertex 25.5381 29.1913 4.5
+      vertex 25.5381 29.1913 2
+    endloop
+  endfacet
+  facet normal -0.95681 0.290715 0
+    outer loop
+      vertex 25.5381 29.1913 4.5
+      vertex 25.5096 29.0975 2
+      vertex 25.5096 29.0975 4.5
+    endloop
+  endfacet
+  facet normal -0.995188 -0.0979877 0
+    outer loop
+      vertex 25.5096 23.9025 2
+      vertex 25.5 24 2.4
+      vertex 25.5 24 2
+    endloop
+  endfacet
+  facet normal -0.995188 -0.0979877 0
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 25.5096 23.9025 2
+      vertex 25.5096 23.9025 2.4
+    endloop
+  endfacet
+  facet normal 0.881957 0.471329 0
+    outer loop
+      vertex 64.2716 27.648 4.5
+      vertex 63.9944 28.1667 0
+      vertex 63.9944 28.1667 4.5
+    endloop
+  endfacet
+  facet normal 0.881957 0.471329 0
+    outer loop
+      vertex 63.9944 28.1667 0
+      vertex 64.2716 27.648 4.5
+      vertex 64.2716 27.648 0
+    endloop
+  endfacet
+  facet normal -0.471117 0.882071 0
+    outer loop
+      vertex 25.8087 29.4619 2
+      vertex 25.7222 29.4157 4.5
+      vertex 25.8087 29.4619 4.5
+    endloop
+  endfacet
+  facet normal -0.471117 0.882071 0
+    outer loop
+      vertex 25.7222 29.4157 4.5
+      vertex 25.8087 29.4619 2
+      vertex 25.7222 29.4157 2
+    endloop
+  endfacet
+  facet normal 0.995193 -0.097938 0
+    outer loop
+      vertex 64.4424 25.9147 4.5
+      vertex 64.5 26.5 3.3
+      vertex 64.5 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0.995193 -0.097938 0
+    outer loop
+      vertex 64.5 26.5 3.3
+      vertex 64.4424 25.9147 4.5
+      vertex 64.4424 25.9147 3.3
+    endloop
+  endfacet
+  facet normal 0.634413 -0.772994 0
+    outer loop
+      vertex 63.1667 24.0056 3.3
+      vertex 63.6213 24.3787 4.5
+      vertex 63.1667 24.0056 4.5
+    endloop
+  endfacet
+  facet normal 0.634413 -0.772994 0
+    outer loop
+      vertex 63.6213 24.3787 4.5
+      vertex 63.1667 24.0056 3.3
+      vertex 63.6213 24.3787 3.3
+    endloop
+  endfacet
+  facet normal -0.882071 0.471117 0
+    outer loop
+      vertex 25.5381 29.1913 2
+      vertex 25.5843 29.2778 4.5
+      vertex 25.5843 29.2778 2
+    endloop
+  endfacet
+  facet normal -0.882071 0.471117 0
+    outer loop
+      vertex 25.5843 29.2778 4.5
+      vertex 25.5381 29.1913 2
+      vertex 25.5381 29.1913 4.5
+    endloop
+  endfacet
+  facet normal -0.95681 -0.290715 0
+    outer loop
+      vertex 25.5381 23.8087 2
+      vertex 25.5096 23.9025 2.4
+      vertex 25.5096 23.9025 2
+    endloop
+  endfacet
+  facet normal -0.95681 -0.290715 0
+    outer loop
+      vertex 25.5096 23.9025 2.4
+      vertex 25.5381 23.8087 2
+      vertex 25.5381 23.8087 2.4
+    endloop
+  endfacet
+  facet normal -0.773548 0.633738 0
+    outer loop
+      vertex 25.5843 29.2778 2
+      vertex 25.6464 29.3536 4.5
+      vertex 25.6464 29.3536 2
+    endloop
+  endfacet
+  facet normal -0.773548 0.633738 0
+    outer loop
+      vertex 25.6464 29.3536 4.5
+      vertex 25.5843 29.2778 2
+      vertex 25.5843 29.2778 4.5
+    endloop
+  endfacet
+  facet normal -0.471117 -0.882071 0
+    outer loop
+      vertex 25.7222 23.5843 2
+      vertex 25.8087 23.5381 2.4
+      vertex 25.7222 23.5843 2.4
+    endloop
+  endfacet
+  facet normal -0.471117 -0.882071 -0
+    outer loop
+      vertex 25.8087 23.5381 2.4
+      vertex 25.7222 23.5843 2
+      vertex 25.8087 23.5381 2
+    endloop
+  endfacet
+  facet normal 0.772994 -0.634413 0
+    outer loop
+      vertex 63.6213 24.3787 4.5
+      vertex 63.9944 24.8333 3.3
+      vertex 63.9944 24.8333 4.5
+    endloop
+  endfacet
+  facet normal 0.772994 -0.634413 0
+    outer loop
+      vertex 63.9944 24.8333 3.3
+      vertex 63.6213 24.3787 4.5
+      vertex 63.6213 24.3787 3.3
+    endloop
+  endfacet
+  facet normal -0.633738 -0.773548 0
+    outer loop
+      vertex 25.6464 23.6464 2
+      vertex 25.7222 23.5843 2.4
+      vertex 25.6464 23.6464 2.4
+    endloop
+  endfacet
+  facet normal -0.633738 -0.773548 -0
+    outer loop
+      vertex 25.7222 23.5843 2.4
+      vertex 25.6464 23.6464 2
+      vertex 25.7222 23.5843 2
+    endloop
+  endfacet
+  facet normal -0.882071 -0.471117 0
+    outer loop
+      vertex 25.5843 23.7222 2
+      vertex 25.5381 23.8087 2.4
+      vertex 25.5381 23.8087 2
+    endloop
+  endfacet
+  facet normal -0.882071 -0.471117 0
+    outer loop
+      vertex 25.5381 23.8087 2.4
+      vertex 25.5843 23.7222 2
+      vertex 25.5843 23.7222 2.4
+    endloop
+  endfacet
+  facet normal -0.773548 -0.633738 0
+    outer loop
+      vertex 25.6464 23.6464 2
+      vertex 25.5843 23.7222 2.4
+      vertex 25.5843 23.7222 2
+    endloop
+  endfacet
+  facet normal -0.773548 -0.633738 0
+    outer loop
+      vertex 25.5843 23.7222 2.4
+      vertex 25.6464 23.6464 2
+      vertex 25.6464 23.6464 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 3 -3.67394e-16 -3
-      vertex 22 -1 -3
+      vertex 28.5 26 2.4
+      vertex 37.7 29.5 2.4
+      vertex 28.5 29 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 2.93444 0.623734 -3
-      vertex 3 -3.67394e-16 -3
+      vertex 37.7 29.5 2.4
+      vertex 28.4904 29.0975 2.4
+      vertex 28.5 29 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 2.74064 1.22021 -3
-      vertex 2.93444 0.623734 -3
+      vertex 37.7 29.5 2.4
+      vertex 28.4619 29.1913 2.4
+      vertex 28.4904 29.0975 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 2.42705 1.76336 -3
-      vertex 2.74064 1.22021 -3
+      vertex 37.7 29.5 2.4
+      vertex 28.4157 29.2778 2.4
+      vertex 28.4619 29.1913 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 2.00739 2.22943 -3
-      vertex 2.42705 1.76336 -3
+      vertex 37.7 29.5 2.4
+      vertex 28.3536 29.3536 2.4
+      vertex 28.4157 29.2778 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 1.5 2.59808 -3
-      vertex 2.00739 2.22943 -3
+      vertex 37.7 29.5 2.4
+      vertex 28.2778 29.4157 2.4
+      vertex 28.3536 29.3536 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 0.927051 2.85317 -3
-      vertex 1.5 2.59808 -3
+      vertex 37.7 29.5 2.4
+      vertex 28.1913 29.4619 2.4
+      vertex 28.2778 29.4157 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 0.313585 2.98357 -3
-      vertex 0.927051 2.85317 -3
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 0 3 -3
-      vertex 0.313585 2.98357 -3
-      vertex 22 3 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.313585 2.98357 -3
-      vertex 0 3 -3
-      vertex 0 2.98357 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 52.3446 -1.02574 -3
-      vertex 55 -1 -3
-      vertex 52.3473 -1 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 52.2674 -1.265 -3
-      vertex 55 -1 -3
-      vertex 52.3446 -1.02574 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 55 -1 -3
-      vertex 52.2674 -1.265 -3
-      vertex 55 -3 -3
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 52.1414 -1.4818 -3
-      vertex 55 -3 -3
-      vertex 52.2674 -1.265 -3
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 51.9735 -1.66832 -3
-      vertex 55 -3 -3
-      vertex 52.1414 -1.4818 -3
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 51.7713 -1.81578 -3
-      vertex 55 -3 -3
-      vertex 51.9735 -1.66832 -3
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 51.5418 -1.91832 -3
-      vertex 55 -3 -3
-      vertex 51.7713 -1.81578 -3
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 51.2967 -1.97008 -3
-      vertex 55 -3 -3
-      vertex 51.5418 -1.91832 -3
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 51.0457 -1.97008 -3
-      vertex 55 -3 -3
-      vertex 51.2967 -1.97008 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 46.1304 -3 -3
-      vertex 51.0457 -1.97008 -3
-      vertex 50.8006 -1.91832 -3
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 46.1952 -1 -3
-      vertex 49.9969 -1.02574 -3
-      vertex 49.9942 -1 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 46.1825 -1.12047 -3
-      vertex 49.9969 -1.02574 -3
-      vertex 46.1952 -1 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 49.9969 -1.02574 -3
-      vertex 46.1825 -1.12047 -3
-      vertex 50.075 -1.265 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 46.1053 -1.35875 -3
-      vertex 50.075 -1.265 -3
-      vertex 46.1825 -1.12047 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 46.1053 -2.92223 -3
-      vertex 50.075 -1.265 -3
-      vertex 46.1053 -1.35875 -3
+      vertex 37.7 29.5 2.4
+      vertex 28.0975 29.4904 2.4
+      vertex 28.1913 29.4619 2.4
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex 46.1304 -3 -3
-      vertex 50.075 -1.265 -3
-      vertex 46.1053 -2.92223 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 50.075 -1.265 -3
-      vertex 46.1304 -3 -3
-      vertex 50.2 -1.4818 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 50.2 -1.4818 -3
-      vertex 46.1304 -3 -3
-      vertex 50.368 -1.66832 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 51.0457 -1.97008 -3
-      vertex 46.1304 -3 -3
-      vertex 55 -3 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 50.368 -1.66832 -3
-      vertex 46.1304 -3 -3
-      vertex 50.5711 -1.81578 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 50.5711 -1.81578 -3
-      vertex 46.1304 -3 -3
-      vertex 50.8006 -1.91832 -3
+      vertex 28.0975 29.4904 2.4
+      vertex 37.7 29.5 2.4
+      vertex 28 29.5 2.4
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 45.9793 -1.57555 -3
-      vertex 46.1053 -2.92223 -3
-      vertex 46.1053 -1.35875 -3
+      vertex 57.7 29.5 2.4
+      vertex 60.9147 29.4424 2.4
+      vertex 61.5 29.5 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 45.9793 -1.57555 -3
-      vertex 45.9793 -2.70543 -3
-      vertex 46.1053 -2.92223 -3
+      vertex 57.7 29.5 2.4
+      vertex 60.352 29.2716 2.4
+      vertex 60.9147 29.4424 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.7 29.5 2.4
+      vertex 59.8333 28.9944 2.4
+      vertex 60.352 29.2716 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.7 29.5 2.4
+      vertex 59.3787 28.6213 2.4
+      vertex 59.8333 28.9944 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.7 29.5 2.4
+      vertex 59.0056 28.1667 2.4
+      vertex 59.3787 28.6213 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.7 29.5 2.4
+      vertex 58.7284 27.648 2.4
+      vertex 59.0056 28.1667 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.7 29.5 2.4
+      vertex 58.5576 27.0853 2.4
+      vertex 58.7284 27.648 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.7 25 2.4
+      vertex 58.5576 27.0853 2.4
+      vertex 57.7 29.5 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5576 27.0853 2.4
+      vertex 57.7 25 2.4
+      vertex 58.5 26.5 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 26.5 2.4
+      vertex 57.7 25 2.4
+      vertex 58.5 23.5 2.4
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 45.8123 -1.76207 -3
-      vertex 45.9793 -2.70543 -3
-      vertex 45.9793 -1.57555 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 45.8123 -1.76207 -3
-      vertex 45.8123 -2.51891 -3
-      vertex 45.9793 -2.70543 -3
+      vertex 57.6904 24.9025 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.7 25 2.4
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 45.6092 -1.90953 -3
-      vertex 45.8123 -2.51891 -3
-      vertex 45.8123 -1.76207 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 45.6092 -1.90953 -3
-      vertex 45.6092 -2.37144 -3
-      vertex 45.8123 -2.51891 -3
+      vertex 57.6619 24.8087 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.6904 24.9025 2.4
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 45.3797 -2.01207 -3
-      vertex 45.6092 -2.37144 -3
-      vertex 45.6092 -1.90953 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 45.3797 -2.01207 -3
-      vertex 45.3797 -2.26891 -3
-      vertex 45.6092 -2.37144 -3
+      vertex 57.6157 24.7222 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.6619 24.8087 2.4
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 45.1346 -2.06383 -3
-      vertex 45.3797 -2.26891 -3
-      vertex 45.3797 -2.01207 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 45.1346 -2.06383 -3
-      vertex 45.1346 -2.21715 -3
-      vertex 45.3797 -2.26891 -3
+      vertex 57.5536 24.6464 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.6157 24.7222 2.4
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 44.8836 -2.06383 -3
-      vertex 45.1346 -2.21715 -3
-      vertex 45.1346 -2.06383 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.8836 -2.06383 -3
-      vertex 44.8836 -2.21715 -3
-      vertex 45.1346 -2.21715 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.6385 -2.01207 -3
-      vertex 44.8836 -2.21715 -3
-      vertex 44.8836 -2.06383 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.6385 -2.01207 -3
-      vertex 44.6385 -2.26891 -3
-      vertex 44.8836 -2.21715 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.409 -1.90953 -3
-      vertex 44.6385 -2.26891 -3
-      vertex 44.6385 -2.01207 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.409 -1.90953 -3
-      vertex 44.409 -2.37144 -3
-      vertex 44.6385 -2.26891 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.2059 -1.76207 -3
-      vertex 44.409 -2.37144 -3
-      vertex 44.409 -1.90953 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.2059 -1.76207 -3
-      vertex 44.2059 -2.51891 -3
-      vertex 44.409 -2.37144 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.0379 -1.57555 -3
-      vertex 44.2059 -2.51891 -3
-      vertex 44.2059 -1.76207 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 44.0379 -1.57555 -3
-      vertex 44.0379 -2.70543 -3
-      vertex 44.2059 -2.51891 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 43.9129 -1.35875 -3
-      vertex 44.0379 -2.70543 -3
-      vertex 44.0379 -1.57555 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 43.9129 -1.35875 -3
-      vertex 43.9129 -2.92223 -3
-      vertex 44.0379 -2.70543 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 43.9129 -1.35875 -3
-      vertex 43.8875 -3 -3
-      vertex 43.9129 -2.92223 -3
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 43.8348 -1.12047 -3
-      vertex 43.8875 -3 -3
-      vertex 43.9129 -1.35875 -3
+      vertex 57.4778 24.5843 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.5536 24.6464 2.4
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 22 -1 -3
-      vertex 43.8348 -1.12047 -3
-      vertex 43.8226 -1 -3
+      vertex 57.3913 24.5381 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.4778 24.5843 2.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 57.2975 24.5096 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.3913 24.5381 2.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 57.2 24.5 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.2975 24.5096 2.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 38.2 24.5 2.4
+      vertex 58.5 23.5 2.4
+      vertex 57.2 24.5 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 43.8348 -1.12047 -3
-      vertex 22 -1 -3
-      vertex 43.8875 -3 -3
+      vertex 37.7 29.5 2.4
+      vertex 28.5 26 2.4
+      vertex 37.7 25 2.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.4904 25.9025 2.4
+      vertex 37.7 25 2.4
+      vertex 28.5 26 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 3 -3 -3
-      vertex 22 -1 -3
-      vertex 3 -3.67394e-16 -3
+      vertex 37.7 25 2.4
+      vertex 28.4904 25.9025 2.4
+      vertex 37.7096 24.9025 2.4
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 28.4619 25.8087 2.4
+      vertex 37.7096 24.9025 2.4
+      vertex 28.4904 25.9025 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 22 -1 -3
-      vertex 3 -3 -3
-      vertex 43.8875 -3 -3
+      vertex 37.7096 24.9025 2.4
+      vertex 28.4619 25.8087 2.4
+      vertex 37.7381 24.8087 2.4
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal -0 0 1
     outer loop
-      vertex 58 3 -4.5
-      vertex 55 3 -2.7
-      vertex 58 3 -2.7
+      vertex 28.4157 25.7222 2.4
+      vertex 37.7381 24.8087 2.4
+      vertex 28.4619 25.8087 2.4
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 58 3 -4.5
-      vertex 55 3 -4.5
+      vertex 37.7381 24.8087 2.4
+      vertex 28.4157 25.7222 2.4
+      vertex 37.7843 24.7222 2.4
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal -0 0 1
     outer loop
-      vertex 45 3 -4.5
-      vertex 25 3 -2.7
-      vertex 45 3 -2.7
+      vertex 28.3536 25.6464 2.4
+      vertex 37.7843 24.7222 2.4
+      vertex 28.4157 25.7222 2.4
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 0 1
     outer loop
-      vertex 25 3 -2.7
-      vertex 45 3 -4.5
-      vertex 22 3 -3
+      vertex 37.7843 24.7222 2.4
+      vertex 28.3536 25.6464 2.4
+      vertex 37.8464 24.6464 2.4
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal -0 0 1
     outer loop
-      vertex 0 3 -4.5
-      vertex 22 3 -3
-      vertex 45 3 -4.5
+      vertex 28.2778 25.5843 2.4
+      vertex 37.8464 24.6464 2.4
+      vertex 28.3536 25.6464 2.4
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 0 1
     outer loop
-      vertex 22 3 -3
-      vertex 0 3 -4.5
-      vertex 0 3 -3
+      vertex 26 23.5 2.4
+      vertex 37.8464 24.6464 2.4
+      vertex 28.2778 25.5843 2.4
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0 0 1
     outer loop
-      vertex 25 3 -2.7
-      vertex 22 3 -3.67394e-16
-      vertex 25 3 -3.67394e-16
+      vertex 37.8464 24.6464 2.4
+      vertex 26 23.5 2.4
+      vertex 37.9222 24.5843 2.4
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 0 1
     outer loop
-      vertex 22 3 -3.67394e-16
-      vertex 25 3 -2.7
-      vertex 22 3 -3
+      vertex 37.9222 24.5843 2.4
+      vertex 26 23.5 2.4
+      vertex 38.0087 24.5381 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26 23.5 2.4
+      vertex 28.2778 25.5843 2.4
+      vertex 28.1913 25.5381 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26 23.5 2.4
+      vertex 28.1913 25.5381 2.4
+      vertex 28.0975 25.5096 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26 23.5 2.4
+      vertex 28.0975 25.5096 2.4
+      vertex 28 25.5 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.0087 24.5381 2.4
+      vertex 26 23.5 2.4
+      vertex 38.1025 24.5096 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26 23.5 2.4
+      vertex 28 25.5 2.4
+      vertex 26 25.5 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.2 24.5 2.4
+      vertex 26 23.5 2.4
+      vertex 58.5 23.5 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 38.1025 24.5096 2.4
+      vertex 26 23.5 2.4
+      vertex 38.2 24.5 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 26 25.5 2.4
+      vertex 25.9025 25.5096 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26 25.5 2.4
+      vertex 25.5 24 2.4
+      vertex 26 23.5 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 25.9025 25.5096 2.4
+      vertex 25.8087 25.5381 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 26 23.5 2.4
+      vertex 25.5 24 2.4
+      vertex 25.9025 23.5096 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 25.8087 25.5381 2.4
+      vertex 25.7222 25.5843 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9025 23.5096 2.4
+      vertex 25.5 24 2.4
+      vertex 25.8087 23.5381 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 25.7222 25.5843 2.4
+      vertex 25.6464 25.6464 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8087 23.5381 2.4
+      vertex 25.5 24 2.4
+      vertex 25.7222 23.5843 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 25.6464 25.6464 2.4
+      vertex 25.5843 25.7222 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7222 23.5843 2.4
+      vertex 25.5 24 2.4
+      vertex 25.6464 23.6464 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 25.5843 25.7222 2.4
+      vertex 25.5381 25.8087 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.6464 23.6464 2.4
+      vertex 25.5 24 2.4
+      vertex 25.5843 23.7222 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 25.5381 25.8087 2.4
+      vertex 25.5096 25.9025 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5843 23.7222 2.4
+      vertex 25.5 24 2.4
+      vertex 25.5381 23.8087 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 24 2.4
+      vertex 25.5096 25.9025 2.4
+      vertex 25.5 26 2.4
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5381 23.8087 2.4
+      vertex 25.5 24 2.4
+      vertex 25.5096 23.9025 2.4
+    endloop
+  endfacet
+  facet normal 0.881919 -0.4714 0
+    outer loop
+      vertex 63.9944 24.8333 4.5
+      vertex 64.2716 25.3519 3.3
+      vertex 64.2716 25.3519 4.5
+    endloop
+  endfacet
+  facet normal 0.881919 -0.4714 0
+    outer loop
+      vertex 64.2716 25.3519 3.3
+      vertex 63.9944 24.8333 4.5
+      vertex 63.9944 24.8333 3.3
+    endloop
+  endfacet
+  facet normal -0.0979877 0.995188 0
+    outer loop
+      vertex 26 29.5 2
+      vertex 25.9025 29.4904 4.5
+      vertex 26 29.5 4.5
+    endloop
+  endfacet
+  facet normal -0.0979877 0.995188 0
+    outer loop
+      vertex 25.9025 29.4904 4.5
+      vertex 26 29.5 2
+      vertex 25.9025 29.4904 2
+    endloop
+  endfacet
+  facet normal -0.471117 -0.882071 0
+    outer loop
+      vertex 25.7222 25.5843 2.4
+      vertex 25.8087 25.5381 4.5
+      vertex 25.7222 25.5843 4.5
+    endloop
+  endfacet
+  facet normal -0.471117 -0.882071 -0
+    outer loop
+      vertex 25.8087 25.5381 4.5
+      vertex 25.7222 25.5843 2.4
+      vertex 25.8087 25.5381 2.4
+    endloop
+  endfacet
+  facet normal 0.633738 0.773548 -0
+    outer loop
+      vertex 28.3536 29.3536 2.4
+      vertex 28.2778 29.4157 4.5
+      vertex 28.3536 29.3536 4.5
+    endloop
+  endfacet
+  facet normal 0.633738 0.773548 0
+    outer loop
+      vertex 28.2778 29.4157 4.5
+      vertex 28.3536 29.3536 2.4
+      vertex 28.2778 29.4157 2.4
+    endloop
+  endfacet
+  facet normal 0.471117 0.882071 -0
+    outer loop
+      vertex 28.2778 29.4157 2.4
+      vertex 28.1913 29.4619 4.5
+      vertex 28.2778 29.4157 4.5
+    endloop
+  endfacet
+  facet normal 0.471117 0.882071 0
+    outer loop
+      vertex 28.1913 29.4619 4.5
+      vertex 28.2778 29.4157 2.4
+      vertex 28.1913 29.4619 2.4
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 3 -3 -4.5
-      vertex 43.8875 -3 -3
-      vertex 3 -3 -3
+      vertex 26 25.5 2.4
+      vertex 28 25.5 4.5
+      vertex 26 25.5 4.5
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 43.8875 -3 -3
-      vertex 3 -3 -4.5
-      vertex 43.8875 -3 -4.5
+      vertex 28 25.5 4.5
+      vertex 26 25.5 2.4
+      vertex 28 25.5 2.4
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.633738 -0.773548 0
     outer loop
-      vertex 46.1304 -3 -4.5
-      vertex 55 -3 -3
-      vertex 46.1304 -3 -3
+      vertex 28.2778 25.5843 2.4
+      vertex 28.3536 25.6464 4.5
+      vertex 28.2778 25.5843 4.5
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0.633738 -0.773548 0
     outer loop
-      vertex 55 -3 -3
-      vertex 46.1304 -3 -4.5
-      vertex 55 -3 -4.5
+      vertex 28.3536 25.6464 4.5
+      vertex 28.2778 25.5843 2.4
+      vertex 28.3536 25.6464 2.4
     endloop
   endfacet
-  facet normal -1 0 0
+  facet normal 0.95681 -0.290715 0
     outer loop
-      vertex 22 -1 -3
-      vertex 22 3 -3.67394e-16
-      vertex 22 3 -3
+      vertex 28.4619 25.8087 4.5
+      vertex 28.4904 25.9025 2.4
+      vertex 28.4904 25.9025 4.5
     endloop
   endfacet
-  facet normal -1 -0 0
+  facet normal 0.95681 -0.290715 0
     outer loop
-      vertex 22 3 -3.67394e-16
-      vertex 22 -1 -3
-      vertex 22 -1 1.22465e-16
+      vertex 28.4904 25.9025 2.4
+      vertex 28.4619 25.8087 4.5
+      vertex 28.4619 25.8087 2.4
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal -0.995188 -0.0979877 0
     outer loop
-      vertex 25 -1 1.22465e-16
-      vertex 25 3 -2.7
-      vertex 25 3 -3.67394e-16
+      vertex 25.5096 25.9025 2.4
+      vertex 25.5 26 4.5
+      vertex 25.5 26 2.4
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal -0.995188 -0.0979877 0
     outer loop
-      vertex 25 3 -2.7
-      vertex 25 -1 1.22465e-16
-      vertex 25 -1 -2.7
+      vertex 25.5 26 4.5
+      vertex 25.5096 25.9025 2.4
+      vertex 25.5096 25.9025 4.5
     endloop
   endfacet
-  facet normal -0 1.22465e-16 1
+  facet normal 0.995188 -0.0979877 0
     outer loop
-      vertex 22 3 -3.67394e-16
-      vertex 25 -1 1.22465e-16
-      vertex 25 3 -3.67394e-16
+      vertex 28.4904 25.9025 4.5
+      vertex 28.5 26 2.4
+      vertex 28.5 26 4.5
     endloop
   endfacet
-  facet normal 0 1.22465e-16 1
+  facet normal 0.995188 -0.0979877 0
     outer loop
-      vertex 25 -1 1.22465e-16
-      vertex 22 3 -3.67394e-16
-      vertex 22 -1 1.22465e-16
+      vertex 28.5 26 2.4
+      vertex 28.4904 25.9025 4.5
+      vertex 28.4904 25.9025 2.4
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.773548 -0.633738 0
     outer loop
-      vertex 49.9942 -1 -3.1
-      vertex 52.3473 -1 -3
-      vertex 49.9942 -1 -3
+      vertex 25.6464 25.6464 2.4
+      vertex 25.5843 25.7222 4.5
+      vertex 25.5843 25.7222 2.4
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.773548 -0.633738 0
     outer loop
-      vertex 52.3473 -1 -3
-      vertex 49.9942 -1 -3.1
-      vertex 52.3473 -1 -3.1
+      vertex 25.5843 25.7222 4.5
+      vertex 25.6464 25.6464 2.4
+      vertex 25.6464 25.6464 4.5
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.290715 -0.95681 0
     outer loop
-      vertex 43.8226 -1 -3.1
-      vertex 46.1952 -1 -3
-      vertex 43.8226 -1 -3
+      vertex 28.0975 25.5096 2.4
+      vertex 28.1913 25.5381 4.5
+      vertex 28.0975 25.5096 4.5
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0.290715 -0.95681 0
     outer loop
-      vertex 46.1952 -1 -3
-      vertex 43.8226 -1 -3.1
-      vertex 46.1952 -1 -3.1
+      vertex 28.1913 25.5381 4.5
+      vertex 28.0975 25.5096 2.4
+      vertex 28.1913 25.5381 2.4
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.773548 0.633738 0
     outer loop
-      vertex 22 -1 1.22465e-16
-      vertex 25 -1 -2.7
-      vertex 25 -1 1.22465e-16
+      vertex 28.4157 29.2778 4.5
+      vertex 28.3536 29.3536 2.4
+      vertex 28.3536 29.3536 4.5
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.773548 0.633738 0
     outer loop
-      vertex 22 -1 -3
-      vertex 25 -1 -2.7
-      vertex 22 -1 1.22465e-16
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 43.8226 -1 -3
-      vertex 25 -1 -2.7
-      vertex 22 -1 -3
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 25 -1 -2.7
-      vertex 43.8226 -1 -3
-      vertex 55 -1 -2.7
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 46.1952 -1 -3
-      vertex 55 -1 -2.7
-      vertex 43.8226 -1 -3
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 49.9942 -1 -3
-      vertex 55 -1 -2.7
-      vertex 46.1952 -1 -3
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 52.3473 -1 -3
-      vertex 55 -1 -2.7
-      vertex 49.9942 -1 -3
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 55 -1 -2.7
-      vertex 52.3473 -1 -3
-      vertex 55 -1 -3
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 45 3.29555 -4.5
-      vertex 45 3 -4.5
-      vertex 45 3.29555 -3.1
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 45 5.68227 -3.1
-      vertex 45 6 -4.5
-      vertex 45 5.68227 -4.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 45 6 -4.5
-      vertex 45 5.68227 -3.1
-      vertex 45 6 -2.7
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 45 3 -2.7
-      vertex 45 5.68227 -3.1
-      vertex 45 3.29555 -3.1
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 45 5.68227 -3.1
-      vertex 45 3 -2.7
-      vertex 45 6 -2.7
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 45 3 -2.7
-      vertex 45 3.29555 -3.1
-      vertex 45 3 -4.5
+      vertex 28.3536 29.3536 2.4
+      vertex 28.4157 29.2778 4.5
+      vertex 28.4157 29.2778 2.4
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 55 3 -2.7
-      vertex 55 6 -4.5
-      vertex 55 6 -2.7
+      vertex 28.5 26 4.5
+      vertex 28.5 29 2.4
+      vertex 28.5 29 4.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 55 6 -4.5
-      vertex 55 3 -2.7
-      vertex 55 3 -4.5
+      vertex 28.5 29 2.4
+      vertex 28.5 26 4.5
+      vertex 28.5 26 2.4
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.773548 -0.633738 0
     outer loop
-      vertex 55 6 -4.5
-      vertex 45 6 -2.7
-      vertex 55 6 -2.7
+      vertex 28.3536 25.6464 4.5
+      vertex 28.4157 25.7222 2.4
+      vertex 28.4157 25.7222 4.5
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.773548 -0.633738 0
     outer loop
-      vertex 45 6 -2.7
-      vertex 55 6 -4.5
-      vertex 45 6 -4.5
+      vertex 28.4157 25.7222 2.4
+      vertex 28.3536 25.6464 4.5
+      vertex 28.3536 25.6464 2.4
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal 0.882071 -0.471117 0
     outer loop
-      vertex 58 -20.0164 2.45131e-15
-      vertex 58 -20 -2
-      vertex 58 -20 2.44929e-15
+      vertex 28.4157 25.7222 4.5
+      vertex 28.4619 25.8087 2.4
+      vertex 28.4619 25.8087 4.5
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal 0.882071 -0.471117 0
     outer loop
-      vertex 58 -20 -2
-      vertex 58 -20.0164 2.45131e-15
-      vertex 58 -20.0164 -2
+      vertex 28.4619 25.8087 2.4
+      vertex 28.4157 25.7222 4.5
+      vertex 28.4157 25.7222 2.4
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal -0.95681 -0.290715 0
     outer loop
-      vertex 58 -26 3.18408e-15
-      vertex 58 -25.9836 -4.5
-      vertex 58 -25.9836 3.18207e-15
+      vertex 25.5381 25.8087 2.4
+      vertex 25.5096 25.9025 4.5
+      vertex 25.5096 25.9025 2.4
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal -0.95681 -0.290715 0
     outer loop
-      vertex 58 -25.9836 -4.5
-      vertex 58 -26 3.18408e-15
-      vertex 58 -26 -4.5
+      vertex 25.5096 25.9025 4.5
+      vertex 25.5381 25.8087 2.4
+      vertex 25.5381 25.8087 4.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.882071 -0.471117 0
     outer loop
-      vertex 23.6081 -24.0671 -2.5
-      vertex 25 -26 -2.5
-      vertex 23.6081 -21.9429 -2.5
+      vertex 25.5843 25.7222 2.4
+      vertex 25.5381 25.8087 4.5
+      vertex 25.5381 25.8087 2.4
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -26 -2.5
-      vertex 23.6081 -24.0671 -2.5
-      vertex 23.63 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.5435 -22.1417 -2.5
-      vertex 23.6081 -24.0671 -2.5
-      vertex 23.6081 -21.9429 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.5435 -22.1417 -2.5
-      vertex 23.5435 -23.8683 -2.5
-      vertex 23.6081 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.439 -22.3228 -2.5
-      vertex 23.5435 -23.8683 -2.5
-      vertex 23.5435 -22.1417 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.439 -22.3228 -2.5
-      vertex 23.439 -23.6872 -2.5
-      vertex 23.5435 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.2991 -22.4781 -2.5
-      vertex 23.439 -23.6872 -2.5
-      vertex 23.439 -22.3228 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.2991 -22.4781 -2.5
-      vertex 23.2991 -23.5319 -2.5
-      vertex 23.439 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.13 -22.601 -2.5
-      vertex 23.2991 -23.5319 -2.5
-      vertex 23.2991 -22.4781 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.13 -22.601 -2.5
-      vertex 23.13 -23.409 -2.5
-      vertex 23.2991 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.939 -22.6861 -2.5
-      vertex 23.13 -23.409 -2.5
-      vertex 23.13 -22.601 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.939 -22.6861 -2.5
-      vertex 22.939 -23.3239 -2.5
-      vertex 23.13 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.7345 -22.7295 -2.5
-      vertex 22.939 -23.3239 -2.5
-      vertex 22.939 -22.6861 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.7345 -22.7295 -2.5
-      vertex 22.7345 -23.2805 -2.5
-      vertex 22.939 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 22.5255 -22.7295 -2.5
-      vertex 22.7345 -23.2805 -2.5
-      vertex 22.7345 -22.7295 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.5255 -22.7295 -2.5
-      vertex 22.5255 -23.2805 -2.5
-      vertex 22.7345 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.321 -22.6861 -2.5
-      vertex 22.5255 -23.2805 -2.5
-      vertex 22.5255 -22.7295 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.321 -22.6861 -2.5
-      vertex 22.321 -23.3239 -2.5
-      vertex 22.5255 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.13 -22.601 -2.5
-      vertex 22.321 -23.3239 -2.5
-      vertex 22.321 -22.6861 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.13 -22.601 -2.5
-      vertex 22.13 -23.409 -2.5
-      vertex 22.321 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.9609 -22.4781 -2.5
-      vertex 22.13 -23.409 -2.5
-      vertex 22.13 -22.601 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.9609 -22.4781 -2.5
-      vertex 21.9609 -23.5319 -2.5
-      vertex 22.13 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.821 -22.3228 -2.5
-      vertex 21.9609 -23.5319 -2.5
-      vertex 21.9609 -22.4781 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.821 -22.3228 -2.5
-      vertex 21.821 -23.6872 -2.5
-      vertex 21.9609 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.7165 -22.1417 -2.5
-      vertex 21.821 -23.6872 -2.5
-      vertex 21.821 -22.3228 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.7165 -22.1417 -2.5
-      vertex 21.7165 -23.8683 -2.5
-      vertex 21.821 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.9235 -23.8683 -2.5
-      vertex 21.7165 -22.1417 -2.5
-      vertex 21.6519 -21.9429 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.7165 -22.1417 -2.5
-      vertex 15.9235 -23.8683 -2.5
-      vertex 21.7165 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.819 -23.6872 -2.5
-      vertex 21.6519 -21.9429 -2.5
-      vertex 21.63 -21.735 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.7165 -23.8683 -2.5
-      vertex 15.9235 -23.8683 -2.5
-      vertex 21.6519 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.6081 -21.9429 -2.5
-      vertex 25 -20 -2.5
-      vertex 23.63 -21.735 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 23.6081 -21.5271 -2.5
-      vertex 23.63 -21.735 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 23.5435 -21.3283 -2.5
-      vertex 23.6081 -21.5271 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 23.439 -21.1472 -2.5
-      vertex 23.5435 -21.3283 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 23.2991 -20.9919 -2.5
-      vertex 23.439 -21.1472 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
+  facet normal -0.882071 -0.471117 0
     outer loop
-      vertex 25 -20 -2.5
-      vertex 23.13 -20.869 -2.5
-      vertex 23.2991 -20.9919 -2.5
+      vertex 25.5381 25.8087 4.5
+      vertex 25.5843 25.7222 2.4
+      vertex 25.5843 25.7222 4.5
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 22.939 -20.7839 -2.5
-      vertex 23.13 -20.869 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 22.7345 -20.7405 -2.5
-      vertex 22.939 -20.7839 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 22.5255 -20.7405 -2.5
-      vertex 22.7345 -20.7405 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 22.321 -20.7839 -2.5
-      vertex 22.5255 -20.7405 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.6519 -24.0671 -2.5
-      vertex 15.9881 -24.0671 -2.5
-      vertex 21.63 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.6791 -23.5319 -2.5
-      vertex 21.63 -21.735 -2.5
-      vertex 21.6519 -21.5271 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.51 -23.409 -2.5
-      vertex 21.6519 -21.5271 -2.5
-      vertex 21.7165 -21.3283 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.319 -23.3239 -2.5
-      vertex 21.7165 -21.3283 -2.5
-      vertex 21.821 -21.1472 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.1145 -23.2805 -2.5
-      vertex 21.821 -21.1472 -2.5
-      vertex 21.9609 -20.9919 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.9055 -23.2805 -2.5
-      vertex 21.9609 -20.9919 -2.5
-      vertex 22.13 -20.869 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.63 -24.275 -2.5
-      vertex 15.9881 -24.0671 -2.5
-      vertex 16.01 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.6519 -24.0671 -2.5
-      vertex 15.9235 -23.8683 -2.5
-      vertex 15.9881 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.6519 -21.9429 -2.5
-      vertex 15.819 -23.6872 -2.5
-      vertex 15.9235 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.63 -21.735 -2.5
-      vertex 15.6791 -23.5319 -2.5
-      vertex 15.819 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3 -20 -2.5
-      vertex 22.13 -20.869 -2.5
-      vertex 22.321 -20.7839 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.6519 -21.5271 -2.5
-      vertex 15.51 -23.409 -2.5
-      vertex 15.6791 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
+  facet normal -0.0979877 -0.995188 0
     outer loop
-      vertex 21.7165 -21.3283 -2.5
-      vertex 15.319 -23.3239 -2.5
-      vertex 15.51 -23.409 -2.5
+      vertex 25.9025 25.5096 2.4
+      vertex 26 25.5 4.5
+      vertex 25.9025 25.5096 4.5
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.821 -21.1472 -2.5
-      vertex 15.1145 -23.2805 -2.5
-      vertex 15.319 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.9609 -20.9919 -2.5
-      vertex 14.9055 -23.2805 -2.5
-      vertex 15.1145 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.13 -20.869 -2.5
-      vertex 12.5745 -23.2805 -2.5
-      vertex 14.9055 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0319 -24.0671 -2.5
-      vertex 13.47 -24.275 -2.5
-      vertex 14.01 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.4481 -24.0671 -2.5
-      vertex 14.0319 -24.0671 -2.5
-      vertex 14.0965 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.3835 -23.8683 -2.5
-      vertex 14.0965 -23.8683 -2.5
-      vertex 14.201 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.279 -23.6872 -2.5
-      vertex 14.201 -23.6872 -2.5
-      vertex 14.3409 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0319 -24.0671 -2.5
-      vertex 13.4481 -24.0671 -2.5
-      vertex 13.47 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
+  facet normal -0.0979877 -0.995188 -0
     outer loop
-      vertex 13.1391 -23.5319 -2.5
-      vertex 14.3409 -23.5319 -2.5
-      vertex 14.51 -23.409 -2.5
+      vertex 26 25.5 4.5
+      vertex 25.9025 25.5096 2.4
+      vertex 26 25.5 2.4
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.0965 -23.8683 -2.5
-      vertex 13.3835 -23.8683 -2.5
-      vertex 13.4481 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.97 -23.409 -2.5
-      vertex 14.51 -23.409 -2.5
-      vertex 14.701 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.201 -23.6872 -2.5
-      vertex 13.279 -23.6872 -2.5
-      vertex 13.3835 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.9055 -23.2805 -2.5
-      vertex 12.5745 -23.2805 -2.5
-      vertex 14.701 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.3409 -23.5319 -2.5
-      vertex 13.1391 -23.5319 -2.5
-      vertex 13.279 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.51 -23.409 -2.5
-      vertex 12.97 -23.409 -2.5
-      vertex 13.1391 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
+  facet normal 0.0979877 -0.995188 0
     outer loop
-      vertex 3 -20 -2.5
-      vertex 22.321 -20.7839 -2.5
-      vertex 25 -20 -2.5
+      vertex 28 25.5 2.4
+      vertex 28.0975 25.5096 4.5
+      vertex 28 25.5 4.5
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.701 -23.3239 -2.5
-      vertex 12.779 -23.3239 -2.5
-      vertex 12.97 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
+  facet normal 0.0979877 -0.995188 0
     outer loop
-      vertex 14.701 -23.3239 -2.5
-      vertex 12.5745 -23.2805 -2.5
-      vertex 12.779 -23.3239 -2.5
+      vertex 28.0975 25.5096 4.5
+      vertex 28 25.5 2.4
+      vertex 28.0975 25.5096 2.4
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.633738 -0.773548 0
     outer loop
-      vertex 22.13 -20.869 -2.5
-      vertex 3 -20 -2.5
-      vertex 12.5745 -23.2805 -2.5
+      vertex 25.6464 25.6464 2.4
+      vertex 25.7222 25.5843 4.5
+      vertex 25.6464 25.6464 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.633738 -0.773548 -0
     outer loop
-      vertex 12.5745 -23.2805 -2.5
-      vertex 3 -20 -2.5
-      vertex 12.3655 -23.2805 -2.5
+      vertex 25.7222 25.5843 4.5
+      vertex 25.6464 25.6464 2.4
+      vertex 25.7222 25.5843 2.4
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290715 0.95681 -0
     outer loop
-      vertex 11.4919 -24.0671 -2.5
-      vertex 10.93 -24.275 -2.5
-      vertex 11.47 -24.275 -2.5
+      vertex 28.1913 29.4619 2.4
+      vertex 28.0975 29.4904 4.5
+      vertex 28.1913 29.4619 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290715 0.95681 0
     outer loop
-      vertex 10.9081 -24.0671 -2.5
-      vertex 11.4919 -24.0671 -2.5
-      vertex 11.5565 -23.8683 -2.5
+      vertex 28.0975 29.4904 4.5
+      vertex 28.1913 29.4619 2.4
+      vertex 28.0975 29.4904 2.4
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.8435 -23.8683 -2.5
-      vertex 11.5565 -23.8683 -2.5
-      vertex 11.661 -23.6872 -2.5
+      vertex 28 29.5 4.5
+      vertex 28.5 29 4.5
+      vertex 28.4904 29.0975 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.739 -23.6872 -2.5
-      vertex 11.661 -23.6872 -2.5
-      vertex 11.8009 -23.5319 -2.5
+      vertex 28.5 29 4.5
+      vertex 25.5 29 4.5
+      vertex 28.5 26 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 11.4919 -24.0671 -2.5
-      vertex 10.9081 -24.0671 -2.5
-      vertex 10.93 -24.275 -2.5
+      vertex 28 29.5 4.5
+      vertex 28.4904 29.0975 4.5
+      vertex 28.4619 29.1913 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.5991 -23.5319 -2.5
-      vertex 11.8009 -23.5319 -2.5
-      vertex 11.97 -23.409 -2.5
+      vertex 25.5 26 4.5
+      vertex 28.5 26 4.5
+      vertex 25.5 29 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 11.5565 -23.8683 -2.5
-      vertex 10.8435 -23.8683 -2.5
-      vertex 10.9081 -24.0671 -2.5
+      vertex 28 29.5 4.5
+      vertex 28.4619 29.1913 4.5
+      vertex 28.4157 29.2778 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.43 -23.409 -2.5
-      vertex 11.97 -23.409 -2.5
-      vertex 12.161 -23.3239 -2.5
+      vertex 28.5 29 4.5
+      vertex 28 29.5 4.5
+      vertex 25.5 29 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 11.661 -23.6872 -2.5
-      vertex 10.739 -23.6872 -2.5
-      vertex 10.8435 -23.8683 -2.5
+      vertex 28 29.5 4.5
+      vertex 28.4157 29.2778 4.5
+      vertex 28.3536 29.3536 4.5
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex 10.0345 -23.2805 -2.5
-      vertex 12.3655 -23.2805 -2.5
-      vertex 3 -20 -2.5
+      vertex 28 25.5 4.5
+      vertex 28.5 26 4.5
+      vertex 25.5 26 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 11.8009 -23.5319 -2.5
-      vertex 10.5991 -23.5319 -2.5
-      vertex 10.739 -23.6872 -2.5
+      vertex 28 29.5 4.5
+      vertex 28.3536 29.3536 4.5
+      vertex 28.2778 29.4157 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 11.97 -23.409 -2.5
-      vertex 10.43 -23.409 -2.5
-      vertex 10.5991 -23.5319 -2.5
+      vertex 28.4619 25.8087 4.5
+      vertex 28 25.5 4.5
+      vertex 28.4157 25.7222 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 12.161 -23.3239 -2.5
-      vertex 10.239 -23.3239 -2.5
-      vertex 10.43 -23.409 -2.5
+      vertex 28 29.5 4.5
+      vertex 28.2778 29.4157 4.5
+      vertex 28.1913 29.4619 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 12.161 -23.3239 -2.5
-      vertex 10.0345 -23.2805 -2.5
-      vertex 10.239 -23.3239 -2.5
+      vertex 28.4157 25.7222 4.5
+      vertex 28 25.5 4.5
+      vertex 28.3536 25.6464 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 12.3655 -23.2805 -2.5
-      vertex 10.0345 -23.2805 -2.5
-      vertex 12.161 -23.3239 -2.5
+      vertex 28 29.5 4.5
+      vertex 28.1913 29.4619 4.5
+      vertex 28.0975 29.4904 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 10.0345 -23.2805 -2.5
-      vertex 3 -20 -2.5
-      vertex 9.82547 -23.2805 -2.5
+      vertex 28.3536 25.6464 4.5
+      vertex 28 25.5 4.5
+      vertex 28.2778 25.5843 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 8.95185 -24.0671 -2.5
-      vertex 8.39 -24.275 -2.5
-      vertex 8.93 -24.275 -2.5
+      vertex 28.2778 25.5843 4.5
+      vertex 28 25.5 4.5
+      vertex 28.1913 25.5381 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 8.36815 -24.0671 -2.5
-      vertex 8.95185 -24.0671 -2.5
-      vertex 9.01645 -23.8683 -2.5
+      vertex 28.1913 25.5381 4.5
+      vertex 28 25.5 4.5
+      vertex 28.0975 25.5096 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 8.30354 -23.8683 -2.5
-      vertex 9.01645 -23.8683 -2.5
-      vertex 9.12098 -23.6872 -2.5
+      vertex 25.5 29 4.5
+      vertex 28 29.5 4.5
+      vertex 26 29.5 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 8.19902 -23.6872 -2.5
-      vertex 9.12098 -23.6872 -2.5
-      vertex 9.26087 -23.5319 -2.5
+      vertex 28.5 26 4.5
+      vertex 28 25.5 4.5
+      vertex 28.4904 25.9025 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 8.95185 -24.0671 -2.5
-      vertex 8.36815 -24.0671 -2.5
-      vertex 8.39 -24.275 -2.5
+      vertex 25.5 29 4.5
+      vertex 26 29.5 4.5
+      vertex 25.9025 29.4904 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 8.05913 -23.5319 -2.5
-      vertex 9.26087 -23.5319 -2.5
-      vertex 9.43 -23.409 -2.5
+      vertex 28.4904 25.9025 4.5
+      vertex 28 25.5 4.5
+      vertex 28.4619 25.8087 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.01645 -23.8683 -2.5
-      vertex 8.30354 -23.8683 -2.5
-      vertex 8.36815 -24.0671 -2.5
+      vertex 25.5 29 4.5
+      vertex 25.9025 29.4904 4.5
+      vertex 25.8087 29.4619 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 7.89 -23.409 -2.5
-      vertex 9.43 -23.409 -2.5
-      vertex 9.62098 -23.3239 -2.5
+      vertex 28 25.5 4.5
+      vertex 25.5 26 4.5
+      vertex 26 25.5 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.12098 -23.6872 -2.5
-      vertex 8.19902 -23.6872 -2.5
-      vertex 8.30354 -23.8683 -2.5
+      vertex 25.5 29 4.5
+      vertex 25.8087 29.4619 4.5
+      vertex 25.7222 29.4157 4.5
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.26087 -23.5319 -2.5
-      vertex 8.05913 -23.5319 -2.5
-      vertex 8.19902 -23.6872 -2.5
+      vertex 26 25.5 4.5
+      vertex 25.5 26 4.5
+      vertex 25.9025 25.5096 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 29 4.5
+      vertex 25.7222 29.4157 4.5
+      vertex 25.6464 29.3536 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.9025 25.5096 4.5
+      vertex 25.5 26 4.5
+      vertex 25.8087 25.5381 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 29 4.5
+      vertex 25.6464 29.3536 4.5
+      vertex 25.5843 29.2778 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.8087 25.5381 4.5
+      vertex 25.5 26 4.5
+      vertex 25.7222 25.5843 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 29 4.5
+      vertex 25.5843 29.2778 4.5
+      vertex 25.5381 29.1913 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.7222 25.5843 4.5
+      vertex 25.5 26 4.5
+      vertex 25.6464 25.6464 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5 29 4.5
+      vertex 25.5381 29.1913 4.5
+      vertex 25.5096 29.0975 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.6464 25.6464 4.5
+      vertex 25.5 26 4.5
+      vertex 25.5843 25.7222 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5843 25.7222 4.5
+      vertex 25.5 26 4.5
+      vertex 25.5381 25.8087 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 25.5381 25.8087 4.5
+      vertex 25.5 26 4.5
+      vertex 25.5096 25.9025 4.5
+    endloop
+  endfacet
+  facet normal 0.995188 0.0979877 0
+    outer loop
+      vertex 28.5 29 4.5
+      vertex 28.4904 29.0975 2.4
+      vertex 28.4904 29.0975 4.5
+    endloop
+  endfacet
+  facet normal 0.995188 0.0979877 0
+    outer loop
+      vertex 28.4904 29.0975 2.4
+      vertex 28.5 29 4.5
+      vertex 28.5 29 2.4
+    endloop
+  endfacet
+  facet normal 0.471117 -0.882071 0
+    outer loop
+      vertex 28.1913 25.5381 2.4
+      vertex 28.2778 25.5843 4.5
+      vertex 28.1913 25.5381 4.5
+    endloop
+  endfacet
+  facet normal 0.471117 -0.882071 0
+    outer loop
+      vertex 28.2778 25.5843 4.5
+      vertex 28.1913 25.5381 2.4
+      vertex 28.2778 25.5843 2.4
+    endloop
+  endfacet
+  facet normal 0.95681 0.290715 0
+    outer loop
+      vertex 28.4904 29.0975 4.5
+      vertex 28.4619 29.1913 2.4
+      vertex 28.4619 29.1913 4.5
+    endloop
+  endfacet
+  facet normal 0.95681 0.290715 0
+    outer loop
+      vertex 28.4619 29.1913 2.4
+      vertex 28.4904 29.0975 4.5
+      vertex 28.4904 29.0975 2.4
+    endloop
+  endfacet
+  facet normal 0.882071 0.471117 0
+    outer loop
+      vertex 28.4619 29.1913 4.5
+      vertex 28.4157 29.2778 2.4
+      vertex 28.4157 29.2778 4.5
+    endloop
+  endfacet
+  facet normal 0.882071 0.471117 0
+    outer loop
+      vertex 28.4157 29.2778 2.4
+      vertex 28.4619 29.1913 4.5
+      vertex 28.4619 29.1913 2.4
+    endloop
+  endfacet
+  facet normal 0.0979877 0.995188 -0
+    outer loop
+      vertex 28.0975 29.4904 2.4
+      vertex 28 29.5 4.5
+      vertex 28.0975 29.4904 4.5
+    endloop
+  endfacet
+  facet normal 0.0979877 0.995188 0
+    outer loop
+      vertex 28 29.5 4.5
+      vertex 28.0975 29.4904 2.4
+      vertex 28 29.5 2.4
+    endloop
+  endfacet
+  facet normal -0.290715 -0.95681 0
+    outer loop
+      vertex 25.8087 25.5381 2.4
+      vertex 25.9025 25.5096 4.5
+      vertex 25.8087 25.5381 4.5
+    endloop
+  endfacet
+  facet normal -0.290715 -0.95681 -0
+    outer loop
+      vertex 25.9025 25.5096 4.5
+      vertex 25.8087 25.5381 2.4
+      vertex 25.9025 25.5096 2.4
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6.5 26.5 3
+      vertex 6.5 23.5 1.1
+      vertex 6.5 26.5 1.1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6.5 12.79 0
+      vertex 6.5 23.5 1.1
+      vertex 6.5 12.79 1.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6.5 26.5 3
+      vertex 6.5 12.79 1.8
+      vertex 6.5 23.5 1.1
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 6.5 6.5 3
+      vertex 6.5 12.79 1.8
+      vertex 6.5 26.5 3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6.5 12.79 1.8
+      vertex 6.5 6.5 3
+      vertex 6.5 7.75 1.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6.5 6.5 0
+      vertex 6.5 7.75 1.8
+      vertex 6.5 6.5 3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6.5 7.75 1.8
+      vertex 6.5 6.5 0
+      vertex 6.5 7.75 0
+    endloop
+  endfacet
+  facet normal 0 0 0
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 6.5 26.5 1.1
+      vertex 6.5 23.5 1.1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 6.5 23.5 1.1
+      vertex 6.5 12.79 0
+      vertex 6.5 23.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 6.44236 27.0853 1.1
+      vertex 6.5 26.5 1.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 6.27164 27.648 1.1
+      vertex 6.44236 27.0853 1.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 5.99441 28.1667 1.1
+      vertex 6.27164 27.648 1.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 5.62132 28.6213 1.1
+      vertex 5.99441 28.1667 1.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 5.16671 28.9944 1.1
+      vertex 5.62132 28.6213 1.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 4.64805 29.2716 1.1
+      vertex 5.16671 28.9944 1.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 4.08527 29.4424 1.1
+      vertex 4.64805 29.2716 1.1
     endloop
   endfacet
   facet normal 0 -0 1
     outer loop
-      vertex 7.49453 -23.2805 -2.5
-      vertex 9.82547 -23.2805 -2.5
-      vertex 3 -20 -2.5
+      vertex 4.08527 29.4424 1.1
+      vertex 6.5 29.5 1.1
+      vertex 3.5 29.5 1.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 9.43 -23.409 -2.5
-      vertex 7.89 -23.409 -2.5
-      vertex 8.05913 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.62098 -23.3239 -2.5
-      vertex 7.69902 -23.3239 -2.5
-      vertex 7.89 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.82547 -23.2805 -2.5
-      vertex 7.49453 -23.2805 -2.5
-      vertex 9.62098 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.62098 -23.3239 -2.5
-      vertex 7.49453 -23.2805 -2.5
-      vertex 7.69902 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.47645 -23.8683 -2.5
-      vertex 3 -23 -2.5
-      vertex 6.41185 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.58098 -23.6872 -2.5
-      vertex 3 -23 -2.5
-      vertex 6.47645 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.72087 -23.5319 -2.5
-      vertex 3 -23 -2.5
-      vertex 6.58098 -23.6872 -2.5
+      vertex 0.728361 27.648 1.1
+      vertex 0.728362 27.648 1.1
+      vertex 1.00559 28.1667 1.1
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 3 -23 -2.5
-      vertex 6.72087 -23.5319 -2.5
-      vertex 3 -20 -2.5
+      vertex 0.728361 27.648 1.1
+      vertex 0.557645 27.0853 1.1
+      vertex 0.728362 27.648 1.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 6.89 -23.409 -2.5
-      vertex 3 -20 -2.5
-      vertex 6.72087 -23.5319 -2.5
+      vertex 0.557644 27.0853 1.1
+      vertex 0.557645 27.0853 1.1
+      vertex 0.728361 27.648 1.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 7.08098 -23.3239 -2.5
-      vertex 3 -20 -2.5
-      vertex 6.89 -23.409 -2.5
+      vertex 0.557645 27.0853 1.1
+      vertex 0.557644 27.0853 1.1
+      vertex 0.5 26.5 1.1
     endloop
   endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 7.28547 -23.2805 -2.5
-      vertex 3 -20 -2.5
-      vertex 7.08098 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 7.49453 -23.2805 -2.5
-      vertex 3 -20 -2.5
-      vertex 7.28547 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 23.6081 -21.9429 -2.5
-      vertex 25 -26 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.6081 -24.4829 -2.5
-      vertex 25 -26 -2.5
-      vertex 23.63 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.5435 -24.6817 -2.5
-      vertex 25 -26 -2.5
-      vertex 23.6081 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 1
+  facet normal 0.471358 0.881942 -0
     outer loop
-      vertex 23.439 -24.8628 -2.5
-      vertex 25 -26 -2.5
-      vertex 23.5435 -24.6817 -2.5
+      vertex 5.16671 28.9944 1.1
+      vertex 4.64805 29.2716 4.5
+      vertex 5.16671 28.9944 4.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.471358 0.881942 0
     outer loop
-      vertex 23.2991 -25.0181 -2.5
-      vertex 25 -26 -2.5
-      vertex 23.439 -24.8628 -2.5
+      vertex 4.64805 29.2716 4.5
+      vertex 5.16671 28.9944 1.1
+      vertex 4.64805 29.2716 1.1
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.956928 0.290326 0
     outer loop
-      vertex 23.13 -25.141 -2.5
-      vertex 25 -26 -2.5
-      vertex 23.2991 -25.0181 -2.5
+      vertex 6.44236 27.0853 4.5
+      vertex 6.27164 27.648 1.1
+      vertex 6.27164 27.648 4.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.956928 0.290326 0
     outer loop
-      vertex 22.939 -25.2261 -2.5
-      vertex 25 -26 -2.5
-      vertex 23.13 -25.141 -2.5
+      vertex 6.27164 27.648 1.1
+      vertex 6.44236 27.0853 4.5
+      vertex 6.44236 27.0853 1.1
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.995186 0.0980053 -0
     outer loop
-      vertex 22.7345 -25.2695 -2.5
-      vertex 25 -26 -2.5
-      vertex 22.939 -25.2261 -2.5
+      vertex 6.5 26.5 3
+      vertex 6.44236 27.0853 4.5
+      vertex 6.5 26.5 4.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.995186 0.0980053 0
     outer loop
-      vertex 22.5255 -25.2695 -2.5
-      vertex 25 -26 -2.5
-      vertex 22.7345 -25.2695 -2.5
+      vertex 6.44236 27.0853 4.5
+      vertex 6.5 26.5 3
+      vertex 6.44236 27.0853 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.995186 0.0980053 0
     outer loop
-      vertex 22.321 -25.2261 -2.5
-      vertex 25 -26 -2.5
-      vertex 22.5255 -25.2695 -2.5
+      vertex 6.44236 27.0853 1.1
+      vertex 6.5 26.5 3
+      vertex 6.5 26.5 1.1
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.881936 0.471369 0
     outer loop
-      vertex 16.01 -24.275 -2.5
-      vertex 21.6519 -24.4829 -2.5
-      vertex 21.63 -24.275 -2.5
+      vertex 6.27164 27.648 4.5
+      vertex 5.99441 28.1667 1.1
+      vertex 5.99441 28.1667 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.881936 0.471369 0
     outer loop
-      vertex 15.9881 -24.4829 -2.5
-      vertex 21.6519 -24.4829 -2.5
-      vertex 16.01 -24.275 -2.5
+      vertex 5.99441 28.1667 1.1
+      vertex 6.27164 27.648 4.5
+      vertex 6.27164 27.648 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0979429 0.995192 -0
     outer loop
-      vertex 21.6519 -24.4829 -2.5
-      vertex 15.9881 -24.4829 -2.5
-      vertex 21.7165 -24.6817 -2.5
+      vertex 4.08527 29.4424 1.1
+      vertex 3.5 29.5 4.5
+      vertex 4.08527 29.4424 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0979429 0.995192 0
     outer loop
-      vertex 15.9235 -24.6817 -2.5
-      vertex 21.7165 -24.6817 -2.5
-      vertex 15.9881 -24.4829 -2.5
+      vertex 3.5 29.5 4.5
+      vertex 4.08527 29.4424 1.1
+      vertex 3.5 29.5 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290413 0.956901 -0
     outer loop
-      vertex 21.7165 -24.6817 -2.5
-      vertex 15.9235 -24.6817 -2.5
-      vertex 21.821 -24.8628 -2.5
+      vertex 4.64805 29.2716 1.1
+      vertex 4.08527 29.4424 4.5
+      vertex 4.64805 29.2716 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290413 0.956901 0
     outer loop
-      vertex 15.819 -24.8628 -2.5
-      vertex 21.821 -24.8628 -2.5
-      vertex 15.9235 -24.6817 -2.5
+      vertex 4.08527 29.4424 4.5
+      vertex 4.64805 29.2716 1.1
+      vertex 4.08527 29.4424 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.634405 0.773001 -0
     outer loop
-      vertex 21.821 -24.8628 -2.5
-      vertex 15.819 -24.8628 -2.5
-      vertex 21.9609 -25.0181 -2.5
+      vertex 5.62132 28.6213 1.1
+      vertex 5.16671 28.9944 4.5
+      vertex 5.62132 28.6213 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.634405 0.773001 0
     outer loop
-      vertex 15.6791 -25.0181 -2.5
-      vertex 21.9609 -25.0181 -2.5
-      vertex 15.819 -24.8628 -2.5
+      vertex 5.16671 28.9944 4.5
+      vertex 5.62132 28.6213 1.1
+      vertex 5.16671 28.9944 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.634405 0.773001 0
     outer loop
-      vertex 21.9609 -25.0181 -2.5
-      vertex 15.6791 -25.0181 -2.5
-      vertex 22.13 -25.141 -2.5
+      vertex 1.83329 28.9944 1.1
+      vertex 1.37868 28.6213 4.5
+      vertex 1.83329 28.9944 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.634405 0.773001 0
     outer loop
-      vertex 15.51 -25.141 -2.5
-      vertex 22.13 -25.141 -2.5
-      vertex 15.6791 -25.0181 -2.5
+      vertex 1.37868 28.6213 4.5
+      vertex 1.83329 28.9944 1.1
+      vertex 1.37868 28.6213 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.290413 0.956901 0
     outer loop
-      vertex 22.13 -25.141 -2.5
-      vertex 15.51 -25.141 -2.5
-      vertex 22.321 -25.2261 -2.5
+      vertex 2.91473 29.4424 1.1
+      vertex 2.35195 29.2716 4.5
+      vertex 2.91473 29.4424 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.290413 0.956901 0
     outer loop
-      vertex 15.319 -25.2261 -2.5
-      vertex 22.321 -25.2261 -2.5
-      vertex 15.51 -25.141 -2.5
+      vertex 2.35195 29.2716 4.5
+      vertex 2.91473 29.4424 1.1
+      vertex 2.35195 29.2716 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.881937 0.471366 0
     outer loop
-      vertex 22.321 -25.2261 -2.5
-      vertex 15.319 -25.2261 -2.5
-      vertex 25 -26 -2.5
+      vertex 0.728362 27.648 1.1
+      vertex 1.00559 28.1667 4.5
+      vertex 1.00559 28.1667 1.1
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.881937 0.471366 0
     outer loop
-      vertex 15.1145 -25.2695 -2.5
-      vertex 25 -26 -2.5
-      vertex 15.319 -25.2261 -2.5
+      vertex 1.00559 28.1667 4.5
+      vertex 0.728362 27.648 1.1
+      vertex 0.728362 27.648 4.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.773003 0.634403 0
     outer loop
-      vertex 14.9055 -25.2695 -2.5
-      vertex 25 -26 -2.5
-      vertex 15.1145 -25.2695 -2.5
+      vertex 5.99441 28.1667 4.5
+      vertex 5.62132 28.6213 1.1
+      vertex 5.62132 28.6213 4.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.773003 0.634403 0
     outer loop
-      vertex 13.47 -24.275 -2.5
-      vertex 14.0319 -24.4829 -2.5
-      vertex 14.01 -24.275 -2.5
+      vertex 5.62132 28.6213 1.1
+      vertex 5.99441 28.1667 4.5
+      vertex 5.99441 28.1667 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.471358 0.881942 0
     outer loop
-      vertex 13.4481 -24.4829 -2.5
-      vertex 14.0319 -24.4829 -2.5
-      vertex 13.47 -24.275 -2.5
+      vertex 2.35195 29.2716 1.1
+      vertex 1.83329 28.9944 4.5
+      vertex 2.35195 29.2716 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.471358 0.881942 0
     outer loop
-      vertex 14.0319 -24.4829 -2.5
-      vertex 13.4481 -24.4829 -2.5
-      vertex 14.0965 -24.6817 -2.5
+      vertex 1.83329 28.9944 4.5
+      vertex 2.35195 29.2716 1.1
+      vertex 1.83329 28.9944 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.0979429 0.995192 0
     outer loop
-      vertex 13.3835 -24.6817 -2.5
-      vertex 14.0965 -24.6817 -2.5
-      vertex 13.4481 -24.4829 -2.5
+      vertex 3.5 29.5 1.1
+      vertex 2.91473 29.4424 4.5
+      vertex 3.5 29.5 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.0979429 0.995192 0
     outer loop
-      vertex 14.0965 -24.6817 -2.5
-      vertex 13.3835 -24.6817 -2.5
-      vertex 14.201 -24.8628 -2.5
+      vertex 2.91473 29.4424 4.5
+      vertex 3.5 29.5 1.1
+      vertex 2.91473 29.4424 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.773003 0.634403 0
     outer loop
-      vertex 13.279 -24.8628 -2.5
-      vertex 14.201 -24.8628 -2.5
-      vertex 13.3835 -24.6817 -2.5
+      vertex 1.00559 28.1667 1.1
+      vertex 1.37868 28.6213 4.5
+      vertex 1.37868 28.6213 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.773003 0.634403 0
     outer loop
-      vertex 14.201 -24.8628 -2.5
-      vertex 13.279 -24.8628 -2.5
-      vertex 14.3409 -25.0181 -2.5
+      vertex 1.37868 28.6213 4.5
+      vertex 1.00559 28.1667 1.1
+      vertex 1.00559 28.1667 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.956929 0.290322 0
     outer loop
-      vertex 13.1391 -25.0181 -2.5
-      vertex 14.3409 -25.0181 -2.5
-      vertex 13.279 -24.8628 -2.5
+      vertex 0.557645 27.0853 1.1
+      vertex 0.728362 27.648 4.5
+      vertex 0.728362 27.648 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.956929 0.290322 0
     outer loop
-      vertex 14.3409 -25.0181 -2.5
-      vertex 13.1391 -25.0181 -2.5
-      vertex 14.51 -25.141 -2.5
+      vertex 0.728362 27.648 4.5
+      vertex 0.557645 27.0853 1.1
+      vertex 0.557645 27.0853 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995185 0.0980137 0
     outer loop
-      vertex 12.97 -25.141 -2.5
-      vertex 14.51 -25.141 -2.5
-      vertex 13.1391 -25.0181 -2.5
+      vertex 0.5 26.5 3
+      vertex 0.557645 27.0853 1.1
+      vertex 0.5 26.5 1.1
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995185 0.0980137 0
     outer loop
-      vertex 14.51 -25.141 -2.5
-      vertex 12.97 -25.141 -2.5
-      vertex 14.701 -25.2261 -2.5
+      vertex 0.557645 27.0853 1.1
+      vertex 0.5 26.5 3
+      vertex 0.557645 27.0853 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995185 0.0980137 0
     outer loop
-      vertex 12.779 -25.2261 -2.5
-      vertex 14.701 -25.2261 -2.5
-      vertex 12.97 -25.141 -2.5
+      vertex 0.557645 27.0853 4.5
+      vertex 0.5 26.5 3
+      vertex 0.5 26.5 4.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 14.701 -25.2261 -2.5
-      vertex 12.779 -25.2261 -2.5
-      vertex 14.9055 -25.2695 -2.5
+      vertex 10.3443 1.66431 2
+      vertex 10.2448 1.78554 0
+      vertex 10.2448 1.78554 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 12.5745 -25.2695 -2.5
-      vertex 14.9055 -25.2695 -2.5
-      vertex 12.779 -25.2261 -2.5
+      vertex 10.2448 1.78554 0
+      vertex 10.3443 1.66431 2
+      vertex 10.3443 1.66431 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 14.9055 -25.2695 -2.5
-      vertex 12.5745 -25.2695 -2.5
-      vertex 25 -26 -2.5
+      vertex 10.1709 2.53615 2
+      vertex 10.2448 2.67446 0
+      vertex 10.2448 2.67446 2
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 12.3655 -25.2695 -2.5
-      vertex 25 -26 -2.5
-      vertex 12.5745 -25.2695 -2.5
+      vertex 10.2448 2.67446 0
+      vertex 10.1709 2.53615 2
+      vertex 10.1709 2.53615 0
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 10.93 -24.275 -2.5
-      vertex 11.4919 -24.4829 -2.5
-      vertex 11.47 -24.275 -2.5
+      vertex 11.6946 2.07393 0
+      vertex 11.71 2.23 2
+      vertex 11.71 2.23 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 10.9081 -24.4829 -2.5
-      vertex 11.4919 -24.4829 -2.5
-      vertex 10.93 -24.275 -2.5
+      vertex 11.71 2.23 2
+      vertex 11.6946 2.07393 0
+      vertex 11.6946 2.07393 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 11.4919 -24.4829 -2.5
-      vertex 10.9081 -24.4829 -2.5
-      vertex 11.5565 -24.6817 -2.5
+      vertex 11.6491 2.53615 0
+      vertex 11.5752 2.67446 2
+      vertex 11.5752 2.67446 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 10.8435 -24.6817 -2.5
-      vertex 11.5565 -24.6817 -2.5
-      vertex 10.9081 -24.4829 -2.5
+      vertex 11.5752 2.67446 2
+      vertex 11.6491 2.53615 0
+      vertex 11.6491 2.53615 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290448 0.956891 -0
     outer loop
-      vertex 11.5565 -24.6817 -2.5
-      vertex 10.8435 -24.6817 -2.5
-      vertex 11.661 -24.8628 -2.5
+      vertex 10.7539 1.44537 0
+      vertex 10.6039 1.4909 2
+      vertex 10.7539 1.44537 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290448 0.956891 0
     outer loop
-      vertex 10.739 -24.8628 -2.5
-      vertex 11.661 -24.8628 -2.5
-      vertex 10.8435 -24.6817 -2.5
+      vertex 10.6039 1.4909 2
+      vertex 10.7539 1.44537 0
+      vertex 10.6039 1.4909 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex 11.661 -24.8628 -2.5
-      vertex 10.739 -24.8628 -2.5
-      vertex 11.8009 -25.0181 -2.5
+      vertex 11.5752 1.78554 0
+      vertex 11.6491 1.92385 2
+      vertex 11.6491 1.92385 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex 10.5991 -25.0181 -2.5
-      vertex 11.8009 -25.0181 -2.5
-      vertex 10.739 -24.8628 -2.5
+      vertex 11.6491 1.92385 2
+      vertex 11.5752 1.78554 0
+      vertex 11.5752 1.78554 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 11.8009 -25.0181 -2.5
-      vertex 10.5991 -25.0181 -2.5
-      vertex 11.97 -25.141 -2.5
+      vertex 11.71 2.23 0
+      vertex 11.6946 2.38607 2
+      vertex 11.6946 2.38607 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 10.43 -25.141 -2.5
-      vertex 11.97 -25.141 -2.5
-      vertex 10.5991 -25.0181 -2.5
+      vertex 11.6946 2.38607 2
+      vertex 11.71 2.23 0
+      vertex 11.71 2.23 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex 11.97 -25.141 -2.5
-      vertex 10.43 -25.141 -2.5
-      vertex 12.161 -25.2261 -2.5
+      vertex 10.1709 1.92385 2
+      vertex 10.1254 2.07393 0
+      vertex 10.1254 2.07393 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex 10.239 -25.2261 -2.5
-      vertex 12.161 -25.2261 -2.5
-      vertex 10.43 -25.141 -2.5
+      vertex 10.1254 2.07393 0
+      vertex 10.1709 1.92385 2
+      vertex 10.1709 1.92385 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex 12.161 -25.2261 -2.5
-      vertex 10.239 -25.2261 -2.5
-      vertex 12.3655 -25.2695 -2.5
+      vertex 10.11 2.23 2
+      vertex 10.1254 2.38607 0
+      vertex 10.1254 2.38607 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex 10.0345 -25.2695 -2.5
-      vertex 12.3655 -25.2695 -2.5
-      vertex 10.239 -25.2261 -2.5
+      vertex 10.1254 2.38607 0
+      vertex 10.11 2.23 2
+      vertex 10.11 2.23 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 1 -26 -2.5
-      vertex 12.3655 -25.2695 -2.5
-      vertex 10.0345 -25.2695 -2.5
+      vertex 11.6946 2.38607 0
+      vertex 11.6491 2.53615 2
+      vertex 11.6491 2.53615 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 1 -26 -2.5
-      vertex 10.0345 -25.2695 -2.5
-      vertex 9.82547 -25.2695 -2.5
+      vertex 11.6491 2.53615 2
+      vertex 11.6946 2.38607 0
+      vertex 11.6946 2.38607 2
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 8.39 -24.275 -2.5
-      vertex 8.95185 -24.4829 -2.5
-      vertex 8.93 -24.275 -2.5
+      vertex 10.2448 1.78554 2
+      vertex 10.1709 1.92385 0
+      vertex 10.1709 1.92385 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 8.36815 -24.4829 -2.5
-      vertex 8.95185 -24.4829 -2.5
-      vertex 8.39 -24.275 -2.5
+      vertex 10.1709 1.92385 0
+      vertex 10.2448 1.78554 2
+      vertex 10.2448 1.78554 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 8.95185 -24.4829 -2.5
-      vertex 8.36815 -24.4829 -2.5
-      vertex 9.01645 -24.6817 -2.5
+      vertex 11.4757 1.66431 0
+      vertex 11.3545 1.56482 2
+      vertex 11.4757 1.66431 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 8.30354 -24.6817 -2.5
-      vertex 9.01645 -24.6817 -2.5
-      vertex 8.36815 -24.4829 -2.5
+      vertex 11.3545 1.56482 2
+      vertex 11.4757 1.66431 0
+      vertex 11.3545 1.56482 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 9.01645 -24.6817 -2.5
-      vertex 8.30354 -24.6817 -2.5
-      vertex 9.12098 -24.8628 -2.5
+      vertex 10.7539 3.01463 0
+      vertex 10.91 3.03 2
+      vertex 10.7539 3.01463 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 8.19902 -24.8628 -2.5
-      vertex 9.12098 -24.8628 -2.5
-      vertex 8.30354 -24.6817 -2.5
+      vertex 10.91 3.03 2
+      vertex 10.7539 3.01463 0
+      vertex 10.91 3.03 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.290448 -0.956891 0
     outer loop
-      vertex 9.12098 -24.8628 -2.5
-      vertex 8.19902 -24.8628 -2.5
-      vertex 9.26087 -25.0181 -2.5
+      vertex 11.0661 3.01463 0
+      vertex 11.2161 2.9691 2
+      vertex 11.0661 3.01463 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.290448 -0.956891 -0
     outer loop
-      vertex 8.05913 -25.0181 -2.5
-      vertex 9.26087 -25.0181 -2.5
-      vertex 8.19902 -24.8628 -2.5
+      vertex 11.2161 2.9691 2
+      vertex 11.0661 3.01463 0
+      vertex 11.2161 2.9691 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex 9.26087 -25.0181 -2.5
-      vertex 8.05913 -25.0181 -2.5
-      vertex 9.43 -25.141 -2.5
+      vertex 10.3443 2.79569 0
+      vertex 10.4655 2.89518 2
+      vertex 10.3443 2.79569 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex 7.89 -25.141 -2.5
-      vertex 9.43 -25.141 -2.5
-      vertex 8.05913 -25.0181 -2.5
+      vertex 10.4655 2.89518 2
+      vertex 10.3443 2.79569 0
+      vertex 10.4655 2.89518 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 9.43 -25.141 -2.5
-      vertex 7.89 -25.141 -2.5
-      vertex 9.62098 -25.2261 -2.5
+      vertex 10.6039 2.9691 0
+      vertex 10.7539 3.01463 2
+      vertex 10.6039 2.9691 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 7.69902 -25.2261 -2.5
-      vertex 9.62098 -25.2261 -2.5
-      vertex 7.89 -25.141 -2.5
+      vertex 10.7539 3.01463 2
+      vertex 10.6039 2.9691 0
+      vertex 10.7539 3.01463 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 9.62098 -25.2261 -2.5
-      vertex 7.69902 -25.2261 -2.5
-      vertex 9.82547 -25.2695 -2.5
+      vertex 11.4757 1.66431 0
+      vertex 11.5752 1.78554 2
+      vertex 11.5752 1.78554 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 7.49453 -25.2695 -2.5
-      vertex 9.82547 -25.2695 -2.5
-      vertex 7.69902 -25.2261 -2.5
+      vertex 11.5752 1.78554 2
+      vertex 11.4757 1.66431 0
+      vertex 11.4757 1.66431 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.634484 -0.772936 0
     outer loop
-      vertex 1 -26 -2.5
-      vertex 9.82547 -25.2695 -2.5
-      vertex 7.49453 -25.2695 -2.5
+      vertex 11.3545 2.89518 0
+      vertex 11.4757 2.79569 2
+      vertex 11.3545 2.89518 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.634484 -0.772936 -0
     outer loop
-      vertex 1 -26 -2.5
-      vertex 7.49453 -25.2695 -2.5
-      vertex 7.28547 -25.2695 -2.5
+      vertex 11.4757 2.79569 2
+      vertex 11.3545 2.89518 0
+      vertex 11.4757 2.79569 0
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.634484 0.772936 -0
     outer loop
-      vertex 2.93444 -23.6237 -2.5
-      vertex 6.41185 -24.0671 -2.5
-      vertex 3 -23 -2.5
+      vertex 10.4655 1.56482 0
+      vertex 10.3443 1.66431 2
+      vertex 10.4655 1.56482 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.634484 0.772936 0
     outer loop
-      vertex 6.41185 -24.0671 -2.5
-      vertex 2.93444 -23.6237 -2.5
-      vertex 6.39 -24.275 -2.5
+      vertex 10.3443 1.66431 2
+      vertex 10.4655 1.56482 0
+      vertex 10.3443 1.66431 0
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.0979887 0.995188 -0
     outer loop
-      vertex 2.74064 -24.2202 -2.5
-      vertex 6.39 -24.275 -2.5
-      vertex 2.93444 -23.6237 -2.5
+      vertex 10.91 1.43 0
+      vertex 10.7539 1.44537 2
+      vertex 10.91 1.43 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0979887 0.995188 0
     outer loop
-      vertex 6.39 -24.275 -2.5
-      vertex 2.74064 -24.2202 -2.5
-      vertex 6.41185 -24.4829 -2.5
+      vertex 10.7539 1.44537 2
+      vertex 10.91 1.43 0
+      vertex 10.7539 1.44537 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex 6.41185 -24.4829 -2.5
-      vertex 2.74064 -24.2202 -2.5
-      vertex 6.47645 -24.6817 -2.5
+      vertex 11.6491 1.92385 0
+      vertex 11.6946 2.07393 2
+      vertex 11.6946 2.07393 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex 2.42705 -24.7634 -2.5
-      vertex 6.47645 -24.6817 -2.5
-      vertex 2.74064 -24.2202 -2.5
+      vertex 11.6946 2.07393 2
+      vertex 11.6491 1.92385 0
+      vertex 11.6491 1.92385 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 6.47645 -24.6817 -2.5
-      vertex 2.42705 -24.7634 -2.5
-      vertex 6.58098 -24.8628 -2.5
+      vertex 11.3545 1.56482 0
+      vertex 11.2161 1.4909 2
+      vertex 11.3545 1.56482 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 6.58098 -24.8628 -2.5
-      vertex 2.42705 -24.7634 -2.5
-      vertex 6.72087 -25.0181 -2.5
+      vertex 11.2161 1.4909 2
+      vertex 11.3545 1.56482 0
+      vertex 11.2161 1.4909 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 2.00739 -25.2294 -2.5
-      vertex 6.72087 -25.0181 -2.5
-      vertex 2.42705 -24.7634 -2.5
+      vertex 11.2161 1.4909 0
+      vertex 11.0661 1.44537 2
+      vertex 11.2161 1.4909 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 6.72087 -25.0181 -2.5
-      vertex 2.00739 -25.2294 -2.5
-      vertex 6.89 -25.141 -2.5
+      vertex 11.0661 1.44537 2
+      vertex 11.2161 1.4909 0
+      vertex 11.0661 1.44537 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 1.5 -25.5981 -2.5
-      vertex 6.89 -25.141 -2.5
-      vertex 2.00739 -25.2294 -2.5
+      vertex 11.5752 2.67446 0
+      vertex 11.4757 2.79569 2
+      vertex 11.4757 2.79569 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 1 -26 -2.5
-      vertex 6.89 -25.141 -2.5
-      vertex 1.5 -25.5981 -2.5
+      vertex 11.4757 2.79569 2
+      vertex 11.5752 2.67446 0
+      vertex 11.5752 2.67446 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.471117 -0.882071 0
     outer loop
-      vertex 6.89 -25.141 -2.5
-      vertex 1 -26 -2.5
-      vertex 7.08098 -25.2261 -2.5
+      vertex 11.2161 2.9691 0
+      vertex 11.3545 2.89518 2
+      vertex 11.2161 2.9691 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.471117 -0.882071 -0
     outer loop
-      vertex 7.08098 -25.2261 -2.5
-      vertex 1 -26 -2.5
-      vertex 7.28547 -25.2695 -2.5
+      vertex 11.3545 2.89518 2
+      vertex 11.2161 2.9691 0
+      vertex 11.3545 2.89518 0
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 1 -26 -2.5
-      vertex 1.5 -25.5981 -2.5
-      vertex 1 -25.8207 -2.5
+      vertex 10.4655 2.89518 0
+      vertex 10.6039 2.9691 2
+      vertex 10.4655 2.89518 2
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 12.3655 -25.2695 -2.5
-      vertex 1 -26 -2.5
-      vertex 25 -26 -2.5
+      vertex 10.6039 2.9691 2
+      vertex 10.4655 2.89518 0
+      vertex 10.6039 2.9691 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0.927051 -25.8532 -2.5
-      vertex 1 -25.1143 -2.5
-      vertex 1 -25.8207 -2.5
+      vertex 47.1 23.5 0
+      vertex 6.5 23.5 0
+      vertex 47.1 25.7 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0.313585 -25.9836 -2.5
-      vertex 1 -25.1143 -2.5
-      vertex 0.927051 -25.8532 -2.5
+      vertex 61.5 0.5 0
+      vertex 64.5 3.5 0
+      vertex 64.4424 2.91473 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -0.313585 -25.9836 -2.5
-      vertex 1 -25.1143 -2.5
-      vertex 0.313585 -25.9836 -2.5
+      vertex 64.5 3.5 0
+      vertex 58.5 6.5 0
+      vertex 64.5 26.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -0.927051 -25.8532 -2.5
-      vertex 1 -25.1143 -2.5
-      vertex -0.313585 -25.9836 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1 -25.1143 -2.5
-      vertex -0.927051 -25.8532 -2.5
-      vertex 1 -23.9011 -2.5
+      vertex 61.5 0.5 0
+      vertex 64.4424 2.91473 0
+      vertex 64.2716 2.35195 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.5 -25.5981 -2.5
-      vertex 1 -23.9011 -2.5
-      vertex -0.927051 -25.8532 -2.5
+      vertex 58.5 23.5 0
+      vertex 64.5 26.5 0
+      vertex 58.5 6.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.00739 -25.2294 -2.5
-      vertex 1 -23.9011 -2.5
-      vertex -1.5 -25.5981 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.42705 -24.7634 -2.5
-      vertex 1 -23.9011 -2.5
-      vertex -2.00739 -25.2294 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.74064 -24.2202 -2.5
-      vertex 1 -23.9011 -2.5
-      vertex -2.42705 -24.7634 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1 -23.9011 -2.5
-      vertex -2.74064 -24.2202 -2.5
-      vertex 1 -23 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.93444 -23.6237 -2.5
-      vertex 1 -23 -2.5
-      vertex -2.74064 -24.2202 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 1 -23 -2.5
-      vertex -2.93444 -23.6237 -2.5
-      vertex -3 -23 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -25.1143 -2.5
-      vertex 1.17172 -24.5082 -2.5
-      vertex 1.14633 -24.7572 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -25.1143 -2.5
-      vertex 1.14633 -24.7572 -2.5
-      vertex 1.0682 -24.9955 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 -23.9011 -2.5
-      vertex 1.17172 -24.5082 -2.5
-      vertex 1 -25.1143 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.17172 -24.5082 -2.5
-      vertex 1 -23.9011 -2.5
-      vertex 1.14633 -24.2582 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.14633 -24.2582 -2.5
-      vertex 1 -23.9011 -2.5
-      vertex 1.0682 -24.0199 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 48.0772 -20 -4.5
-      vertex 41.7145 -20 -2.5
-      vertex 48.0772 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 41.7145 -20 -2.5
-      vertex 48.0772 -20 -4.5
-      vertex 41.7145 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 55 -20 -4.5
-      vertex 52.9291 -20 -2.5
-      vertex 55 -20 -2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 52.9291 -20 -2.5
-      vertex 55 -20 -4.5
-      vertex 52.9291 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 55 -20 -2
-      vertex 58 -20 2.44929e-15
-      vertex 58 -20 -2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 52.9291 -20 -2.5
-      vertex 58 -20 2.44929e-15
-      vertex 55 -20 -2
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 58 -20 2.44929e-15
-      vertex 52.9291 -20 -2.5
-      vertex 48.0772 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 41.7145 -20 -2.5
-      vertex 58 -20 2.44929e-15
-      vertex 48.0772 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 58 -20 2.44929e-15
-      vertex 41.7145 -20 -2.5
-      vertex 25 -20 2.44929e-15
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 29.1822 -20 -2.5
-      vertex 25 -20 2.44929e-15
-      vertex 41.7145 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 29.1822 -20 -2.5
-      vertex 25 -20 -2.5
-      vertex 25 -20 2.44929e-15
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 29.1822 -20 -4.5
-      vertex 25 -20 -2.5
-      vertex 29.1822 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 3 -20 -4.5
-      vertex 25 -20 -2.5
-      vertex 29.1822 -20 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 25 -20 -2.5
-      vertex 3 -20 -4.5
-      vertex 3 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 1 -26 -4.5
-      vertex 25 -26 -2.5
-      vertex 1 -26 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 48.2107 -26 -4.5
-      vertex 25 -26 -2.5
-      vertex 1 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 25 -26 -2.5
-      vertex 48.2107 -26 -4.5
-      vertex 48.2107 -26 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 48.2107 -26 -2.5
-      vertex 25 -26 3.18408e-15
-      vertex 25 -26 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 25 -26 3.18408e-15
-      vertex 48.2107 -26 -2.5
-      vertex 58 -26 3.18408e-15
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 52.7954 -26 -2.5
-      vertex 58 -26 3.18408e-15
-      vertex 48.2107 -26 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 58 -26 -4.5
-      vertex 52.7954 -26 -2.5
-      vertex 52.7954 -26 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 52.7954 -26 -2.5
-      vertex 58 -26 -4.5
-      vertex 58 -26 3.18408e-15
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 25 -26 -2.5
-      vertex 25 -20 2.44929e-15
-      vertex 25 -20 -2.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 25 -20 2.44929e-15
-      vertex 25 -26 -2.5
-      vertex 25 -26 3.18408e-15
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 7.89 -25.141 -4.5
-      vertex 7.69902 -25.2261 -2.5
-      vertex 7.89 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 7.69902 -25.2261 -2.5
-      vertex 7.89 -25.141 -4.5
-      vertex 7.69902 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104524 0
-    outer loop
-      vertex 6.41185 -24.4829 -2.5
-      vertex 6.39 -24.275 -4.5
-      vertex 6.39 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104524 0
-    outer loop
-      vertex 6.39 -24.275 -4.5
-      vertex 6.41185 -24.4829 -2.5
-      vertex 6.41185 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 8.39 -24.275 -4.5
-      vertex 8.36815 -24.0671 -2.5
-      vertex 8.36815 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 8.36815 -24.0671 -2.5
-      vertex 8.39 -24.275 -4.5
-      vertex 8.39 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 7.28547 -23.2805 -4.5
-      vertex 7.49453 -23.2805 -2.5
-      vertex 7.28547 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 7.49453 -23.2805 -2.5
-      vertex 7.28547 -23.2805 -4.5
-      vertex 7.49453 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 -0
-    outer loop
-      vertex 6.89 -25.141 -4.5
-      vertex 6.72087 -25.0181 -2.5
-      vertex 6.89 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 0
-    outer loop
-      vertex 6.72087 -25.0181 -2.5
-      vertex 6.89 -25.141 -4.5
-      vertex 6.72087 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal -0.951055 0.309021 0
-    outer loop
-      vertex 8.30354 -24.6817 -4.5
-      vertex 8.36815 -24.4829 -2.5
-      vertex 8.36815 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal -0.951055 0.309021 0
-    outer loop
-      vertex 8.36815 -24.4829 -2.5
-      vertex 8.30354 -24.6817 -4.5
-      vertex 8.30354 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.499998 0
-    outer loop
-      vertex 8.19902 -24.8628 -4.5
-      vertex 8.30354 -24.6817 -2.5
-      vertex 8.30354 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.499998 0
-    outer loop
-      vertex 8.30354 -24.6817 -2.5
-      vertex 8.19902 -24.8628 -4.5
-      vertex 8.19902 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 8.05913 -25.0181 -4.5
-      vertex 8.19902 -24.8628 -2.5
-      vertex 8.19902 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 8.19902 -24.8628 -2.5
-      vertex 8.05913 -25.0181 -4.5
-      vertex 8.05913 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.587786 0.809017 0
-    outer loop
-      vertex 8.05913 -25.0181 -4.5
-      vertex 7.89 -25.141 -2.5
-      vertex 8.05913 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.587786 0.809017 0
-    outer loop
-      vertex 7.89 -25.141 -2.5
-      vertex 8.05913 -25.0181 -4.5
-      vertex 7.89 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 0
-    outer loop
-      vertex 7.69902 -25.2261 -4.5
-      vertex 7.49453 -25.2695 -2.5
-      vertex 7.69902 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 0
-    outer loop
-      vertex 7.49453 -25.2695 -2.5
-      vertex 7.69902 -25.2261 -4.5
-      vertex 7.49453 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 -0
-    outer loop
-      vertex 7.28547 -25.2695 -4.5
-      vertex 7.08098 -25.2261 -2.5
-      vertex 7.28547 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 0
-    outer loop
-      vertex 7.08098 -25.2261 -2.5
-      vertex 7.28547 -25.2695 -4.5
-      vertex 7.08098 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 7.49453 -25.2695 -4.5
-      vertex 7.28547 -25.2695 -2.5
-      vertex 7.49453 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.28547 -25.2695 -2.5
-      vertex 7.49453 -25.2695 -4.5
-      vertex 7.28547 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104524 0
-    outer loop
-      vertex 6.39 -24.275 -2.5
-      vertex 6.41185 -24.0671 -4.5
-      vertex 6.41185 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104524 0
-    outer loop
-      vertex 6.41185 -24.0671 -4.5
-      vertex 6.39 -24.275 -2.5
-      vertex 6.39 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0.951055 0.309021 0
-    outer loop
-      vertex 6.47645 -24.6817 -2.5
-      vertex 6.41185 -24.4829 -4.5
-      vertex 6.41185 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal 0.951055 0.309021 0
-    outer loop
-      vertex 6.41185 -24.4829 -4.5
-      vertex 6.47645 -24.6817 -2.5
-      vertex 6.47645 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 6.72087 -25.0181 -2.5
-      vertex 6.58098 -24.8628 -4.5
-      vertex 6.58098 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 6.58098 -24.8628 -4.5
-      vertex 6.72087 -25.0181 -2.5
-      vertex 6.72087 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 -0
-    outer loop
-      vertex 7.08098 -25.2261 -4.5
-      vertex 6.89 -25.141 -2.5
-      vertex 7.08098 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 0
-    outer loop
-      vertex 6.89 -25.141 -2.5
-      vertex 7.08098 -25.2261 -4.5
-      vertex 6.89 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 6.58098 -24.8628 -2.5
-      vertex 6.47645 -24.6817 -4.5
-      vertex 6.47645 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 6.47645 -24.6817 -4.5
-      vertex 6.58098 -24.8628 -2.5
-      vertex 6.58098 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 8.36815 -24.4829 -4.5
-      vertex 8.39 -24.275 -2.5
-      vertex 8.39 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 8.39 -24.275 -2.5
-      vertex 8.36815 -24.4829 -4.5
-      vertex 8.36815 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal -0.207918 -0.978146 0
-    outer loop
-      vertex 7.49453 -23.2805 -4.5
-      vertex 7.69902 -23.3239 -2.5
-      vertex 7.49453 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal -0.207918 -0.978146 -0
-    outer loop
-      vertex 7.69902 -23.3239 -2.5
-      vertex 7.49453 -23.2805 -4.5
-      vertex 7.69902 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal -0.406729 -0.913549 0
-    outer loop
-      vertex 7.69902 -23.3239 -4.5
-      vertex 7.89 -23.409 -2.5
-      vertex 7.69902 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal -0.406729 -0.913549 -0
-    outer loop
-      vertex 7.89 -23.409 -2.5
-      vertex 7.69902 -23.3239 -4.5
-      vertex 7.89 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal -0.587786 -0.809017 0
-    outer loop
-      vertex 7.89 -23.409 -4.5
-      vertex 8.05913 -23.5319 -2.5
-      vertex 7.89 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal -0.587786 -0.809017 -0
-    outer loop
-      vertex 8.05913 -23.5319 -2.5
-      vertex 7.89 -23.409 -4.5
-      vertex 8.05913 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 8.30354 -23.8683 -4.5
-      vertex 8.19902 -23.6872 -2.5
-      vertex 8.19902 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 8.19902 -23.6872 -2.5
-      vertex 8.30354 -23.8683 -4.5
-      vertex 8.30354 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 6.89 -23.409 -4.5
-      vertex 7.08098 -23.3239 -2.5
-      vertex 6.89 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 7.08098 -23.3239 -2.5
-      vertex 6.89 -23.409 -4.5
-      vertex 7.08098 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 6.58098 -23.6872 -2.5
-      vertex 6.72087 -23.5319 -4.5
-      vertex 6.72087 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 6.72087 -23.5319 -4.5
-      vertex 6.58098 -23.6872 -2.5
-      vertex 6.58098 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0.951055 -0.309021 0
-    outer loop
-      vertex 6.41185 -24.0671 -2.5
-      vertex 6.47645 -23.8683 -4.5
-      vertex 6.47645 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0.951055 -0.309021 0
-    outer loop
-      vertex 6.47645 -23.8683 -4.5
-      vertex 6.41185 -24.0671 -2.5
-      vertex 6.41185 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 8.19902 -23.6872 -4.5
-      vertex 8.05913 -23.5319 -2.5
-      vertex 8.05913 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 8.05913 -23.5319 -2.5
-      vertex 8.19902 -23.6872 -4.5
-      vertex 8.19902 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309021 0
-    outer loop
-      vertex 8.36815 -24.0671 -4.5
-      vertex 8.30354 -23.8683 -2.5
-      vertex 8.30354 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309021 0
-    outer loop
-      vertex 8.30354 -23.8683 -2.5
-      vertex 8.36815 -24.0671 -4.5
-      vertex 8.36815 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 7.08098 -23.3239 -4.5
-      vertex 7.28547 -23.2805 -2.5
-      vertex 7.08098 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 7.28547 -23.2805 -2.5
-      vertex 7.08098 -23.3239 -4.5
-      vertex 7.28547 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 6.47645 -23.8683 -2.5
-      vertex 6.58098 -23.6872 -4.5
-      vertex 6.58098 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 6.58098 -23.6872 -4.5
-      vertex 6.47645 -23.8683 -2.5
-      vertex 6.47645 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 6.72087 -23.5319 -4.5
-      vertex 6.89 -23.409 -2.5
-      vertex 6.72087 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 6.89 -23.409 -2.5
-      vertex 6.72087 -23.5319 -4.5
-      vertex 6.89 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 10.9081 -24.4829 -4.5
-      vertex 10.93 -24.275 -2.5
-      vertex 10.93 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 10.93 -24.275 -2.5
-      vertex 10.9081 -24.4829 -4.5
-      vertex 10.9081 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 -0
-    outer loop
-      vertex 9.82547 -25.2695 -4.5
-      vertex 9.62098 -25.2261 -2.5
-      vertex 9.82547 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 0
-    outer loop
-      vertex 9.62098 -25.2261 -2.5
-      vertex 9.82547 -25.2695 -4.5
-      vertex 9.62098 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 10.5991 -25.0181 -4.5
-      vertex 10.43 -25.141 -2.5
-      vertex 10.5991 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 10.43 -25.141 -2.5
-      vertex 10.5991 -25.0181 -4.5
-      vertex 10.43 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 9.12098 -24.8628 -2.5
-      vertex 9.01645 -24.6817 -4.5
-      vertex 9.01645 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 9.01645 -24.6817 -4.5
-      vertex 9.12098 -24.8628 -2.5
-      vertex 9.12098 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0.951055 0.309021 0
-    outer loop
-      vertex 9.01645 -24.6817 -2.5
-      vertex 8.95185 -24.4829 -4.5
-      vertex 8.95185 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal 0.951055 0.309021 0
-    outer loop
-      vertex 8.95185 -24.4829 -4.5
-      vertex 9.01645 -24.6817 -2.5
-      vertex 9.01645 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 -0
-    outer loop
-      vertex 9.43 -25.141 -4.5
-      vertex 9.26087 -25.0181 -2.5
-      vertex 9.43 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 0
-    outer loop
-      vertex 9.26087 -25.0181 -2.5
-      vertex 9.43 -25.141 -4.5
-      vertex 9.26087 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 10.8435 -23.8683 -4.5
-      vertex 10.739 -23.6872 -2.5
-      vertex 10.739 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 10.739 -23.6872 -2.5
-      vertex 10.8435 -23.8683 -4.5
-      vertex 10.8435 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0.951055 -0.309021 0
-    outer loop
-      vertex 8.95185 -24.0671 -2.5
-      vertex 9.01645 -23.8683 -4.5
-      vertex 9.01645 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0.951055 -0.309021 0
-    outer loop
-      vertex 9.01645 -23.8683 -4.5
-      vertex 8.95185 -24.0671 -2.5
-      vertex 8.95185 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.499998 0
-    outer loop
-      vertex 10.739 -24.8628 -4.5
-      vertex 10.8435 -24.6817 -2.5
-      vertex 10.8435 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.499998 0
-    outer loop
-      vertex 10.8435 -24.6817 -2.5
-      vertex 10.739 -24.8628 -4.5
-      vertex 10.739 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal -0.951055 0.309021 0
-    outer loop
-      vertex 10.8435 -24.6817 -4.5
-      vertex 10.9081 -24.4829 -2.5
-      vertex 10.9081 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal -0.951055 0.309021 0
-    outer loop
-      vertex 10.9081 -24.4829 -2.5
-      vertex 10.8435 -24.6817 -4.5
-      vertex 10.8435 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 10.5991 -25.0181 -4.5
-      vertex 10.739 -24.8628 -2.5
-      vertex 10.739 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 10.739 -24.8628 -2.5
-      vertex 10.5991 -25.0181 -4.5
-      vertex 10.5991 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 0
-    outer loop
-      vertex 10.239 -25.2261 -4.5
-      vertex 10.0345 -25.2695 -2.5
-      vertex 10.239 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 0
-    outer loop
-      vertex 10.0345 -25.2695 -2.5
-      vertex 10.239 -25.2261 -4.5
-      vertex 10.0345 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 10.0345 -25.2695 -4.5
-      vertex 9.82547 -25.2695 -2.5
-      vertex 10.0345 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 9.82547 -25.2695 -2.5
-      vertex 10.0345 -25.2695 -4.5
-      vertex 9.82547 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 10.43 -25.141 -4.5
-      vertex 10.239 -25.2261 -2.5
-      vertex 10.43 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 10.239 -25.2261 -2.5
-      vertex 10.43 -25.141 -4.5
-      vertex 10.239 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104524 0
-    outer loop
-      vertex 8.95185 -24.4829 -2.5
-      vertex 8.93 -24.275 -4.5
-      vertex 8.93 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104524 0
-    outer loop
-      vertex 8.93 -24.275 -4.5
-      vertex 8.95185 -24.4829 -2.5
-      vertex 8.95185 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 9.26087 -25.0181 -2.5
-      vertex 9.12098 -24.8628 -4.5
-      vertex 9.12098 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 9.12098 -24.8628 -4.5
-      vertex 9.26087 -25.0181 -2.5
-      vertex 9.26087 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 -0
-    outer loop
-      vertex 9.62098 -25.2261 -4.5
-      vertex 9.43 -25.141 -2.5
-      vertex 9.62098 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 0
-    outer loop
-      vertex 9.43 -25.141 -2.5
-      vertex 9.62098 -25.2261 -4.5
-      vertex 9.43 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal -0.207918 -0.978146 0
-    outer loop
-      vertex 10.0345 -23.2805 -4.5
-      vertex 10.239 -23.3239 -2.5
-      vertex 10.0345 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal -0.207918 -0.978146 -0
-    outer loop
-      vertex 10.239 -23.3239 -2.5
-      vertex 10.0345 -23.2805 -4.5
-      vertex 10.239 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 0
-    outer loop
-      vertex 10.43 -23.409 -4.5
-      vertex 10.5991 -23.5319 -2.5
-      vertex 10.43 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 -0
-    outer loop
-      vertex 10.5991 -23.5319 -2.5
-      vertex 10.43 -23.409 -4.5
-      vertex 10.5991 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 9.43 -23.409 -4.5
-      vertex 9.62098 -23.3239 -2.5
-      vertex 9.43 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 9.62098 -23.3239 -2.5
-      vertex 9.43 -23.409 -4.5
-      vertex 9.62098 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 9.82547 -23.2805 -4.5
-      vertex 10.0345 -23.2805 -2.5
-      vertex 9.82547 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 10.0345 -23.2805 -2.5
-      vertex 9.82547 -23.2805 -4.5
-      vertex 10.0345 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 9.12098 -23.6872 -2.5
-      vertex 9.26087 -23.5319 -4.5
-      vertex 9.26087 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 9.26087 -23.5319 -4.5
-      vertex 9.12098 -23.6872 -2.5
-      vertex 9.12098 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 9.01645 -23.8683 -2.5
-      vertex 9.12098 -23.6872 -4.5
-      vertex 9.12098 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 9.12098 -23.6872 -4.5
-      vertex 9.01645 -23.8683 -2.5
-      vertex 9.01645 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104524 0
-    outer loop
-      vertex 8.93 -24.275 -2.5
-      vertex 8.95185 -24.0671 -4.5
-      vertex 8.95185 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104524 0
-    outer loop
-      vertex 8.95185 -24.0671 -4.5
-      vertex 8.93 -24.275 -2.5
-      vertex 8.93 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0.406729 -0.913549 0
-    outer loop
-      vertex 10.239 -23.3239 -4.5
-      vertex 10.43 -23.409 -2.5
-      vertex 10.239 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal -0.406729 -0.913549 -0
-    outer loop
-      vertex 10.43 -23.409 -2.5
-      vertex 10.239 -23.3239 -4.5
-      vertex 10.43 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 10.739 -23.6872 -4.5
-      vertex 10.5991 -23.5319 -2.5
-      vertex 10.5991 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 10.5991 -23.5319 -2.5
-      vertex 10.739 -23.6872 -4.5
-      vertex 10.739 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309021 0
-    outer loop
-      vertex 10.9081 -24.0671 -4.5
-      vertex 10.8435 -23.8683 -2.5
-      vertex 10.8435 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309021 0
-    outer loop
-      vertex 10.8435 -23.8683 -2.5
-      vertex 10.9081 -24.0671 -4.5
-      vertex 10.9081 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 10.93 -24.275 -4.5
-      vertex 10.9081 -24.0671 -2.5
-      vertex 10.9081 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 10.9081 -24.0671 -2.5
-      vertex 10.93 -24.275 -4.5
-      vertex 10.93 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 9.62098 -23.3239 -4.5
-      vertex 9.82547 -23.2805 -2.5
-      vertex 9.62098 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 9.82547 -23.2805 -2.5
-      vertex 9.62098 -23.3239 -4.5
-      vertex 9.82547 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 9.26087 -23.5319 -4.5
-      vertex 9.43 -23.409 -2.5
-      vertex 9.26087 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 9.43 -23.409 -2.5
-      vertex 9.26087 -23.5319 -4.5
-      vertex 9.43 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 13.4481 -24.4829 -4.5
-      vertex 13.47 -24.275 -2.5
-      vertex 13.47 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 13.47 -24.275 -2.5
-      vertex 13.4481 -24.4829 -4.5
-      vertex 13.4481 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 -0
-    outer loop
-      vertex 12.3655 -25.2695 -4.5
-      vertex 12.161 -25.2261 -2.5
-      vertex 12.3655 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 0
-    outer loop
-      vertex 12.161 -25.2261 -2.5
-      vertex 12.3655 -25.2695 -4.5
-      vertex 12.161 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 12.3655 -23.2805 -4.5
-      vertex 12.5745 -23.2805 -2.5
-      vertex 12.3655 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 12.5745 -23.2805 -2.5
-      vertex 12.3655 -23.2805 -4.5
-      vertex 12.5745 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 13.1391 -25.0181 -4.5
-      vertex 12.97 -25.141 -2.5
-      vertex 13.1391 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 12.97 -25.141 -2.5
-      vertex 13.1391 -25.0181 -4.5
-      vertex 12.97 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 11.661 -24.8628 -2.5
-      vertex 11.5565 -24.6817 -4.5
-      vertex 11.5565 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 11.5565 -24.6817 -4.5
-      vertex 11.661 -24.8628 -2.5
-      vertex 11.661 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 -0
-    outer loop
-      vertex 11.97 -25.141 -4.5
-      vertex 11.8009 -25.0181 -2.5
-      vertex 11.97 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 0
-    outer loop
-      vertex 11.8009 -25.0181 -2.5
-      vertex 11.97 -25.141 -4.5
-      vertex 11.8009 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 13.279 -23.6872 -4.5
-      vertex 13.1391 -23.5319 -2.5
-      vertex 13.1391 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 13.1391 -23.5319 -2.5
-      vertex 13.279 -23.6872 -4.5
-      vertex 13.279 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 11.4919 -24.0671 -2.5
-      vertex 11.5565 -23.8683 -4.5
-      vertex 11.5565 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 11.5565 -23.8683 -4.5
-      vertex 11.4919 -24.0671 -2.5
-      vertex 11.4919 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.499998 0
-    outer loop
-      vertex 13.279 -24.8628 -4.5
-      vertex 13.3835 -24.6817 -2.5
-      vertex 13.3835 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.499998 0
-    outer loop
-      vertex 13.3835 -24.6817 -2.5
-      vertex 13.279 -24.8628 -4.5
-      vertex 13.279 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal -0.951055 0.309021 0
-    outer loop
-      vertex 13.3835 -24.6817 -4.5
-      vertex 13.4481 -24.4829 -2.5
-      vertex 13.4481 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal -0.951055 0.309021 0
-    outer loop
-      vertex 13.4481 -24.4829 -2.5
-      vertex 13.3835 -24.6817 -4.5
-      vertex 13.3835 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 13.1391 -25.0181 -4.5
-      vertex 13.279 -24.8628 -2.5
-      vertex 13.279 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 13.279 -24.8628 -2.5
-      vertex 13.1391 -25.0181 -4.5
-      vertex 13.1391 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 0
-    outer loop
-      vertex 12.779 -25.2261 -4.5
-      vertex 12.5745 -25.2695 -2.5
-      vertex 12.779 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 0
-    outer loop
-      vertex 12.5745 -25.2695 -2.5
-      vertex 12.779 -25.2261 -4.5
-      vertex 12.5745 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 12.5745 -25.2695 -4.5
-      vertex 12.3655 -25.2695 -2.5
-      vertex 12.5745 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.3655 -25.2695 -2.5
-      vertex 12.5745 -25.2695 -4.5
-      vertex 12.3655 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 12.97 -25.141 -4.5
-      vertex 12.779 -25.2261 -2.5
-      vertex 12.97 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 12.779 -25.2261 -2.5
-      vertex 12.97 -25.141 -4.5
-      vertex 12.779 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 11.5565 -24.6817 -2.5
-      vertex 11.4919 -24.4829 -4.5
-      vertex 11.4919 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 11.4919 -24.4829 -4.5
-      vertex 11.5565 -24.6817 -2.5
-      vertex 11.5565 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 11.4919 -24.4829 -2.5
-      vertex 11.47 -24.275 -4.5
-      vertex 11.47 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 11.47 -24.275 -4.5
-      vertex 11.4919 -24.4829 -2.5
-      vertex 11.4919 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 11.47 -24.275 -2.5
-      vertex 11.4919 -24.0671 -4.5
-      vertex 11.4919 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 11.4919 -24.0671 -4.5
-      vertex 11.47 -24.275 -2.5
-      vertex 11.47 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 11.8009 -25.0181 -2.5
-      vertex 11.661 -24.8628 -4.5
-      vertex 11.661 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 11.661 -24.8628 -4.5
-      vertex 11.8009 -25.0181 -2.5
-      vertex 11.8009 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 -0
-    outer loop
-      vertex 12.161 -25.2261 -4.5
-      vertex 11.97 -25.141 -2.5
-      vertex 12.161 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 0
-    outer loop
-      vertex 11.97 -25.141 -2.5
-      vertex 12.161 -25.2261 -4.5
-      vertex 11.97 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal -0.207918 -0.978146 0
-    outer loop
-      vertex 12.5745 -23.2805 -4.5
-      vertex 12.779 -23.3239 -2.5
-      vertex 12.5745 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal -0.207918 -0.978146 -0
-    outer loop
-      vertex 12.779 -23.3239 -2.5
-      vertex 12.5745 -23.2805 -4.5
-      vertex 12.779 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 0
-    outer loop
-      vertex 12.97 -23.409 -4.5
-      vertex 13.1391 -23.5319 -2.5
-      vertex 12.97 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 -0
-    outer loop
-      vertex 13.1391 -23.5319 -2.5
-      vertex 12.97 -23.409 -4.5
-      vertex 13.1391 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 11.8009 -23.5319 -4.5
-      vertex 11.97 -23.409 -2.5
-      vertex 11.8009 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 11.97 -23.409 -2.5
-      vertex 11.8009 -23.5319 -4.5
-      vertex 11.97 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 12.161 -23.3239 -4.5
-      vertex 12.3655 -23.2805 -2.5
-      vertex 12.161 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 12.3655 -23.2805 -2.5
-      vertex 12.161 -23.3239 -4.5
-      vertex 12.3655 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 11.5565 -23.8683 -2.5
-      vertex 11.661 -23.6872 -4.5
-      vertex 11.661 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 11.661 -23.6872 -4.5
-      vertex 11.5565 -23.8683 -2.5
-      vertex 11.5565 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 11.661 -23.6872 -2.5
-      vertex 11.8009 -23.5319 -4.5
-      vertex 11.8009 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 11.8009 -23.5319 -4.5
-      vertex 11.661 -23.6872 -2.5
-      vertex 11.661 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0.406729 -0.913549 0
-    outer loop
-      vertex 12.779 -23.3239 -4.5
-      vertex 12.97 -23.409 -2.5
-      vertex 12.779 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal -0.406729 -0.913549 -0
-    outer loop
-      vertex 12.97 -23.409 -2.5
-      vertex 12.779 -23.3239 -4.5
-      vertex 12.97 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309021 0
-    outer loop
-      vertex 13.4481 -24.0671 -4.5
-      vertex 13.3835 -23.8683 -2.5
-      vertex 13.3835 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal -0.951055 -0.309021 0
-    outer loop
-      vertex 13.3835 -23.8683 -2.5
-      vertex 13.4481 -24.0671 -4.5
-      vertex 13.4481 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 13.3835 -23.8683 -4.5
-      vertex 13.279 -23.6872 -2.5
-      vertex 13.279 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 13.279 -23.6872 -2.5
-      vertex 13.3835 -23.8683 -4.5
-      vertex 13.3835 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 13.47 -24.275 -4.5
-      vertex 13.4481 -24.0671 -2.5
-      vertex 13.4481 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 13.4481 -24.0671 -2.5
-      vertex 13.47 -24.275 -4.5
-      vertex 13.47 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 11.97 -23.409 -4.5
-      vertex 12.161 -23.3239 -2.5
-      vertex 11.97 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 12.161 -23.3239 -2.5
-      vertex 11.97 -23.409 -4.5
-      vertex 12.161 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 15.51 -25.141 -4.5
-      vertex 15.319 -25.2261 -2.5
-      vertex 15.51 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal -0.406737 0.913545 0
-    outer loop
-      vertex 15.319 -25.2261 -2.5
-      vertex 15.51 -25.141 -4.5
-      vertex 15.319 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 14.01 -24.275 -2.5
-      vertex 14.0319 -24.0671 -4.5
-      vertex 14.0319 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 14.0319 -24.0671 -4.5
-      vertex 14.01 -24.275 -2.5
-      vertex 14.01 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 16.01 -24.275 -4.5
-      vertex 15.9881 -24.0671 -2.5
-      vertex 15.9881 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 15.9881 -24.0671 -2.5
-      vertex 16.01 -24.275 -4.5
-      vertex 16.01 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 14.701 -23.3239 -4.5
-      vertex 14.9055 -23.2805 -2.5
-      vertex 14.701 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 14.9055 -23.2805 -2.5
-      vertex 14.701 -23.3239 -4.5
-      vertex 14.9055 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 -0
-    outer loop
-      vertex 14.51 -25.141 -4.5
-      vertex 14.3409 -25.0181 -2.5
-      vertex 14.51 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal 0.587785 0.809017 0
-    outer loop
-      vertex 14.3409 -25.0181 -2.5
-      vertex 14.51 -25.141 -4.5
-      vertex 14.3409 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 14.0319 -24.4829 -2.5
-      vertex 14.01 -24.275 -4.5
-      vertex 14.01 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 14.01 -24.275 -4.5
-      vertex 14.0319 -24.4829 -2.5
-      vertex 14.0319 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 14.0319 -24.0671 -2.5
-      vertex 14.0965 -23.8683 -4.5
-      vertex 14.0965 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 14.0965 -23.8683 -4.5
-      vertex 14.0319 -24.0671 -2.5
-      vertex 14.0319 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.866024 0.500002 0
-    outer loop
-      vertex 15.819 -24.8628 -4.5
-      vertex 15.9235 -24.6817 -2.5
-      vertex 15.9235 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal -0.866024 0.500002 0
-    outer loop
-      vertex 15.9235 -24.6817 -2.5
-      vertex 15.819 -24.8628 -4.5
-      vertex 15.819 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 15.6791 -25.0181 -4.5
-      vertex 15.819 -24.8628 -2.5
-      vertex 15.819 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 0.66913 0
-    outer loop
-      vertex 15.819 -24.8628 -2.5
-      vertex 15.6791 -25.0181 -4.5
-      vertex 15.6791 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 15.6791 -25.0181 -4.5
-      vertex 15.51 -25.141 -2.5
-      vertex 15.6791 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 15.51 -25.141 -2.5
-      vertex 15.6791 -25.0181 -4.5
-      vertex 15.51 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 0
-    outer loop
-      vertex 15.319 -25.2261 -4.5
-      vertex 15.1145 -25.2695 -2.5
-      vertex 15.319 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal -0.207909 0.978148 0
-    outer loop
-      vertex 15.1145 -25.2695 -2.5
-      vertex 15.319 -25.2261 -4.5
-      vertex 15.1145 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 -0
-    outer loop
-      vertex 14.9055 -25.2695 -4.5
-      vertex 14.701 -25.2261 -2.5
-      vertex 14.9055 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 0
-    outer loop
-      vertex 14.701 -25.2261 -2.5
-      vertex 14.9055 -25.2695 -4.5
-      vertex 14.701 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 15.1145 -25.2695 -4.5
-      vertex 14.9055 -25.2695 -2.5
-      vertex 15.1145 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 14.9055 -25.2695 -2.5
-      vertex 15.1145 -25.2695 -4.5
-      vertex 14.9055 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 14.0965 -24.6817 -2.5
-      vertex 14.0319 -24.4829 -4.5
-      vertex 14.0319 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 14.0319 -24.4829 -4.5
-      vertex 14.0965 -24.6817 -2.5
-      vertex 14.0965 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 14.3409 -25.0181 -2.5
-      vertex 14.201 -24.8628 -4.5
-      vertex 14.201 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 0.66913 0
-    outer loop
-      vertex 14.201 -24.8628 -4.5
-      vertex 14.3409 -25.0181 -2.5
-      vertex 14.3409 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 -0
-    outer loop
-      vertex 14.701 -25.2261 -4.5
-      vertex 14.51 -25.141 -2.5
-      vertex 14.701 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 0
-    outer loop
-      vertex 14.51 -25.141 -2.5
-      vertex 14.701 -25.2261 -4.5
-      vertex 14.51 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 14.201 -24.8628 -2.5
-      vertex 14.0965 -24.6817 -4.5
-      vertex 14.0965 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 14.0965 -24.6817 -4.5
-      vertex 14.201 -24.8628 -2.5
-      vertex 14.201 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 15.9881 -24.4829 -4.5
-      vertex 16.01 -24.275 -2.5
-      vertex 16.01 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 16.01 -24.275 -2.5
-      vertex 15.9881 -24.4829 -4.5
-      vertex 15.9881 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal -0.207918 -0.978146 0
-    outer loop
-      vertex 15.1145 -23.2805 -4.5
-      vertex 15.319 -23.3239 -2.5
-      vertex 15.1145 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal -0.207918 -0.978146 -0
-    outer loop
-      vertex 15.319 -23.3239 -2.5
-      vertex 15.1145 -23.2805 -4.5
-      vertex 15.319 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal -0.866024 -0.500002 0
-    outer loop
-      vertex 15.9235 -23.8683 -4.5
-      vertex 15.819 -23.6872 -2.5
-      vertex 15.819 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0.866024 -0.500002 0
-    outer loop
-      vertex 15.819 -23.6872 -2.5
-      vertex 15.9235 -23.8683 -4.5
-      vertex 15.9235 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 15.9881 -24.0671 -4.5
-      vertex 15.9235 -23.8683 -2.5
-      vertex 15.9235 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 15.9235 -23.8683 -2.5
-      vertex 15.9881 -24.0671 -4.5
-      vertex 15.9881 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal -0.406729 -0.913549 0
-    outer loop
-      vertex 15.319 -23.3239 -4.5
-      vertex 15.51 -23.409 -2.5
-      vertex 15.319 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal -0.406729 -0.913549 -0
-    outer loop
-      vertex 15.51 -23.409 -2.5
-      vertex 15.319 -23.3239 -4.5
-      vertex 15.51 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 0
-    outer loop
-      vertex 15.51 -23.409 -4.5
-      vertex 15.6791 -23.5319 -2.5
-      vertex 15.51 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 -0
-    outer loop
-      vertex 15.6791 -23.5319 -2.5
-      vertex 15.51 -23.409 -4.5
-      vertex 15.6791 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 14.9055 -23.2805 -4.5
-      vertex 15.1145 -23.2805 -2.5
-      vertex 14.9055 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 15.1145 -23.2805 -2.5
-      vertex 14.9055 -23.2805 -4.5
-      vertex 15.1145 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 14.3409 -23.5319 -4.5
-      vertex 14.51 -23.409 -2.5
-      vertex 14.3409 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.587785 -0.809017 0
-    outer loop
-      vertex 14.51 -23.409 -2.5
-      vertex 14.3409 -23.5319 -4.5
-      vertex 14.51 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 14.0965 -23.8683 -2.5
-      vertex 14.201 -23.6872 -4.5
-      vertex 14.201 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 14.201 -23.6872 -4.5
-      vertex 14.0965 -23.8683 -2.5
-      vertex 14.0965 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 14.201 -23.6872 -2.5
-      vertex 14.3409 -23.5319 -4.5
-      vertex 14.3409 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.743145 -0.66913 0
-    outer loop
-      vertex 14.3409 -23.5319 -4.5
-      vertex 14.201 -23.6872 -2.5
-      vertex 14.201 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 0.309017 0
-    outer loop
-      vertex 15.9235 -24.6817 -4.5
-      vertex 15.9881 -24.4829 -2.5
-      vertex 15.9881 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 0.309017 0
-    outer loop
-      vertex 15.9881 -24.4829 -2.5
-      vertex 15.9235 -24.6817 -4.5
-      vertex 15.9235 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 15.819 -23.6872 -4.5
-      vertex 15.6791 -23.5319 -2.5
-      vertex 15.6791 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal -0.743145 -0.66913 0
-    outer loop
-      vertex 15.6791 -23.5319 -2.5
-      vertex 15.819 -23.6872 -4.5
-      vertex 15.819 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 14.51 -23.409 -4.5
-      vertex 14.701 -23.3239 -2.5
-      vertex 14.51 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 14.701 -23.3239 -2.5
-      vertex 14.51 -23.409 -4.5
-      vertex 14.701 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal -0.406739 0.913545 0
-    outer loop
-      vertex 23.13 -25.141 -4.5
-      vertex 22.939 -25.2261 -2.5
-      vertex 23.13 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal -0.406739 0.913545 0
-    outer loop
-      vertex 22.939 -25.2261 -2.5
-      vertex 23.13 -25.141 -4.5
-      vertex 22.939 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 21.63 -24.275 -2.5
-      vertex 21.6519 -24.0671 -4.5
-      vertex 21.6519 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 21.6519 -24.0671 -4.5
-      vertex 21.63 -24.275 -2.5
-      vertex 21.63 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 23.63 -24.275 -4.5
-      vertex 23.6081 -24.0671 -2.5
-      vertex 23.6081 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 23.6081 -24.0671 -2.5
-      vertex 23.63 -24.275 -4.5
-      vertex 23.63 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 22.321 -23.3239 -4.5
-      vertex 22.5255 -23.2805 -2.5
-      vertex 22.321 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal 0.207917 -0.978146 0
-    outer loop
-      vertex 22.5255 -23.2805 -2.5
-      vertex 22.321 -23.3239 -4.5
-      vertex 22.5255 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 -0
-    outer loop
-      vertex 22.13 -25.141 -4.5
-      vertex 21.9609 -25.0181 -2.5
-      vertex 22.13 -25.141 -2.5
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 0
-    outer loop
-      vertex 21.9609 -25.0181 -2.5
-      vertex 22.13 -25.141 -4.5
-      vertex 21.9609 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 21.6519 -24.4829 -2.5
-      vertex 21.63 -24.275 -4.5
-      vertex 21.63 -24.275 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 21.63 -24.275 -4.5
-      vertex 21.6519 -24.4829 -2.5
-      vertex 21.6519 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal -0.743143 -0.669133 0
-    outer loop
-      vertex 23.439 -23.6872 -4.5
-      vertex 23.2991 -23.5319 -2.5
-      vertex 23.2991 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal -0.743143 -0.669133 0
-    outer loop
-      vertex 23.2991 -23.5319 -2.5
-      vertex 23.439 -23.6872 -4.5
-      vertex 23.439 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 21.6519 -24.0671 -2.5
-      vertex 21.7165 -23.8683 -4.5
-      vertex 21.7165 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 21.7165 -23.8683 -4.5
-      vertex 21.6519 -24.0671 -2.5
-      vertex 21.6519 -24.0671 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 0.309017 0
-    outer loop
-      vertex 23.5435 -24.6817 -4.5
-      vertex 23.6081 -24.4829 -2.5
-      vertex 23.6081 -24.4829 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 0.309017 0
-    outer loop
-      vertex 23.6081 -24.4829 -2.5
-      vertex 23.5435 -24.6817 -4.5
-      vertex 23.5435 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.499998 0
-    outer loop
-      vertex 23.439 -24.8628 -4.5
-      vertex 23.5435 -24.6817 -2.5
-      vertex 23.5435 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 0.499998 0
-    outer loop
-      vertex 23.5435 -24.6817 -2.5
-      vertex 23.439 -24.8628 -4.5
-      vertex 23.439 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal -0.743143 0.669133 0
-    outer loop
-      vertex 23.2991 -25.0181 -4.5
-      vertex 23.439 -24.8628 -2.5
-      vertex 23.439 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal -0.743143 0.669133 0
-    outer loop
-      vertex 23.439 -24.8628 -2.5
-      vertex 23.2991 -25.0181 -4.5
-      vertex 23.2991 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 23.2991 -25.0181 -4.5
-      vertex 23.13 -25.141 -2.5
-      vertex 23.2991 -25.0181 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 23.13 -25.141 -2.5
-      vertex 23.2991 -25.0181 -4.5
-      vertex 23.13 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal -0.207908 0.978148 0
-    outer loop
-      vertex 22.939 -25.2261 -4.5
-      vertex 22.7345 -25.2695 -2.5
-      vertex 22.939 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal -0.207908 0.978148 0
-    outer loop
-      vertex 22.7345 -25.2695 -2.5
-      vertex 22.939 -25.2261 -4.5
-      vertex 22.7345 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 -0
-    outer loop
-      vertex 22.5255 -25.2695 -4.5
-      vertex 22.321 -25.2261 -2.5
-      vertex 22.5255 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 0
-    outer loop
-      vertex 22.321 -25.2261 -2.5
-      vertex 22.5255 -25.2695 -4.5
-      vertex 22.321 -25.2261 -4.5
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 21.7165 -24.6817 -2.5
-      vertex 21.6519 -24.4829 -4.5
-      vertex 21.6519 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 0.309017 0
-    outer loop
-      vertex 21.6519 -24.4829 -4.5
-      vertex 21.7165 -24.6817 -2.5
-      vertex 21.7165 -24.6817 -4.5
-    endloop
-  endfacet
-  facet normal 0.743143 0.669133 0
-    outer loop
-      vertex 21.9609 -25.0181 -2.5
-      vertex 21.821 -24.8628 -4.5
-      vertex 21.821 -24.8628 -2.5
-    endloop
-  endfacet
-  facet normal 0.743143 0.669133 0
-    outer loop
-      vertex 21.821 -24.8628 -4.5
-      vertex 21.9609 -25.0181 -2.5
-      vertex 21.9609 -25.0181 -4.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 -0
-    outer loop
-      vertex 22.321 -25.2261 -4.5
-      vertex 22.13 -25.141 -2.5
-      vertex 22.321 -25.2261 -2.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 0
-    outer loop
-      vertex 22.13 -25.141 -2.5
-      vertex 22.321 -25.2261 -4.5
-      vertex 22.13 -25.141 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 21.821 -24.8628 -2.5
-      vertex 21.7165 -24.6817 -4.5
-      vertex 21.7165 -24.6817 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 0.499998 0
-    outer loop
-      vertex 21.7165 -24.6817 -4.5
-      vertex 21.821 -24.8628 -2.5
-      vertex 21.821 -24.8628 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 23.6081 -24.4829 -4.5
-      vertex 23.63 -24.275 -2.5
-      vertex 23.63 -24.275 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 23.63 -24.275 -2.5
-      vertex 23.6081 -24.4829 -4.5
-      vertex 23.6081 -24.4829 -2.5
-    endloop
-  endfacet
-  facet normal -0.207917 -0.978146 0
-    outer loop
-      vertex 22.7345 -23.2805 -4.5
-      vertex 22.939 -23.3239 -2.5
-      vertex 22.7345 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal -0.207917 -0.978146 -0
-    outer loop
-      vertex 22.939 -23.3239 -2.5
-      vertex 22.7345 -23.2805 -4.5
-      vertex 22.939 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 23.5435 -23.8683 -4.5
-      vertex 23.439 -23.6872 -2.5
-      vertex 23.439 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 23.439 -23.6872 -2.5
-      vertex 23.5435 -23.8683 -4.5
-      vertex 23.5435 -23.8683 -2.5
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 23.6081 -24.0671 -4.5
-      vertex 23.5435 -23.8683 -2.5
-      vertex 23.5435 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 23.5435 -23.8683 -2.5
-      vertex 23.6081 -24.0671 -4.5
-      vertex 23.6081 -24.0671 -2.5
-    endloop
-  endfacet
-  facet normal -0.406731 -0.913548 0
-    outer loop
-      vertex 22.939 -23.3239 -4.5
-      vertex 23.13 -23.409 -2.5
-      vertex 22.939 -23.3239 -2.5
-    endloop
-  endfacet
-  facet normal -0.406731 -0.913548 -0
-    outer loop
-      vertex 23.13 -23.409 -2.5
-      vertex 22.939 -23.3239 -4.5
-      vertex 23.13 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 0
-    outer loop
-      vertex 23.13 -23.409 -4.5
-      vertex 23.2991 -23.5319 -2.5
-      vertex 23.13 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 -0
-    outer loop
-      vertex 23.2991 -23.5319 -2.5
-      vertex 23.13 -23.409 -4.5
-      vertex 23.2991 -23.5319 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 22.5255 -23.2805 -4.5
-      vertex 22.7345 -23.2805 -2.5
-      vertex 22.5255 -23.2805 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 22.7345 -23.2805 -2.5
-      vertex 22.5255 -23.2805 -4.5
-      vertex 22.7345 -23.2805 -4.5
-    endloop
-  endfacet
-  facet normal 0.587787 -0.809016 0
-    outer loop
-      vertex 21.9609 -23.5319 -4.5
-      vertex 22.13 -23.409 -2.5
-      vertex 21.9609 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.587787 -0.809016 0
-    outer loop
-      vertex 22.13 -23.409 -2.5
-      vertex 21.9609 -23.5319 -4.5
-      vertex 22.13 -23.409 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 21.7165 -23.8683 -2.5
-      vertex 21.821 -23.6872 -4.5
-      vertex 21.821 -23.6872 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 21.821 -23.6872 -4.5
-      vertex 21.7165 -23.8683 -2.5
-      vertex 21.7165 -23.8683 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 22.7345 -25.2695 -4.5
-      vertex 22.5255 -25.2695 -2.5
-      vertex 22.7345 -25.2695 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 22.5255 -25.2695 -2.5
-      vertex 22.7345 -25.2695 -4.5
-      vertex 22.5255 -25.2695 -4.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 22.13 -23.409 -4.5
-      vertex 22.321 -23.3239 -2.5
-      vertex 22.13 -23.409 -2.5
-    endloop
-  endfacet
-  facet normal 0.406731 -0.913548 0
-    outer loop
-      vertex 22.321 -23.3239 -2.5
-      vertex 22.13 -23.409 -4.5
-      vertex 22.321 -23.3239 -4.5
-    endloop
-  endfacet
-  facet normal 0.743143 -0.669133 0
-    outer loop
-      vertex 21.821 -23.6872 -2.5
-      vertex 21.9609 -23.5319 -4.5
-      vertex 21.9609 -23.5319 -2.5
-    endloop
-  endfacet
-  facet normal 0.743143 -0.669133 0
-    outer loop
-      vertex 21.9609 -23.5319 -4.5
-      vertex 21.821 -23.6872 -2.5
-      vertex 21.821 -23.6872 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 23.6081 -21.9429 -4.5
-      vertex 23.63 -21.735 -2.5
-      vertex 23.63 -21.735 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 0.104529 0
-    outer loop
-      vertex 23.63 -21.735 -2.5
-      vertex 23.6081 -21.9429 -4.5
-      vertex 23.6081 -21.9429 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 21.6519 -21.9429 -2.5
-      vertex 21.63 -21.735 -4.5
-      vertex 21.63 -21.735 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 0.104529 0
-    outer loop
-      vertex 21.63 -21.735 -4.5
-      vertex 21.6519 -21.9429 -2.5
-      vertex 21.6519 -21.9429 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 22.7345 -22.7295 -4.5
-      vertex 22.5255 -22.7295 -2.5
-      vertex 22.7345 -22.7295 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 22.5255 -22.7295 -2.5
-      vertex 22.7345 -22.7295 -4.5
-      vertex 22.5255 -22.7295 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 22.5255 -20.7405 -4.5
-      vertex 22.7345 -20.7405 -2.5
-      vertex 22.5255 -20.7405 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 22.7345 -20.7405 -2.5
-      vertex 22.5255 -20.7405 -4.5
-      vertex 22.7345 -20.7405 -4.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 23.2991 -22.4781 -4.5
-      vertex 23.13 -22.601 -2.5
-      vertex 23.2991 -22.4781 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 0.809016 0
-    outer loop
-      vertex 23.13 -22.601 -2.5
-      vertex 23.2991 -22.4781 -4.5
-      vertex 23.13 -22.601 -4.5
-    endloop
-  endfacet
-  facet normal -0.406739 0.913545 0
-    outer loop
-      vertex 23.13 -22.601 -4.5
-      vertex 22.939 -22.6861 -2.5
-      vertex 23.13 -22.601 -2.5
-    endloop
-  endfacet
-  facet normal -0.406739 0.913545 0
-    outer loop
-      vertex 22.939 -22.6861 -2.5
-      vertex 23.13 -22.601 -4.5
-      vertex 22.939 -22.6861 -4.5
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 -0
-    outer loop
-      vertex 22.13 -22.601 -4.5
-      vertex 21.9609 -22.4781 -2.5
-      vertex 22.13 -22.601 -2.5
-    endloop
-  endfacet
-  facet normal 0.587787 0.809016 0
-    outer loop
-      vertex 21.9609 -22.4781 -2.5
-      vertex 22.13 -22.601 -4.5
-      vertex 21.9609 -22.4781 -4.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 -0
-    outer loop
-      vertex 22.5255 -22.7295 -4.5
-      vertex 22.321 -22.6861 -2.5
-      vertex 22.5255 -22.7295 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 0.978148 0
-    outer loop
-      vertex 22.321 -22.6861 -2.5
-      vertex 22.5255 -22.7295 -4.5
-      vertex 22.321 -22.6861 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 23.5435 -21.3283 -4.5
-      vertex 23.439 -21.1472 -2.5
-      vertex 23.439 -21.1472 -4.5
-    endloop
-  endfacet
-  facet normal -0.866026 -0.499998 0
-    outer loop
-      vertex 23.439 -21.1472 -2.5
-      vertex 23.5435 -21.3283 -4.5
-      vertex 23.5435 -21.3283 -2.5
-    endloop
-  endfacet
-  facet normal -0.866024 0.500002 0
-    outer loop
-      vertex 23.439 -22.3228 -4.5
-      vertex 23.5435 -22.1417 -2.5
-      vertex 23.5435 -22.1417 -4.5
-    endloop
-  endfacet
-  facet normal -0.866024 0.500002 0
-    outer loop
-      vertex 23.5435 -22.1417 -2.5
-      vertex 23.439 -22.3228 -4.5
-      vertex 23.439 -22.3228 -2.5
-    endloop
-  endfacet
-  facet normal -0.951057 0.309015 0
-    outer loop
-      vertex 23.5435 -22.1417 -4.5
-      vertex 23.6081 -21.9429 -2.5
-      vertex 23.6081 -21.9429 -4.5
-    endloop
-  endfacet
-  facet normal -0.951057 0.309015 0
-    outer loop
-      vertex 23.6081 -21.9429 -2.5
-      vertex 23.5435 -22.1417 -4.5
-      vertex 23.5435 -22.1417 -2.5
-    endloop
-  endfacet
-  facet normal -0.743143 0.669133 0
-    outer loop
-      vertex 23.2991 -22.4781 -4.5
-      vertex 23.439 -22.3228 -2.5
-      vertex 23.439 -22.3228 -4.5
-    endloop
-  endfacet
-  facet normal -0.743143 0.669133 0
-    outer loop
-      vertex 23.439 -22.3228 -2.5
-      vertex 23.2991 -22.4781 -4.5
-      vertex 23.2991 -22.4781 -2.5
-    endloop
-  endfacet
-  facet normal -0.207908 0.978148 0
-    outer loop
-      vertex 22.939 -22.6861 -4.5
-      vertex 22.7345 -22.7295 -2.5
-      vertex 22.939 -22.6861 -2.5
-    endloop
-  endfacet
-  facet normal -0.207908 0.978148 0
-    outer loop
-      vertex 22.7345 -22.7295 -2.5
-      vertex 22.939 -22.6861 -4.5
-      vertex 22.7345 -22.7295 -4.5
-    endloop
-  endfacet
-  facet normal 0.866024 0.500002 0
-    outer loop
-      vertex 21.821 -22.3228 -2.5
-      vertex 21.7165 -22.1417 -4.5
-      vertex 21.7165 -22.1417 -2.5
-    endloop
-  endfacet
-  facet normal 0.866024 0.500002 0
-    outer loop
-      vertex 21.7165 -22.1417 -4.5
-      vertex 21.821 -22.3228 -2.5
-      vertex 21.821 -22.3228 -4.5
-    endloop
-  endfacet
-  facet normal 0.743143 0.669133 0
-    outer loop
-      vertex 21.9609 -22.4781 -2.5
-      vertex 21.821 -22.3228 -4.5
-      vertex 21.821 -22.3228 -2.5
-    endloop
-  endfacet
-  facet normal 0.743143 0.669133 0
-    outer loop
-      vertex 21.821 -22.3228 -4.5
-      vertex 21.9609 -22.4781 -2.5
-      vertex 21.9609 -22.4781 -4.5
-    endloop
-  endfacet
-  facet normal 0.951057 0.309015 0
-    outer loop
-      vertex 21.7165 -22.1417 -2.5
-      vertex 21.6519 -21.9429 -4.5
-      vertex 21.6519 -21.9429 -2.5
-    endloop
-  endfacet
-  facet normal 0.951057 0.309015 0
-    outer loop
-      vertex 21.6519 -21.9429 -4.5
-      vertex 21.7165 -22.1417 -2.5
-      vertex 21.7165 -22.1417 -4.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 -0
-    outer loop
-      vertex 22.321 -22.6861 -4.5
-      vertex 22.13 -22.601 -2.5
-      vertex 22.321 -22.6861 -2.5
-    endloop
-  endfacet
-  facet normal 0.406739 0.913545 0
-    outer loop
-      vertex 22.13 -22.601 -2.5
-      vertex 22.321 -22.6861 -4.5
-      vertex 22.13 -22.601 -4.5
-    endloop
-  endfacet
-  facet normal -0.207908 -0.978148 0
-    outer loop
-      vertex 22.7345 -20.7405 -4.5
-      vertex 22.939 -20.7839 -2.5
-      vertex 22.7345 -20.7405 -2.5
-    endloop
-  endfacet
-  facet normal -0.207908 -0.978148 -0
-    outer loop
-      vertex 22.939 -20.7839 -2.5
-      vertex 22.7345 -20.7405 -4.5
-      vertex 22.939 -20.7839 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 23.6081 -21.5271 -4.5
-      vertex 23.5435 -21.3283 -2.5
-      vertex 23.5435 -21.3283 -4.5
-    endloop
-  endfacet
-  facet normal -0.951056 -0.309017 0
-    outer loop
-      vertex 23.5435 -21.3283 -2.5
-      vertex 23.6081 -21.5271 -4.5
-      vertex 23.6081 -21.5271 -2.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 23.63 -21.735 -4.5
-      vertex 23.6081 -21.5271 -2.5
-      vertex 23.6081 -21.5271 -4.5
-    endloop
-  endfacet
-  facet normal -0.994522 -0.104529 0
-    outer loop
-      vertex 23.6081 -21.5271 -2.5
-      vertex 23.63 -21.735 -4.5
-      vertex 23.63 -21.735 -2.5
-    endloop
-  endfacet
-  facet normal 0.587787 -0.809016 0
-    outer loop
-      vertex 21.9609 -20.9919 -4.5
-      vertex 22.13 -20.869 -2.5
-      vertex 21.9609 -20.9919 -2.5
-    endloop
-  endfacet
-  facet normal 0.587787 -0.809016 0
-    outer loop
-      vertex 22.13 -20.869 -2.5
-      vertex 21.9609 -20.9919 -4.5
-      vertex 22.13 -20.869 -4.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 21.7165 -21.3283 -2.5
-      vertex 21.821 -21.1472 -4.5
-      vertex 21.821 -21.1472 -2.5
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499998 0
-    outer loop
-      vertex 21.821 -21.1472 -4.5
-      vertex 21.7165 -21.3283 -2.5
-      vertex 21.7165 -21.3283 -4.5
-    endloop
-  endfacet
-  facet normal 0.743143 -0.669133 0
-    outer loop
-      vertex 21.821 -21.1472 -2.5
-      vertex 21.9609 -20.9919 -4.5
-      vertex 21.9609 -20.9919 -2.5
-    endloop
-  endfacet
-  facet normal 0.743143 -0.669133 0
-    outer loop
-      vertex 21.9609 -20.9919 -4.5
-      vertex 21.821 -21.1472 -2.5
-      vertex 21.821 -21.1472 -4.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 0
-    outer loop
-      vertex 23.13 -20.869 -4.5
-      vertex 23.2991 -20.9919 -2.5
-      vertex 23.13 -20.869 -2.5
-    endloop
-  endfacet
-  facet normal -0.587787 -0.809016 -0
-    outer loop
-      vertex 23.2991 -20.9919 -2.5
-      vertex 23.13 -20.869 -4.5
-      vertex 23.2991 -20.9919 -4.5
-    endloop
-  endfacet
-  facet normal -0.406739 -0.913545 0
-    outer loop
-      vertex 22.939 -20.7839 -4.5
-      vertex 23.13 -20.869 -2.5
-      vertex 22.939 -20.7839 -2.5
-    endloop
-  endfacet
-  facet normal -0.406739 -0.913545 -0
-    outer loop
-      vertex 23.13 -20.869 -2.5
-      vertex 22.939 -20.7839 -4.5
-      vertex 23.13 -20.869 -4.5
-    endloop
-  endfacet
-  facet normal 0.207908 -0.978148 0
-    outer loop
-      vertex 22.321 -20.7839 -4.5
-      vertex 22.5255 -20.7405 -2.5
-      vertex 22.321 -20.7839 -2.5
-    endloop
-  endfacet
-  facet normal 0.207908 -0.978148 0
-    outer loop
-      vertex 22.5255 -20.7405 -2.5
-      vertex 22.321 -20.7839 -4.5
-      vertex 22.5255 -20.7405 -4.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 21.6519 -21.5271 -2.5
-      vertex 21.7165 -21.3283 -4.5
-      vertex 21.7165 -21.3283 -2.5
-    endloop
-  endfacet
-  facet normal 0.951056 -0.309017 0
-    outer loop
-      vertex 21.7165 -21.3283 -4.5
-      vertex 21.6519 -21.5271 -2.5
-      vertex 21.6519 -21.5271 -4.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 21.63 -21.735 -2.5
-      vertex 21.6519 -21.5271 -4.5
-      vertex 21.6519 -21.5271 -2.5
-    endloop
-  endfacet
-  facet normal 0.994522 -0.104529 0
-    outer loop
-      vertex 21.6519 -21.5271 -4.5
-      vertex 21.63 -21.735 -2.5
-      vertex 21.63 -21.735 -4.5
-    endloop
-  endfacet
-  facet normal -0.743143 -0.669133 0
-    outer loop
-      vertex 23.439 -21.1472 -4.5
-      vertex 23.2991 -20.9919 -2.5
-      vertex 23.2991 -20.9919 -4.5
-    endloop
-  endfacet
-  facet normal -0.743143 -0.669133 0
-    outer loop
-      vertex 23.2991 -20.9919 -2.5
-      vertex 23.439 -21.1472 -4.5
-      vertex 23.439 -21.1472 -2.5
-    endloop
-  endfacet
-  facet normal 0.406739 -0.913545 0
-    outer loop
-      vertex 22.13 -20.869 -4.5
-      vertex 22.321 -20.7839 -2.5
-      vertex 22.13 -20.869 -2.5
-    endloop
-  endfacet
-  facet normal 0.406739 -0.913545 0
-    outer loop
-      vertex 22.321 -20.7839 -2.5
-      vertex 22.13 -20.869 -4.5
-      vertex 22.321 -20.7839 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.2625 -23.5492 -2.5
-      vertex 48.5 -23.7869 -2.5
-      vertex 48.4295 -23.7357 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.5 -23.7869 -2.5
-      vertex 48.2625 -23.5492 -2.5
-      vertex 48.5 -21.9013 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.1366 -23.3324 -2.5
-      vertex 48.5 -21.9013 -2.5
-      vertex 48.2625 -23.5492 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.5 -21.9013 -2.5
-      vertex 48.2625 -22.139 -2.5
-      vertex 48.4295 -21.9525 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.5 -21.9013 -2.5
-      vertex 48.1366 -23.3324 -2.5
-      vertex 48.2625 -22.139 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.1366 -23.3324 -2.5
-      vertex 48.1366 -22.3558 -2.5
-      vertex 48.2625 -22.139 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -23.0931 -2.5
-      vertex 48.1366 -22.3558 -2.5
-      vertex 48.1366 -23.3324 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 48.0594 -23.0931 -2.5
-      vertex 48.0594 -22.5951 -2.5
-      vertex 48.1366 -22.3558 -2.5
+      vertex 61.5 0.5 0
+      vertex 64.2716 2.35195 0
+      vertex 63.9944 1.83329 0
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex 48.0594 -22.5951 -2.5
-      vertex 48.0594 -23.0931 -2.5
-      vertex 48.033 -22.8441 -2.5
+      vertex 61.5 29.5 0
+      vertex 64.5 26.5 0
+      vertex 58.5 23.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.7954 -26 -2.5
-      vertex 52.9725 -25.3841 -2.5
-      vertex 52.9471 -25.6332 -2.5
+      vertex 61.5 0.5 0
+      vertex 63.9944 1.83329 0
+      vertex 63.6213 1.37868 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.7954 -26 -2.5
-      vertex 52.9471 -25.6332 -2.5
-      vertex 52.869 -25.8724 -2.5
+      vertex 64.5 26.5 0
+      vertex 61.5 29.5 0
+      vertex 64.4424 27.0853 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.5 0.5 0
+      vertex 63.6213 1.37868 0
+      vertex 63.1667 1.00559 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.4424 27.0853 0
+      vertex 61.5 29.5 0
+      vertex 64.2716 27.648 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.5 0.5 0
+      vertex 63.1667 1.00559 0
+      vertex 62.648 0.728361 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 64.2716 27.648 0
+      vertex 61.5 29.5 0
+      vertex 63.9944 28.1667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 61.5 0.5 0
+      vertex 62.648 0.728361 0
+      vertex 62.0853 0.557644 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.9944 28.1667 0
+      vertex 61.5 29.5 0
+      vertex 63.6213 28.6213 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 52.9725 -25.3841 -2.5
-      vertex 52.7954 -26 -2.5
-      vertex 52.9471 -25.1341 -2.5
+      vertex 64.5 3.5 0
+      vertex 61.5 0.5 0
+      vertex 58.5 6.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.6213 28.6213 0
+      vertex 61.5 29.5 0
+      vertex 63.1667 28.9944 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 63.1667 28.9944 0
+      vertex 61.5 29.5 0
+      vertex 62.648 29.2716 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 56.49 0.5 0
+      vertex 58.5 6.5 0
+      vertex 61.5 0.5 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 52.9471 -25.1341 -2.5
-      vertex 52.7954 -26 -2.5
-      vertex 52.869 -24.8959 -2.5
+      vertex 58.5 6.5 0
+      vertex 56.49 0.5 0
+      vertex 56.49 6.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.5 -24.4374 -2.5
-      vertex 52.869 -24.8959 -2.5
-      vertex 52.7954 -26 -2.5
+      vertex 62.648 29.2716 0
+      vertex 61.5 29.5 0
+      vertex 62.0853 29.4424 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.869 -24.8959 -2.5
-      vertex 52.5 -24.4374 -2.5
-      vertex 52.744 -24.6791 -2.5
+      vertex 58.5 23.5 0
+      vertex 57.7 29.5 0
+      vertex 61.5 29.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.744 -24.6791 -2.5
-      vertex 52.5 -24.4374 -2.5
-      vertex 52.576 -24.4925 -2.5
+      vertex 55.95 31.5 0
+      vertex 57.7 30.5 0
+      vertex 57.7 29.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.5 -23.7869 -2.5
-      vertex 52.5 -23.7909 -2.5
-      vertex 52.5 -24.4374 -2.5
+      vertex 57.7 30.5 0
+      vertex 56.7 31.5 0
+      vertex 57.6808 30.6951 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.5 -23.7909 -2.5
-      vertex 48.5 -23.7869 -2.5
-      vertex 52.5 -21.8973 -2.5
+      vertex 57.6808 30.6951 0
+      vertex 56.7 31.5 0
+      vertex 57.6239 30.8827 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.5 -23.7869 -2.5
-      vertex 52.5 -24.4374 -2.5
-      vertex 48.5 -24.4414 -2.5
+      vertex 57.6239 30.8827 0
+      vertex 56.7 31.5 0
+      vertex 57.5315 31.0556 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.7954 -26 -2.5
-      vertex 48.5 -24.4414 -2.5
-      vertex 52.5 -24.4374 -2.5
+      vertex 55.95 25.7 0
+      vertex 57.7 29.5 0
+      vertex 58.5 23.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.2107 -26 -2.5
-      vertex 48.5 -24.4414 -2.5
-      vertex 52.7954 -26 -2.5
+      vertex 55.95 31.5 0
+      vertex 57.7 29.5 0
+      vertex 55.95 25.7 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.7 30.5 0
+      vertex 55.95 31.5 0
+      vertex 56.7 31.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.5315 31.0556 0
+      vertex 56.7 31.5 0
+      vertex 57.4071 31.2071 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.2556 31.3315 0
+      vertex 56.7 31.5 0
+      vertex 57.0827 31.4239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.0827 31.4239 0
+      vertex 56.7 31.5 0
+      vertex 56.8951 31.4808 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5 23.5 0
+      vertex 55.926 25.4561 0
+      vertex 55.95 25.7 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5 23.5 0
+      vertex 55.8549 25.2216 0
+      vertex 55.926 25.4561 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5 23.5 0
+      vertex 55.7393 25.0055 0
+      vertex 55.8549 25.2216 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5 23.5 0
+      vertex 55.5839 24.8161 0
+      vertex 55.7393 25.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5 23.5 0
+      vertex 55.3945 24.6607 0
+      vertex 55.5839 24.8161 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5 23.5 0
+      vertex 55.1784 24.5452 0
+      vertex 55.3945 24.6607 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5 23.5 0
+      vertex 54.9439 24.474 0
+      vertex 55.1784 24.5452 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 58.5 23.5 0
+      vertex 54.7 24.45 0
+      vertex 54.9439 24.474 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 23.5 0
+      vertex 54.7 24.45 0
+      vertex 58.5 23.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.7 29.5 0
+      vertex 53.45 31.5 0
+      vertex 53.45 25.7 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 25.7 0
+      vertex 53.45 25.7 0
+      vertex 53.474 25.4561 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.7 30.5 0
+      vertex 53.45 31.5 0
+      vertex 51.7 29.5 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 53.45 31.5 0
+      vertex 51.7 30.5 0
+      vertex 52.7 31.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 52.7 31.5 0
+      vertex 51.7 30.5 0
+      vertex 52.5049 31.4808 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 52.5049 31.4808 0
+      vertex 51.7 30.5 0
+      vertex 52.3173 31.4239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 52.3173 31.4239 0
+      vertex 51.7 30.5 0
+      vertex 52.1444 31.3315 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 52.1444 31.3315 0
+      vertex 51.7 30.5 0
+      vertex 51.9929 31.2071 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 25.7 0
+      vertex 53.474 25.4561 0
+      vertex 53.5452 25.2216 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.9929 31.2071 0
+      vertex 51.7 30.5 0
+      vertex 51.8685 31.0556 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.8685 31.0556 0
+      vertex 51.7 30.5 0
+      vertex 51.7761 30.8827 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 54.7 24.45 0
+      vertex 49.6 23.5 0
+      vertex 54.4561 24.474 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 23.5 0
+      vertex 54.2216 24.5452 0
+      vertex 54.4561 24.474 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 23.5 0
+      vertex 54.0055 24.6607 0
+      vertex 54.2216 24.5452 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 23.5 0
+      vertex 53.8161 24.8161 0
+      vertex 54.0055 24.6607 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 23.5 0
+      vertex 53.6607 25.0055 0
+      vertex 53.8161 24.8161 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 23.5 0
+      vertex 53.5452 25.2216 0
+      vertex 53.6607 25.0055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 25.7 0
+      vertex 53.5452 25.2216 0
+      vertex 49.6 23.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 0
+      vertex 49.6 25.7 0
+      vertex 49.576 25.9439 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 0
+      vertex 49.576 25.9439 0
+      vertex 49.5048 26.1784 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 0
+      vertex 49.5048 26.1784 0
+      vertex 51.7 29.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.3893 26.3945 0
+      vertex 51.7 29.5 0
+      vertex 49.5048 26.1784 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.2339 26.5839 0
+      vertex 51.7 29.5 0
+      vertex 49.3893 26.3945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.0445 26.7393 0
+      vertex 51.7 29.5 0
+      vertex 49.2339 26.5839 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.8284 26.8549 0
+      vertex 51.7 29.5 0
+      vertex 49.0445 26.7393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.5939 26.926 0
+      vertex 51.7 29.5 0
+      vertex 48.8284 26.8549 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.35 26.95 0
+      vertex 51.7 29.5 0
+      vertex 48.5939 26.926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.1061 26.926 0
+      vertex 51.7 29.5 0
+      vertex 48.35 26.95 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.8716 26.8549 0
+      vertex 51.7 29.5 0
+      vertex 48.1061 26.926 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.6555 26.7393 0
+      vertex 51.7 29.5 0
+      vertex 47.8716 26.8549 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.5 23.5 0
+      vertex 47.124 25.9439 0
+      vertex 47.1 25.7 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.5 23.5 0
+      vertex 47.1952 26.1784 0
+      vertex 47.124 25.9439 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.5 29.5 0
+      vertex 47.1952 26.1784 0
+      vertex 6.5 23.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.1952 26.1784 0
+      vertex 3.5 29.5 0
+      vertex 47.3107 26.3945 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.3107 26.3945 0
+      vertex 3.5 29.5 0
+      vertex 47.4661 26.5839 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.4661 26.5839 0
+      vertex 3.5 29.5 0
+      vertex 47.6555 26.7393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.6555 26.7393 0
+      vertex 3.5 29.5 0
+      vertex 51.7 29.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 57.4071 31.2071 0
+      vertex 56.7 31.5 0
+      vertex 57.2556 31.3315 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.7761 30.8827 0
+      vertex 51.7 30.5 0
+      vertex 51.7192 30.6951 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.03934 20.9055 0
+      vertex 6.5 23.5 0
+      vertex 6.5 12.79 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.25 24.14 0
+      vertex 6.5 23.5 0
+      vertex 1.25 21.6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.15485 24.6184 0
+      vertex 6.5 23.5 0
+      vertex 1.22598 24.3839 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.5 23.5 0
+      vertex 1.15485 24.6184 0
+      vertex 3.5 29.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.03934 24.8345 0
+      vertex 3.5 29.5 0
+      vertex 1.15485 24.6184 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.22598 24.3839 0
+      vertex 6.5 23.5 0
+      vertex 1.25 24.14 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.5 23.5 0
+      vertex 1.22598 21.3561 0
+      vertex 1.25 21.6 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.5 23.5 0
+      vertex 1.15485 21.1216 0
+      vertex 1.22598 21.3561 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.5 23.5 0
+      vertex 1.03934 20.9055 0
+      vertex 1.15485 21.1216 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.5 12.79 0
+      vertex 0.883883 20.7161 0
+      vertex 1.03934 20.9055 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 6.5 12.79 0
+      vertex 0.694463 20.5607 0
+      vertex 0.883883 20.7161 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 12.79 0
+      vertex 0.694463 20.5607 0
+      vertex 6.5 12.79 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.694463 20.5607 0
+      vertex 0.5 12.79 0
+      vertex 0.5 20.4567 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.5 29.5 0
+      vertex 1.03934 24.8345 0
+      vertex 2.91473 29.4424 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.91473 29.4424 0
+      vertex 1.03934 24.8345 0
+      vertex 2.35195 29.2716 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.35195 29.2716 0
+      vertex 1.03934 24.8345 0
+      vertex 1.83329 28.9944 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.83329 28.9944 0
+      vertex 1.03934 24.8345 0
+      vertex 1.37868 28.6213 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.03934 24.8345 0
+      vertex 1.00559 28.1667 0
+      vertex 1.37868 28.6213 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 26.5 0
+      vertex 1.03934 24.8345 0
+      vertex 0.883883 25.0239 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.03934 24.8345 0
+      vertex 0.728361 27.648 0
+      vertex 1.00559 28.1667 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 26.5 0
+      vertex 0.883883 25.0239 0
+      vertex 0.694463 25.1793 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.03934 24.8345 0
+      vertex 0.5 26.5 0
+      vertex 0.728361 27.648 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 26.5 0
+      vertex 0.694463 25.1793 0
+      vertex 0.5 25.2833 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.728361 27.648 0
+      vertex 0.5 26.5 0
+      vertex 0.557644 27.0853 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8891 2.53615 0
+      vertex 32.774 3.75614 0
+      vertex 26.9346 2.38607 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.774 3.75614 0
+      vertex 26.9346 4.61393 0
+      vertex 26.95 4.77 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8891 4.46385 0
+      vertex 32.774 3.75614 0
+      vertex 26.8891 2.53615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.774 3.75614 0
+      vertex 26.8891 4.46385 0
+      vertex 26.9346 4.61393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8152 2.67446 0
+      vertex 26.8891 4.46385 0
+      vertex 26.8891 2.53615 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8152 2.67446 0
+      vertex 26.8152 4.32554 0
+      vertex 26.8891 4.46385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7157 2.79569 0
+      vertex 26.8152 4.32554 0
+      vertex 26.8152 2.67446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7157 2.79569 0
+      vertex 26.7157 4.20431 0
+      vertex 26.8152 4.32554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5945 2.89518 0
+      vertex 26.7157 4.20431 0
+      vertex 26.7157 2.79569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5945 2.89518 0
+      vertex 26.5945 4.10482 0
+      vertex 26.7157 4.20431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4561 2.9691 0
+      vertex 26.5945 4.10482 0
+      vertex 26.5945 2.89518 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.4561 2.9691 0
+      vertex 26.4561 4.0309 0
+      vertex 26.5945 4.10482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.3061 3.01463 0
+      vertex 26.4561 4.0309 0
+      vertex 26.4561 2.9691 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.3061 3.01463 0
+      vertex 26.3061 3.98537 0
+      vertex 26.4561 4.0309 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.15 3.03 0
+      vertex 26.3061 3.98537 0
+      vertex 26.3061 3.01463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.15 3.03 0
+      vertex 26.15 3.97 0
+      vertex 26.3061 3.98537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.9939 3.01463 0
+      vertex 26.15 3.97 0
+      vertex 26.15 3.03 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.9939 3.01463 0
+      vertex 25.9939 3.98537 0
+      vertex 26.15 3.97 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.8439 2.9691 0
+      vertex 25.9939 3.98537 0
+      vertex 25.9939 3.01463 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.8439 2.9691 0
+      vertex 25.8439 4.0309 0
+      vertex 25.9939 3.98537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7055 2.89518 0
+      vertex 25.8439 4.0309 0
+      vertex 25.8439 2.9691 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7055 2.89518 0
+      vertex 25.7055 4.10482 0
+      vertex 25.8439 4.0309 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.5843 2.79569 0
+      vertex 25.7055 4.10482 0
+      vertex 25.7055 2.89518 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.5843 2.79569 0
+      vertex 25.5843 4.20431 0
+      vertex 25.7055 4.10482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4848 2.67446 0
+      vertex 25.5843 4.20431 0
+      vertex 25.5843 2.79569 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4848 2.67446 0
+      vertex 25.4848 4.32554 0
+      vertex 25.5843 4.20431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4109 2.53615 0
+      vertex 25.4848 4.32554 0
+      vertex 25.4848 2.67446 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4109 2.53615 0
+      vertex 25.4109 4.46385 0
+      vertex 25.4848 4.32554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.2691 2.53615 0
+      vertex 25.4109 2.53615 0
+      vertex 25.3654 2.38607 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4109 2.53615 0
+      vertex 19.2691 2.53615 0
+      vertex 25.4109 4.46385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3146 2.38607 0
+      vertex 25.3654 2.38607 0
+      vertex 25.35 2.23 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 25.4109 4.46385 0
+      vertex 19.2691 2.53615 0
+      vertex 25.3654 4.61393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 45.41 4 0
+      vertex 51.45 6.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 45.386 3.75614 0
+      vertex 45.41 4 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 45.3148 3.52165 0
+      vertex 45.386 3.75614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 45.1993 3.30554 0
+      vertex 45.3148 3.52165 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 45.0439 3.11612 0
+      vertex 45.1993 3.30554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 44.8545 2.96066 0
+      vertex 45.0439 3.11612 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 44.6384 2.84515 0
+      vertex 44.8545 2.96066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 44.4039 2.77402 0
+      vertex 44.6384 2.84515 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 44.16 2.75 0
+      vertex 44.4039 2.77402 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 34 2.75 0
+      vertex 44.16 2.75 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.3061 1.44537 0
+      vertex 34 2.75 0
+      vertex 51.45 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.774 3.75614 0
+      vertex 26.95 4.77 0
+      vertex 32.75 4 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 32.8451 3.52165 0
+      vertex 26.9346 2.38607 0
+      vertex 32.774 3.75614 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.9346 2.38607 0
+      vertex 32.8451 3.52165 0
+      vertex 26.95 2.23 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 32.9607 3.30554 0
+      vertex 26.95 2.23 0
+      vertex 32.8451 3.52165 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.9346 2.07393 0
+      vertex 32.9607 3.30554 0
+      vertex 33.1161 3.11612 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.8152 1.78554 0
+      vertex 33.1161 3.11612 0
+      vertex 33.3055 2.96066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.7157 1.66431 0
+      vertex 33.3055 2.96066 0
+      vertex 33.5216 2.84515 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.5945 1.56482 0
+      vertex 33.5216 2.84515 0
+      vertex 33.7561 2.77402 0
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex 48.2625 -24.6791 -2.5
-      vertex 48.5 -24.4414 -2.5
-      vertex 48.2107 -26 -2.5
+      vertex 26.4561 1.4909 0
+      vertex 34 2.75 0
+      vertex 26.3061 1.44537 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.5 -24.4414 -2.5
-      vertex 48.2625 -24.6791 -2.5
-      vertex 48.4295 -24.4925 -2.5
+      vertex 32.9607 3.30554 0
+      vertex 26.9346 2.07393 0
+      vertex 26.95 2.23 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.0594 -25.6332 -2.5
-      vertex 48.2107 -26 -2.5
-      vertex 48.1366 -25.8724 -2.5
+      vertex 33.1161 3.11612 0
+      vertex 26.8891 1.92385 0
+      vertex 26.9346 2.07393 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.2107 -26 -2.5
-      vertex 48.1366 -24.8959 -2.5
-      vertex 48.2625 -24.6791 -2.5
+      vertex 33.1161 3.11612 0
+      vertex 26.8152 1.78554 0
+      vertex 26.8891 1.92385 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.0594 -25.1341 -2.5
-      vertex 48.2107 -26 -2.5
-      vertex 48.0594 -25.6332 -2.5
+      vertex 33.3055 2.96066 0
+      vertex 26.7157 1.66431 0
+      vertex 26.8152 1.78554 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.2107 -26 -2.5
-      vertex 48.0594 -25.1341 -2.5
-      vertex 48.1366 -24.8959 -2.5
+      vertex 33.5216 2.84515 0
+      vertex 26.5945 1.56482 0
+      vertex 26.7157 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 33.7561 2.77402 0
+      vertex 26.4561 1.4909 0
+      vertex 26.5945 1.56482 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 34 2.75 0
+      vertex 26.4561 1.4909 0
+      vertex 33.7561 2.77402 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 0
+      vertex 26.15 1.43 0
+      vertex 26.3061 1.44537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3146 2.38607 0
+      vertex 25.35 2.23 0
+      vertex 19.33 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3654 2.07393 0
+      vertex 19.33 2.23 0
+      vertex 25.35 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.3146 2.07393 0
+      vertex 25.3654 2.07393 0
+      vertex 25.4109 1.92385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.2691 1.92385 0
+      vertex 25.4109 1.92385 0
+      vertex 25.4848 1.78554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.1952 1.78554 0
+      vertex 25.4848 1.78554 0
+      vertex 25.5843 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 19.0957 1.66431 0
+      vertex 25.5843 1.66431 0
+      vertex 25.7055 1.56482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.9745 1.56482 0
+      vertex 25.7055 1.56482 0
+      vertex 25.8439 1.4909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.8361 1.4909 0
+      vertex 25.8439 1.4909 0
+      vertex 25.9939 1.44537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.3654 2.07393 0
+      vertex 19.3146 2.07393 0
+      vertex 19.33 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.6861 1.44537 0
+      vertex 25.9939 1.44537 0
+      vertex 26.15 1.43 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4109 1.92385 0
+      vertex 19.2691 1.92385 0
+      vertex 19.3146 2.07393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.4848 1.78554 0
+      vertex 19.1952 1.78554 0
+      vertex 19.2691 1.92385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.5843 1.66431 0
+      vertex 19.0957 1.66431 0
+      vertex 19.1952 1.78554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.85 0.5 0
+      vertex 26.15 1.43 0
+      vertex 51.45 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.7055 1.56482 0
+      vertex 18.9745 1.56482 0
+      vertex 19.0957 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.8439 1.4909 0
+      vertex 18.8361 1.4909 0
+      vertex 18.9745 1.56482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 25.9939 1.44537 0
+      vertex 18.6861 1.44537 0
+      vertex 18.8361 1.4909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 26.15 1.43 0
+      vertex 18.53 1.43 0
+      vertex 18.6861 1.44537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.7454 2.07393 0
+      vertex 16.79 2.23 0
+      vertex 17.73 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7746 2.07393 0
+      vertex 17.7454 2.07393 0
+      vertex 17.7909 1.92385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.7291 1.92385 0
+      vertex 17.7909 1.92385 0
+      vertex 17.8648 1.78554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.6552 1.78554 0
+      vertex 17.8648 1.78554 0
+      vertex 17.9643 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.5557 1.66431 0
+      vertex 17.9643 1.66431 0
+      vertex 18.0855 1.56482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.4345 1.56482 0
+      vertex 18.0855 1.56482 0
+      vertex 18.2239 1.4909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.7454 2.07393 0
+      vertex 16.7746 2.07393 0
+      vertex 16.79 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.7909 1.92385 0
+      vertex 16.7291 1.92385 0
+      vertex 16.7746 2.07393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.2961 1.4909 0
+      vertex 18.2239 1.4909 0
+      vertex 18.3739 1.44537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.8648 1.78554 0
+      vertex 16.6552 1.78554 0
+      vertex 16.7291 1.92385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 17.9643 1.66431 0
+      vertex 16.5557 1.66431 0
+      vertex 16.6552 1.78554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.0855 1.56482 0
+      vertex 16.4345 1.56482 0
+      vertex 16.5557 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 16.1461 1.44537 0
+      vertex 18.3739 1.44537 0
+      vertex 18.53 1.43 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.2239 1.4909 0
+      vertex 16.2961 1.4909 0
+      vertex 16.4345 1.56482 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 26.15 1.43 0
+      vertex 4.85 0.5 0
+      vertex 18.53 1.43 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.3739 1.44537 0
+      vertex 16.1461 1.44537 0
+      vertex 16.2961 1.4909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 18.53 1.43 0
+      vertex 15.99 1.43 0
+      vertex 16.1461 1.44537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.2054 2.07393 0
+      vertex 14.25 2.23 0
+      vertex 15.19 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.2346 2.07393 0
+      vertex 15.2054 2.07393 0
+      vertex 15.2509 1.92385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1891 1.92385 0
+      vertex 15.2509 1.92385 0
+      vertex 15.3248 1.78554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.1152 1.78554 0
+      vertex 15.3248 1.78554 0
+      vertex 15.4243 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 14.0157 1.66431 0
+      vertex 15.4243 1.66431 0
+      vertex 15.5455 1.56482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.8945 1.56482 0
+      vertex 15.5455 1.56482 0
+      vertex 15.6839 1.4909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.2054 2.07393 0
+      vertex 14.2346 2.07393 0
+      vertex 14.25 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.2509 1.92385 0
+      vertex 14.1891 1.92385 0
+      vertex 14.2346 2.07393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.7561 1.4909 0
+      vertex 15.6839 1.4909 0
+      vertex 15.8339 1.44537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.3248 1.78554 0
+      vertex 14.1152 1.78554 0
+      vertex 14.1891 1.92385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.4243 1.66431 0
+      vertex 14.0157 1.66431 0
+      vertex 14.1152 1.78554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.5455 1.56482 0
+      vertex 13.8945 1.56482 0
+      vertex 14.0157 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.6061 1.44537 0
+      vertex 15.8339 1.44537 0
+      vertex 15.99 1.43 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.6839 1.4909 0
+      vertex 13.7561 1.4909 0
+      vertex 13.8945 1.56482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.8339 1.44537 0
+      vertex 13.6061 1.44537 0
+      vertex 13.7561 1.4909 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 18.53 1.43 0
+      vertex 4.85 0.5 0
+      vertex 15.99 1.43 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 15.99 1.43 0
+      vertex 13.45 1.43 0
+      vertex 13.6061 1.44537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6654 2.07393 0
+      vertex 11.71 2.23 0
+      vertex 12.65 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6946 2.07393 0
+      vertex 12.6654 2.07393 0
+      vertex 12.7109 1.92385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.6491 1.92385 0
+      vertex 12.7109 1.92385 0
+      vertex 12.7848 1.78554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.5752 1.78554 0
+      vertex 12.7848 1.78554 0
+      vertex 12.8843 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.4757 1.66431 0
+      vertex 12.8843 1.66431 0
+      vertex 13.0055 1.56482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.3545 1.56482 0
+      vertex 13.0055 1.56482 0
+      vertex 13.1439 1.4909 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.6654 2.07393 0
+      vertex 11.6946 2.07393 0
+      vertex 11.71 2.23 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.7109 1.92385 0
+      vertex 11.6491 1.92385 0
+      vertex 11.6946 2.07393 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.2161 1.4909 0
+      vertex 13.1439 1.4909 0
+      vertex 13.2939 1.44537 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.7848 1.78554 0
+      vertex 11.5752 1.78554 0
+      vertex 11.6491 1.92385 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 12.8843 1.66431 0
+      vertex 11.4757 1.66431 0
+      vertex 11.5752 1.78554 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.0055 1.56482 0
+      vertex 11.3545 1.56482 0
+      vertex 11.4757 1.66431 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 11.0661 1.44537 0
+      vertex 13.2939 1.44537 0
+      vertex 13.45 1.43 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.1439 1.4909 0
+      vertex 11.2161 1.4909 0
+      vertex 11.3545 1.56482 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 13.2939 1.44537 0
+      vertex 11.0661 1.44537 0
+      vertex 11.2161 1.4909 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 15.99 1.43 0
+      vertex 4.85 0.5 0
+      vertex 13.45 1.43 0
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex 48.0594 -25.1341 -2.5
-      vertex 48.0594 -25.6332 -2.5
-      vertex 48.033 -25.3841 -2.5
+      vertex 10.91 1.43 0
+      vertex 13.45 1.43 0
+      vertex 4.85 0.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.9471 -23.0931 -2.5
-      vertex 52.9471 -22.5951 -2.5
-      vertex 52.9725 -22.8441 -2.5
+      vertex 4.85 2.24 0
+      vertex 10.11 2.23 0
+      vertex 10.1254 2.07393 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.869 -23.3324 -2.5
-      vertex 52.9471 -22.5951 -2.5
-      vertex 52.9471 -23.0931 -2.5
+      vertex 4.85 0.5 0
+      vertex 10.1254 2.07393 0
+      vertex 10.1709 1.92385 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.869 -23.3324 -2.5
-      vertex 52.869 -22.3558 -2.5
-      vertex 52.9471 -22.5951 -2.5
+      vertex 4.85 0.5 0
+      vertex 10.1709 1.92385 0
+      vertex 10.2448 1.78554 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.5 -23.7909 -2.5
-      vertex 52.869 -23.3324 -2.5
-      vertex 52.744 -23.5492 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 52.869 -23.3324 -2.5
-      vertex 52.5 -23.7909 -2.5
-      vertex 52.869 -22.3558 -2.5
+      vertex 13.45 1.43 0
+      vertex 10.91 1.43 0
+      vertex 11.0661 1.44537 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.5 -23.7909 -2.5
-      vertex 52.744 -23.5492 -2.5
-      vertex 52.576 -23.7357 -2.5
+      vertex 4.85 0.5 0
+      vertex 10.7539 1.44537 0
+      vertex 10.91 1.43 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.5 -21.8973 -2.5
-      vertex 52.869 -22.3558 -2.5
-      vertex 52.5 -23.7909 -2.5
+      vertex 4.85 0.5 0
+      vertex 10.6039 1.4909 0
+      vertex 10.7539 1.44537 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.869 -22.3558 -2.5
-      vertex 52.5 -21.8973 -2.5
-      vertex 52.744 -22.139 -2.5
+      vertex 4.85 0.5 0
+      vertex 10.4655 1.56482 0
+      vertex 10.6039 1.4909 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.744 -22.139 -2.5
-      vertex 52.5 -21.8973 -2.5
-      vertex 52.576 -21.9525 -2.5
+      vertex 4.85 0.5 0
+      vertex 10.3443 1.66431 0
+      vertex 10.4655 1.56482 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.9291 -20 -2.5
-      vertex 52.9725 -20.3041 -2.5
-      vertex 52.9471 -20.5541 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.9725 -20.3041 -2.5
-      vertex 52.9291 -20 -2.5
-      vertex 52.9471 -20.055 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.869 -20.7923 -2.5
-      vertex 52.9291 -20 -2.5
-      vertex 52.9471 -20.5541 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.5 -21.2508 -2.5
-      vertex 52.869 -20.7923 -2.5
-      vertex 52.744 -21.0091 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.5 -21.2508 -2.5
-      vertex 52.744 -21.0091 -2.5
-      vertex 52.576 -21.1957 -2.5
+      vertex 4.85 0.5 0
+      vertex 10.2448 1.78554 0
+      vertex 10.3443 1.66431 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 52.869 -20.7923 -2.5
-      vertex 52.5 -21.2508 -2.5
-      vertex 52.9291 -20 -2.5
+      vertex 10.1254 2.07393 0
+      vertex 4.85 0.5 0
+      vertex 4.85 2.24 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.5 -21.9013 -2.5
-      vertex 52.5 -21.8973 -2.5
-      vertex 48.5 -23.7869 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 52.5 -21.8973 -2.5
-      vertex 48.5 -21.9013 -2.5
-      vertex 52.5 -21.2508 -2.5
+      vertex 10.11 2.23 0
+      vertex 4.85 2.24 0
+      vertex 4.82598 2.48386 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.5 -21.2468 -2.5
-      vertex 52.5 -21.2508 -2.5
-      vertex 48.5 -21.9013 -2.5
+      vertex 10.11 2.23 0
+      vertex 4.82598 2.48386 0
+      vertex 4.75485 2.71836 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 52.5 -21.2508 -2.5
-      vertex 48.5 -21.2468 -2.5
-      vertex 52.9291 -20 -2.5
+      vertex 10.11 2.23 0
+      vertex 4.75485 2.71836 0
+      vertex 6.5 6.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.2625 -21.0091 -2.5
-      vertex 48.5 -21.2468 -2.5
-      vertex 48.4295 -21.1957 -2.5
+      vertex 4.63934 2.93446 0
+      vertex 6.5 6.5 0
+      vertex 4.75485 2.71836 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.5 -21.2468 -2.5
-      vertex 48.2625 -21.0091 -2.5
-      vertex 48.0772 -20 -2.5
+      vertex 4.48388 3.12388 0
+      vertex 6.5 6.5 0
+      vertex 4.63934 2.93446 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.0772 -20 -2.5
-      vertex 48.2625 -21.0091 -2.5
-      vertex 48.1366 -20.7923 -2.5
+      vertex 4.29446 3.27934 0
+      vertex 6.5 6.5 0
+      vertex 4.48388 3.12388 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.5 -21.2468 -2.5
-      vertex 48.0772 -20 -2.5
-      vertex 52.9291 -20 -2.5
+      vertex 4.07835 3.39485 0
+      vertex 6.5 6.5 0
+      vertex 4.29446 3.27934 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.0594 -20.5541 -2.5
-      vertex 48.0772 -20 -2.5
-      vertex 48.1366 -20.7923 -2.5
+      vertex 3.84386 3.46598 0
+      vertex 6.5 6.5 0
+      vertex 4.07835 3.39485 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.033 -20.3041 -2.5
-      vertex 48.0772 -20 -2.5
-      vertex 48.0594 -20.5541 -2.5
+      vertex 3.6 3.49 0
+      vertex 6.5 6.5 0
+      vertex 3.84386 3.46598 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 48.0772 -20 -2.5
-      vertex 48.033 -20.3041 -2.5
-      vertex 48.0594 -20.055 -2.5
+      vertex 0.5 7.75 0
+      vertex 6.5 6.5 0
+      vertex 3.6 3.49 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 41.702 -22.9212 -2.5
-      vertex 41.702 -22.4222 -2.5
-      vertex 41.7284 -22.6712 -2.5
+      vertex 0.5 7.75 0
+      vertex 3.6 3.49 0
+      vertex 1.06 3.49 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 41.6248 -23.1595 -2.5
-      vertex 41.702 -22.4222 -2.5
-      vertex 41.702 -22.9212 -2.5
+      vertex 0.5 3.5 0
+      vertex 1.06 3.49 0
+      vertex 0.816136 3.46598 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 41.6248 -23.1595 -2.5
-      vertex 41.6248 -22.183 -2.5
-      vertex 41.702 -22.4222 -2.5
+      vertex 0.5 3.5 0
+      vertex 0.816136 3.46598 0
+      vertex 0.581645 3.39485 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 41.4989 -23.3763 -2.5
-      vertex 41.6248 -22.183 -2.5
-      vertex 41.6248 -23.1595 -2.5
+      vertex 0.5 3.5 0
+      vertex 0.581645 3.39485 0
+      vertex 0.513922 3.35865 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 41.4989 -23.3763 -2.5
-      vertex 41.4989 -21.9662 -2.5
-      vertex 41.6248 -22.183 -2.5
+      vertex 1.06 3.49 0
+      vertex 0.5 3.5 0
+      vertex 0.5 7.75 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 41.3309 -23.5629 -2.5
-      vertex 41.4989 -21.9662 -2.5
-      vertex 41.4989 -23.3763 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41 -21.5747 -2.5
-      vertex 41.4989 -21.9662 -2.5
-      vertex 41.3309 -23.5629 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41 -21.5747 -2.5
-      vertex 41.3309 -23.5629 -2.5
-      vertex 41.1287 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.4989 -21.9662 -2.5
-      vertex 41 -21.5747 -2.5
-      vertex 41.3309 -21.7796 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.3309 -21.7796 -2.5
-      vertex 41 -21.5747 -2.5
-      vertex 41.1287 -21.6322 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 39.6688 -23.5 -2.5
-      vertex 41 -21.5747 -2.5
-      vertex 40.8993 -23.8129 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 40.8993 -23.8129 -2.5
-      vertex 41 -21.5747 -2.5
-      vertex 41.1287 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.702 -20.3812 -2.5
-      vertex 41.7145 -20 -2.5
-      vertex 41.7284 -20.1312 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.6248 -20.6195 -2.5
-      vertex 41.7145 -20 -2.5
-      vertex 41.702 -20.3812 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.4989 -20.8363 -2.5
-      vertex 41.7145 -20 -2.5
-      vertex 41.6248 -20.6195 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41.3309 -21.0228 -2.5
-      vertex 41.7145 -20 -2.5
-      vertex 41.4989 -20.8363 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 41 -21.2278 -2.5
-      vertex 41.3309 -21.0228 -2.5
-      vertex 41.1287 -21.1703 -2.5
+      vertex 6.5 6.5 0
+      vertex 0.5 7.75 0
+      vertex 6.5 7.75 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 41.3309 -21.0228 -2.5
-      vertex 41 -21.2278 -2.5
-      vertex 41.7145 -20 -2.5
+      vertex 51.45 6.5 0
+      vertex 45.41 4 0
+      vertex 45.41 6.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 39.6688 -23.5 -2.5
-      vertex 40.8993 -23.8129 -2.5
-      vertex 40.6541 -23.8646 -2.5
+      vertex 26.9346 4.92607 0
+      vertex 32.75 4 0
+      vertex 26.95 4.77 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 39.6688 -23.5 -2.5
-      vertex 40.6541 -23.8646 -2.5
-      vertex 40.4032 -23.8646 -2.5
+      vertex 32.75 4 0
+      vertex 26.9346 4.92607 0
+      vertex 32.75 6.5 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 39.6688 -23.5 -2.5
-      vertex 40.4032 -23.8646 -2.5
-      vertex 40.158 -23.8129 -2.5
+      vertex 26.8891 5.07615 0
+      vertex 32.75 6.5 0
+      vertex 26.9346 4.92607 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 39.6688 -23.5 -2.5
-      vertex 40.158 -23.8129 -2.5
-      vertex 39.9286 -23.7103 -2.5
+      vertex 26.8152 5.21446 0
+      vertex 32.75 6.5 0
+      vertex 26.8891 5.07615 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 39.6688 -23.5 -2.5
-      vertex 39.9286 -23.7103 -2.5
-      vertex 39.7254 -23.5629 -2.5
+      vertex 26.7157 5.33569 0
+      vertex 32.75 6.5 0
+      vertex 26.8152 5.21446 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 38.8475 -23.5 -2.5
-      vertex 41 -21.5747 -2.5
-      vertex 39.6688 -23.5 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 41 -21.5747 -2.5
-      vertex 38.8475 -23.5 -2.5
-      vertex 41 -21.2278 -2.5
+      vertex 26.5945 5.43518 0
+      vertex 32.75 6.5 0
+      vertex 26.7157 5.33569 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 37.1288 -23.5 -2.5
-      vertex 41 -21.2278 -2.5
-      vertex 38.8475 -23.5 -2.5
+      vertex 26.4561 5.5091 0
+      vertex 32.75 6.5 0
+      vertex 26.5945 5.43518 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 38.5887 -23.7103 -2.5
-      vertex 38.8475 -23.5 -2.5
-      vertex 38.7909 -23.5629 -2.5
+      vertex 26.3061 5.55463 0
+      vertex 32.75 6.5 0
+      vertex 26.4561 5.5091 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 38.3592 -23.8129 -2.5
-      vertex 38.8475 -23.5 -2.5
-      vertex 38.5887 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 38.8475 -23.5 -2.5
-      vertex 38.3592 -23.8129 -2.5
-      vertex 37.1288 -23.5 -2.5
+      vertex 26.15 5.57 0
+      vertex 32.75 6.5 0
+      vertex 26.3061 5.55463 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 37.1288 -23.5 -2.5
-      vertex 38.3592 -23.8129 -2.5
-      vertex 38.1141 -23.8646 -2.5
+      vertex 25.9939 5.55463 0
+      vertex 32.75 6.5 0
+      vertex 26.15 5.57 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 37.1288 -23.5 -2.5
-      vertex 38.1141 -23.8646 -2.5
-      vertex 37.8631 -23.8646 -2.5
+      vertex 25.3654 2.38607 0
+      vertex 19.3146 2.38607 0
+      vertex 19.2691 2.53615 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 37.1288 -23.5 -2.5
-      vertex 37.8631 -23.8646 -2.5
-      vertex 37.618 -23.8129 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 37.1288 -23.5 -2.5
-      vertex 37.618 -23.8129 -2.5
-      vertex 37.3885 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 37.1288 -23.5 -2.5
-      vertex 37.3885 -23.7103 -2.5
-      vertex 37.1854 -23.5629 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 36.3081 -23.5 -2.5
-      vertex 41 -21.2278 -2.5
-      vertex 37.1288 -23.5 -2.5
+      vertex 19.1952 2.67446 0
+      vertex 25.3654 4.61393 0
+      vertex 19.2691 2.53615 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 41 -21.2278 -2.5
-      vertex 36.3081 -23.5 -2.5
-      vertex 41.7145 -20 -2.5
+      vertex 25.3654 4.61393 0
+      vertex 19.1952 2.67446 0
+      vertex 25.35 4.77 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 36.0487 -23.7103 -2.5
-      vertex 36.3081 -23.5 -2.5
-      vertex 36.2518 -23.5629 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 35.8192 -23.8129 -2.5
-      vertex 36.3081 -23.5 -2.5
-      vertex 36.0487 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.5888 -23.5 -2.5
-      vertex 36.3081 -23.5 -2.5
-      vertex 35.8192 -23.8129 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.5888 -23.5 -2.5
-      vertex 35.8192 -23.8129 -2.5
-      vertex 35.5741 -23.8646 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.5888 -23.5 -2.5
-      vertex 35.5741 -23.8646 -2.5
-      vertex 35.3231 -23.8646 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.5888 -23.5 -2.5
-      vertex 35.3231 -23.8646 -2.5
-      vertex 35.078 -23.8129 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.5888 -23.5 -2.5
-      vertex 35.078 -23.8129 -2.5
-      vertex 34.8485 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.5888 -23.5 -2.5
-      vertex 34.8485 -23.7103 -2.5
-      vertex 34.6454 -23.5629 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 36.3081 -23.5 -2.5
-      vertex 34.5888 -23.5 -2.5
-      vertex 41.7145 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30 -21.2733 -2.5
-      vertex 34.5888 -23.5 -2.5
-      vertex 33.768 -23.5 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 33.5086 -23.7103 -2.5
-      vertex 33.768 -23.5 -2.5
-      vertex 33.7118 -23.5629 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 33.2791 -23.8129 -2.5
-      vertex 33.768 -23.5 -2.5
-      vertex 33.5086 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 33.034 -23.8646 -2.5
-      vertex 33.768 -23.5 -2.5
-      vertex 33.2791 -23.8129 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.783 -23.8646 -2.5
-      vertex 33.768 -23.5 -2.5
-      vertex 33.034 -23.8646 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.0487 -23.5 -2.5
-      vertex 33.768 -23.5 -2.5
-      vertex 32.783 -23.8646 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.0487 -23.5 -2.5
-      vertex 32.783 -23.8646 -2.5
-      vertex 32.5379 -23.8129 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.0487 -23.5 -2.5
-      vertex 32.5379 -23.8129 -2.5
-      vertex 32.3084 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.0487 -23.5 -2.5
-      vertex 32.3084 -23.7103 -2.5
-      vertex 32.1053 -23.5629 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 33.768 -23.5 -2.5
-      vertex 32.0487 -23.5 -2.5
-      vertex 30 -21.2733 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30 -21.5292 -2.5
-      vertex 32.0487 -23.5 -2.5
-      vertex 31.2283 -23.5 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30.9686 -23.7103 -2.5
-      vertex 31.2283 -23.5 -2.5
-      vertex 31.1717 -23.5629 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30.7391 -23.8129 -2.5
-      vertex 31.2283 -23.5 -2.5
-      vertex 30.9686 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30.494 -23.8646 -2.5
-      vertex 31.2283 -23.5 -2.5
-      vertex 30.7391 -23.8129 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30.243 -23.8646 -2.5
-      vertex 31.2283 -23.5 -2.5
-      vertex 30.494 -23.8646 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30 -21.5292 -2.5
-      vertex 31.2283 -23.5 -2.5
-      vertex 30.243 -23.8646 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.0487 -23.5 -2.5
-      vertex 30 -21.5292 -2.5
-      vertex 30 -21.2733 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.5888 -23.5 -2.5
-      vertex 30 -21.2733 -2.5
-      vertex 29.1822 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.7684 -21.1703 -2.5
-      vertex 30 -21.2733 -2.5
-      vertex 29.9979 -21.2728 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30 -21.2733 -2.5
-      vertex 29.7684 -21.1703 -2.5
-      vertex 29.1822 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1822 -20 -2.5
-      vertex 29.7684 -21.1703 -2.5
-      vertex 29.5653 -21.0228 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1822 -20 -2.5
-      vertex 29.5653 -21.0228 -2.5
-      vertex 29.3973 -20.8363 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1822 -20 -2.5
-      vertex 29.3973 -20.8363 -2.5
-      vertex 29.2723 -20.6195 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1822 -20 -2.5
-      vertex 29.2723 -20.6195 -2.5
-      vertex 29.1942 -20.3812 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 34.5888 -23.5 -2.5
-      vertex 29.1822 -20 -2.5
-      vertex 41.7145 -20 -2.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 29.1822 -20 -2.5
-      vertex 29.1942 -20.3812 -2.5
-      vertex 29.1688 -20.1312 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.9979 -23.8129 -2.5
-      vertex 30 -21.5292 -2.5
-      vertex 30.243 -23.8646 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.7684 -23.7103 -2.5
-      vertex 30 -21.5292 -2.5
-      vertex 29.9979 -23.8129 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.7684 -21.6322 -2.5
-      vertex 30 -21.5292 -2.5
-      vertex 29.7684 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 30 -21.5292 -2.5
-      vertex 29.7684 -21.6322 -2.5
-      vertex 29.9979 -21.5296 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.5653 -23.5629 -2.5
-      vertex 29.7684 -21.6322 -2.5
-      vertex 29.7684 -23.7103 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.5653 -23.5629 -2.5
-      vertex 29.5653 -21.7796 -2.5
-      vertex 29.7684 -21.6322 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.3973 -23.3763 -2.5
-      vertex 29.5653 -21.7796 -2.5
-      vertex 29.5653 -23.5629 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.3973 -23.3763 -2.5
-      vertex 29.3973 -21.9662 -2.5
-      vertex 29.5653 -21.7796 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.2723 -23.1595 -2.5
-      vertex 29.3973 -21.9662 -2.5
-      vertex 29.3973 -23.3763 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.2723 -23.1595 -2.5
-      vertex 29.2723 -22.183 -2.5
-      vertex 29.3973 -21.9662 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1942 -22.9212 -2.5
-      vertex 29.2723 -22.183 -2.5
-      vertex 29.2723 -23.1595 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.1942 -22.9212 -2.5
-      vertex 29.1942 -22.4222 -2.5
-      vertex 29.2723 -22.183 -2.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 29.1942 -22.4222 -2.5
-      vertex 29.1942 -22.9212 -2.5
-      vertex 29.1688 -22.6712 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.9082 -14.3 -2.5
-      vertex 3 -14.1749 -2.5
-      vertex 3 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -14.1749 -2.5
-      vertex 2.9082 -14.3 -2.5
-      vertex 2.94613 -14.2347 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 3 -18.3 -2.5
-      vertex 2.38543 -14.3 -2.5
-      vertex 2.9082 -14.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.24387 -18.3 -2.5
-      vertex 2.38543 -14.3 -2.5
-      vertex 3 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.368165 -14.3 -2.5
-      vertex 2.38543 -14.3 -2.5
-      vertex 2.24387 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.97641 -18.5189 -2.5
-      vertex 2.24387 -18.3 -2.5
-      vertex 2.17953 -18.3714 -2.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 1.97641 -13.9007 -2.5
-      vertex 2.38543 -14.3 -2.5
-      vertex 0.368165 -14.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.74789 -18.6205 -2.5
-      vertex 2.24387 -18.3 -2.5
-      vertex 1.97641 -18.5189 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.38543 -14.3 -2.5
-      vertex 2.17953 -14.0482 -2.5
-      vertex 2.3475 -14.2347 -2.5
+      vertex 19.0957 2.79569 0
+      vertex 25.35 4.77 0
+      vertex 19.1952 2.67446 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 2.24387 -18.3 -2.5
-      vertex 1.74789 -18.6205 -2.5
-      vertex 0.509724 -18.3 -2.5
+      vertex 25.35 4.77 0
+      vertex 19.0957 2.79569 0
+      vertex 25.3654 4.92607 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 2.38543 -14.3 -2.5
-      vertex 1.97641 -13.9007 -2.5
-      vertex 2.17953 -14.0482 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.509724 -18.3 -2.5
-      vertex 1.74789 -18.6205 -2.5
-      vertex 1.5018 -18.6732 -2.5
+      vertex 18.9745 2.89518 0
+      vertex 25.3654 4.92607 0
+      vertex 19.0957 2.79569 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 1.97641 -13.9007 -2.5
-      vertex 0.368165 -14.3 -2.5
-      vertex 1.74789 -13.7982 -2.5
+      vertex 25.3654 4.92607 0
+      vertex 18.9745 2.89518 0
+      vertex 25.4109 5.07615 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0.509724 -18.3 -2.5
-      vertex 1.5018 -18.6732 -2.5
-      vertex 1.2518 -18.6732 -2.5
+      vertex 18.8361 2.9691 0
+      vertex 25.4109 5.07615 0
+      vertex 18.9745 2.89518 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 1.74789 -13.7982 -2.5
-      vertex 0.368165 -14.3 -2.5
-      vertex 1.5018 -13.7464 -2.5
+      vertex 25.4109 5.07615 0
+      vertex 18.8361 2.9691 0
+      vertex 25.4848 5.21446 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0.509724 -18.3 -2.5
-      vertex 1.2518 -18.6732 -2.5
-      vertex 1.0057 -18.6205 -2.5
+      vertex 18.6861 3.01463 0
+      vertex 25.4848 5.21446 0
+      vertex 18.8361 2.9691 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 1.5018 -13.7464 -2.5
-      vertex 0.368165 -14.3 -2.5
-      vertex 1.2518 -13.7464 -2.5
+      vertex 25.4848 5.21446 0
+      vertex 18.6861 3.01463 0
+      vertex 25.5843 5.33569 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0.509724 -18.3 -2.5
-      vertex 1.0057 -18.6205 -2.5
-      vertex 0.777187 -18.5189 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.2518 -13.7464 -2.5
-      vertex 0.368165 -14.3 -2.5
-      vertex 1.0057 -13.7982 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.509724 -18.3 -2.5
-      vertex 0.777187 -18.5189 -2.5
-      vertex 0.574062 -18.3714 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2.24387 -18.3 -2.5
-      vertex 0.509724 -18.3 -2.5
-      vertex 0.368165 -14.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1.0057 -13.7982 -2.5
-      vertex 0.368165 -14.3 -2.5
-      vertex 0.777187 -13.9007 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.777187 -13.9007 -2.5
-      vertex 0.368165 -14.3 -2.5
-      vertex 0.574062 -14.0482 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.574062 -14.0482 -2.5
-      vertex 0.368165 -14.3 -2.5
-      vertex 0.406094 -14.2347 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.509724 -18.3 -2.5
-      vertex -0.154609 -14.3 -2.5
-      vertex 0.368165 -14.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.296169 -18.3 -2.5
-      vertex -0.154609 -14.3 -2.5
-      vertex 0.509724 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -2.17187 -14.3 -2.5
-      vertex -0.154609 -14.3 -2.5
-      vertex -0.296169 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.563632 -18.5189 -2.5
-      vertex -0.296169 -18.3 -2.5
-      vertex -0.360507 -18.3714 -2.5
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex -0.563632 -13.9007 -2.5
-      vertex -0.154609 -14.3 -2.5
-      vertex -2.17187 -14.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.792148 -18.6205 -2.5
-      vertex -0.296169 -18.3 -2.5
-      vertex -0.563632 -18.5189 -2.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -0.154609 -14.3 -2.5
-      vertex -0.360507 -14.0482 -2.5
-      vertex -0.192538 -14.2347 -2.5
+      vertex 18.53 3.03 0
+      vertex 25.5843 5.33569 0
+      vertex 18.6861 3.01463 0
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -0.296169 -18.3 -2.5
-      vertex -0.792148 -18.6205 -2.5
-      vertex -2.03031 -18.3 -2.5
+      vertex 25.5843 5.33569 0
+      vertex 18.53 3.03 0
+      vertex 25.7055 5.43518 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -0.154609 -14.3 -2.5
-      vertex -0.563632 -13.9007 -2.5
-      vertex -0.360507 -14.0482 -2.5
+      vertex 15.99 3.03 0
+      vertex 25.7055 5.43518 0
+      vertex 18.53 3.03 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.03031 -18.3 -2.5
-      vertex -0.792148 -18.6205 -2.5
-      vertex -1.03726 -18.6732 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.563632 -13.9007 -2.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -0.792148 -13.7982 -2.5
+      vertex 15.99 3.03 0
+      vertex 18.53 3.03 0
+      vertex 18.3739 3.01463 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.03031 -18.3 -2.5
-      vertex -1.03726 -18.6732 -2.5
-      vertex -1.28824 -18.6732 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.792148 -13.7982 -2.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -1.03726 -13.7464 -2.5
+      vertex 16.1461 3.01463 0
+      vertex 18.3739 3.01463 0
+      vertex 18.2239 2.9691 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.03031 -18.3 -2.5
-      vertex -1.28824 -18.6732 -2.5
-      vertex -1.53434 -18.6205 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -1.03726 -13.7464 -2.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -1.28824 -13.7464 -2.5
+      vertex 16.79 2.23 0
+      vertex 17.7454 2.38607 0
+      vertex 17.73 2.23 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.03031 -18.3 -2.5
-      vertex -1.53434 -18.6205 -2.5
-      vertex -1.76285 -18.5189 -2.5
+      vertex 16.7746 2.38607 0
+      vertex 17.7454 2.38607 0
+      vertex 16.79 2.23 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.28824 -13.7464 -2.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -1.53434 -13.7982 -2.5
+      vertex 17.7454 2.38607 0
+      vertex 16.7746 2.38607 0
+      vertex 17.7909 2.53615 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.03031 -18.3 -2.5
-      vertex -1.76285 -18.5189 -2.5
-      vertex -1.96598 -18.3714 -2.5
+      vertex 16.7291 2.53615 0
+      vertex 17.7909 2.53615 0
+      vertex 16.7746 2.38607 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -0.296169 -18.3 -2.5
-      vertex -2.03031 -18.3 -2.5
-      vertex -2.17187 -14.3 -2.5
+      vertex 17.7909 2.53615 0
+      vertex 16.7291 2.53615 0
+      vertex 17.8648 2.67446 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.53434 -13.7982 -2.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -1.76285 -13.9007 -2.5
+      vertex 16.6552 2.67446 0
+      vertex 17.8648 2.67446 0
+      vertex 16.7291 2.53615 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.76285 -13.9007 -2.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -1.96598 -14.0482 -2.5
+      vertex 17.8648 2.67446 0
+      vertex 16.6552 2.67446 0
+      vertex 17.9643 2.79569 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -1.96598 -14.0482 -2.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -2.13394 -14.2347 -2.5
+      vertex 16.5557 2.79569 0
+      vertex 17.9643 2.79569 0
+      vertex 16.6552 2.67446 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 -18.3 -2.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -2.03031 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.17187 -14.3 -2.5
-      vertex -3 -18.3 -2.5
-      vertex -3 -14.3 -2.5
+      vertex 17.9643 2.79569 0
+      vertex 16.5557 2.79569 0
+      vertex 18.0855 2.89518 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.48551 -5.07555 -2.5
-      vertex -2.48551 -4.70152 -2.5
-      vertex -2.465 -4.88902 -2.5
+      vertex 16.4345 2.89518 0
+      vertex 18.0855 2.89518 0
+      vertex 16.5557 2.79569 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.54312 -5.25523 -2.5
-      vertex -2.48551 -4.70152 -2.5
-      vertex -2.48551 -5.07555 -2.5
+      vertex 18.0855 2.89518 0
+      vertex 16.4345 2.89518 0
+      vertex 18.2239 2.9691 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.54312 -5.25523 -2.5
-      vertex -2.54312 -4.52281 -2.5
-      vertex -2.48551 -4.70152 -2.5
+      vertex 16.2961 2.9691 0
+      vertex 18.2239 2.9691 0
+      vertex 16.4345 2.89518 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 -5.7059 -2.5
-      vertex -2.54312 -5.25523 -2.5
-      vertex -2.63687 -5.41832 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.54312 -5.25523 -2.5
-      vertex -3 -5.7059 -2.5
-      vertex -2.54312 -4.52281 -2.5
+      vertex 16.1461 3.01463 0
+      vertex 18.2239 2.9691 0
+      vertex 16.2961 2.9691 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 -5.7059 -2.5
-      vertex -2.63687 -5.41832 -2.5
-      vertex -2.76285 -5.55797 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.54312 -4.52281 -2.5
-      vertex -3 -5.7059 -2.5
-      vertex -2.63687 -4.35973 -2.5
+      vertex 15.99 3.03 0
+      vertex 18.3739 3.01463 0
+      vertex 16.1461 3.01463 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 -5.7059 -2.5
-      vertex -2.76285 -5.55797 -2.5
-      vertex -2.91519 -5.66832 -2.5
+      vertex 6.5 6.5 0
+      vertex 25.7055 5.43518 0
+      vertex 15.99 3.03 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 -4.07166 -2.5
-      vertex -2.63687 -4.35973 -2.5
-      vertex -3 -5.7059 -2.5
+      vertex 25.7055 5.43518 0
+      vertex 6.5 6.5 0
+      vertex 25.8439 5.5091 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.63687 -4.35973 -2.5
-      vertex -3 -4.07166 -2.5
-      vertex -2.76285 -4.22008 -2.5
+      vertex 6.5 6.5 0
+      vertex 15.99 3.03 0
+      vertex 15.8339 3.01463 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.76285 -4.22008 -2.5
-      vertex -3 -4.07166 -2.5
-      vertex -2.91519 -4.10973 -2.5
+      vertex 14.25 2.23 0
+      vertex 15.2054 2.38607 0
+      vertex 15.19 2.23 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.48551 -2.55602 -2.5
-      vertex -2.48551 -2.18199 -2.5
-      vertex -2.465 -2.36949 -2.5
+      vertex 14.2346 2.38607 0
+      vertex 15.2054 2.38607 0
+      vertex 14.25 2.23 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.54312 -2.7357 -2.5
-      vertex -2.48551 -2.18199 -2.5
-      vertex -2.48551 -2.55602 -2.5
+      vertex 15.2054 2.38607 0
+      vertex 14.2346 2.38607 0
+      vertex 15.2509 2.53615 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.54312 -2.7357 -2.5
-      vertex -2.54312 -2.00328 -2.5
-      vertex -2.48551 -2.18199 -2.5
+      vertex 14.1891 2.53615 0
+      vertex 15.2509 2.53615 0
+      vertex 14.2346 2.38607 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.63687 -2.89781 -2.5
-      vertex -2.54312 -2.00328 -2.5
-      vertex -2.54312 -2.7357 -2.5
+      vertex 15.2509 2.53615 0
+      vertex 14.1891 2.53615 0
+      vertex 15.3248 2.67446 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.63687 -2.89781 -2.5
-      vertex -2.63687 -1.84019 -2.5
-      vertex -2.54312 -2.00328 -2.5
+      vertex 14.1152 2.67446 0
+      vertex 15.3248 2.67446 0
+      vertex 14.1891 2.53615 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 -3.18637 -2.5
-      vertex -2.63687 -2.89781 -2.5
-      vertex -2.76285 -3.03844 -2.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -2.63687 -2.89781 -2.5
-      vertex -3 -3.18637 -2.5
-      vertex -2.63687 -1.84019 -2.5
+      vertex 15.3248 2.67446 0
+      vertex 14.1152 2.67446 0
+      vertex 15.4243 2.79569 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 -3.18637 -2.5
-      vertex -2.76285 -3.03844 -2.5
-      vertex -2.91519 -3.14879 -2.5
+      vertex 14.0157 2.79569 0
+      vertex 15.4243 2.79569 0
+      vertex 14.1152 2.67446 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 -1.55213 -2.5
-      vertex -2.63687 -1.84019 -2.5
-      vertex -3 -3.18637 -2.5
+      vertex 15.4243 2.79569 0
+      vertex 14.0157 2.79569 0
+      vertex 15.5455 2.89518 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.63687 -1.84019 -2.5
-      vertex -3 -1.55213 -2.5
-      vertex -2.76285 -1.70055 -2.5
+      vertex 13.8945 2.89518 0
+      vertex 15.5455 2.89518 0
+      vertex 14.0157 2.79569 0
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -2.76285 -1.70055 -2.5
-      vertex -3 -1.55213 -2.5
-      vertex -2.91519 -1.59019 -2.5
+      vertex 15.5455 2.89518 0
+      vertex 13.8945 2.89518 0
+      vertex 15.6839 2.9691 0
     endloop
   endfacet
-  facet normal -0.587471 -0.809245 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.5 -24.4374 -4.5
-      vertex 52.576 -24.4925 -2.5
-      vertex 52.5 -24.4374 -2.5
+      vertex 13.7561 2.9691 0
+      vertex 15.6839 2.9691 0
+      vertex 13.8945 2.89518 0
     endloop
   endfacet
-  facet normal -0.587471 -0.809245 -0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.576 -24.4925 -2.5
-      vertex 52.5 -24.4374 -4.5
-      vertex 52.576 -24.4925 -4.5
+      vertex 15.6839 2.9691 0
+      vertex 13.7561 2.9691 0
+      vertex 15.8339 3.01463 0
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.744 -24.6791 -4.5
-      vertex 52.576 -24.4925 -2.5
-      vertex 52.576 -24.4925 -4.5
+      vertex 13.6061 3.01463 0
+      vertex 15.8339 3.01463 0
+      vertex 13.7561 2.9691 0
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.576 -24.4925 -2.5
-      vertex 52.744 -24.6791 -4.5
-      vertex 52.744 -24.6791 -2.5
+      vertex 6.5 6.5 0
+      vertex 15.8339 3.01463 0
+      vertex 13.6061 3.01463 0
     endloop
   endfacet
-  facet normal -0.866315 -0.499497 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.869 -24.8959 -4.5
-      vertex 52.744 -24.6791 -2.5
-      vertex 52.744 -24.6791 -4.5
+      vertex 6.5 6.5 0
+      vertex 13.6061 3.01463 0
+      vertex 13.45 3.03 0
     endloop
   endfacet
-  facet normal -0.866315 -0.499497 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.744 -24.6791 -2.5
-      vertex 52.869 -24.8959 -4.5
-      vertex 52.869 -24.8959 -2.5
+      vertex 6.5 6.5 0
+      vertex 13.45 3.03 0
+      vertex 13.2939 3.01463 0
     endloop
   endfacet
-  facet normal -0.95023 -0.311551 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.9471 -25.1341 -4.5
-      vertex 52.869 -24.8959 -2.5
-      vertex 52.869 -24.8959 -4.5
+      vertex 11.71 2.23 0
+      vertex 12.6654 2.38607 0
+      vertex 12.65 2.23 0
     endloop
   endfacet
-  facet normal -0.95023 -0.311551 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.869 -24.8959 -2.5
-      vertex 52.9471 -25.1341 -4.5
-      vertex 52.9471 -25.1341 -2.5
+      vertex 11.6946 2.38607 0
+      vertex 12.6654 2.38607 0
+      vertex 11.71 2.23 0
     endloop
   endfacet
-  facet normal -0.994882 -0.101043 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.9725 -25.3841 -4.5
-      vertex 52.9471 -25.1341 -2.5
-      vertex 52.9471 -25.1341 -4.5
+      vertex 12.6654 2.38607 0
+      vertex 11.6946 2.38607 0
+      vertex 12.7109 2.53615 0
     endloop
   endfacet
-  facet normal -0.994882 -0.101043 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.9471 -25.1341 -2.5
-      vertex 52.9725 -25.3841 -4.5
-      vertex 52.9725 -25.3841 -2.5
+      vertex 11.6491 2.53615 0
+      vertex 12.7109 2.53615 0
+      vertex 11.6946 2.38607 0
     endloop
   endfacet
-  facet normal -0.994842 0.101435 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.9471 -25.6332 -4.5
-      vertex 52.9725 -25.3841 -2.5
-      vertex 52.9725 -25.3841 -4.5
+      vertex 12.7109 2.53615 0
+      vertex 11.6491 2.53615 0
+      vertex 12.7848 2.67446 0
     endloop
   endfacet
-  facet normal -0.994842 0.101435 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.9725 -25.3841 -2.5
-      vertex 52.9471 -25.6332 -4.5
-      vertex 52.9471 -25.6332 -2.5
+      vertex 11.5752 2.67446 0
+      vertex 12.7848 2.67446 0
+      vertex 11.6491 2.53615 0
     endloop
   endfacet
-  facet normal -0.950605 0.310402 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.869 -25.8724 -4.5
-      vertex 52.9471 -25.6332 -2.5
-      vertex 52.9471 -25.6332 -4.5
+      vertex 12.7848 2.67446 0
+      vertex 11.5752 2.67446 0
+      vertex 12.8843 2.79569 0
     endloop
   endfacet
-  facet normal -0.950605 0.310402 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.9471 -25.6332 -2.5
-      vertex 52.869 -25.8724 -4.5
-      vertex 52.869 -25.8724 -2.5
+      vertex 11.4757 2.79569 0
+      vertex 12.8843 2.79569 0
+      vertex 11.5752 2.67446 0
     endloop
   endfacet
-  facet normal -0.866316 0.499497 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.7954 -26 -4.5
-      vertex 52.869 -25.8724 -2.5
-      vertex 52.869 -25.8724 -4.5
+      vertex 12.8843 2.79569 0
+      vertex 11.4757 2.79569 0
+      vertex 13.0055 2.89518 0
     endloop
   endfacet
-  facet normal -0.866316 0.499497 0
+  facet normal 0 0 -1
     outer loop
-      vertex 52.869 -25.8724 -2.5
-      vertex 52.7954 -26 -4.5
-      vertex 52.7954 -26 -2.5
+      vertex 11.3545 2.89518 0
+      vertex 13.0055 2.89518 0
+      vertex 11.4757 2.79569 0
     endloop
   endfacet
-  facet normal 0.864622 0.502424 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.2107 -26 -2.5
-      vertex 48.1366 -25.8724 -4.5
-      vertex 48.1366 -25.8724 -2.5
+      vertex 13.0055 2.89518 0
+      vertex 11.3545 2.89518 0
+      vertex 13.1439 2.9691 0
     endloop
   endfacet
-  facet normal 0.864622 0.502424 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.1366 -25.8724 -4.5
-      vertex 48.2107 -26 -2.5
-      vertex 48.2107 -26 -4.5
+      vertex 11.2161 2.9691 0
+      vertex 13.1439 2.9691 0
+      vertex 11.3545 2.89518 0
     endloop
   endfacet
-  facet normal 0.951745 0.306889 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.1366 -25.8724 -2.5
-      vertex 48.0594 -25.6332 -4.5
-      vertex 48.0594 -25.6332 -2.5
+      vertex 13.1439 2.9691 0
+      vertex 11.2161 2.9691 0
+      vertex 13.2939 3.01463 0
     endloop
   endfacet
-  facet normal 0.951745 0.306889 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.0594 -25.6332 -4.5
-      vertex 48.1366 -25.8724 -2.5
-      vertex 48.1366 -25.8724 -4.5
+      vertex 11.0661 3.01463 0
+      vertex 13.2939 3.01463 0
+      vertex 11.2161 2.9691 0
     endloop
   endfacet
-  facet normal 0.994441 0.105294 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.0594 -25.6332 -2.5
-      vertex 48.033 -25.3841 -4.5
-      vertex 48.033 -25.3841 -2.5
+      vertex 13.2939 3.01463 0
+      vertex 11.0661 3.01463 0
+      vertex 6.5 6.5 0
     endloop
   endfacet
-  facet normal 0.994441 0.105294 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.033 -25.3841 -4.5
-      vertex 48.0594 -25.6332 -2.5
-      vertex 48.0594 -25.6332 -4.5
+      vertex 6.5 6.5 0
+      vertex 11.0661 3.01463 0
+      vertex 10.91 3.03 0
     endloop
   endfacet
-  facet normal 0.994484 -0.104887 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.033 -25.3841 -2.5
-      vertex 48.0594 -25.1341 -4.5
-      vertex 48.0594 -25.1341 -2.5
+      vertex 6.5 6.5 0
+      vertex 10.91 3.03 0
+      vertex 10.7539 3.01463 0
     endloop
   endfacet
-  facet normal 0.994484 -0.104887 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.0594 -25.1341 -4.5
-      vertex 48.033 -25.3841 -2.5
-      vertex 48.033 -25.3841 -4.5
+      vertex 25.9939 5.55463 0
+      vertex 6.5 6.5 0
+      vertex 32.75 6.5 0
     endloop
   endfacet
-  facet normal 0.951377 -0.308028 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.0594 -25.1341 -2.5
-      vertex 48.1366 -24.8959 -4.5
-      vertex 48.1366 -24.8959 -2.5
+      vertex 25.8439 5.5091 0
+      vertex 6.5 6.5 0
+      vertex 25.9939 5.55463 0
     endloop
   endfacet
-  facet normal 0.951377 -0.308028 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.1366 -24.8959 -4.5
-      vertex 48.0594 -25.1341 -2.5
-      vertex 48.0594 -25.1341 -4.5
+      vertex 10.6039 2.9691 0
+      vertex 6.5 6.5 0
+      vertex 10.7539 3.01463 0
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.1366 -24.8959 -2.5
-      vertex 48.2625 -24.6791 -4.5
-      vertex 48.2625 -24.6791 -2.5
+      vertex 10.4655 2.89518 0
+      vertex 6.5 6.5 0
+      vertex 10.6039 2.9691 0
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.2625 -24.6791 -4.5
-      vertex 48.1366 -24.8959 -2.5
-      vertex 48.1366 -24.8959 -4.5
+      vertex 10.3443 2.79569 0
+      vertex 6.5 6.5 0
+      vertex 10.4655 2.89518 0
     endloop
   endfacet
-  facet normal 0.745037 -0.667023 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.2625 -24.6791 -2.5
-      vertex 48.4295 -24.4925 -4.5
-      vertex 48.4295 -24.4925 -2.5
+      vertex 10.2448 2.67446 0
+      vertex 6.5 6.5 0
+      vertex 10.3443 2.79569 0
     endloop
   endfacet
-  facet normal 0.745037 -0.667023 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.4295 -24.4925 -4.5
-      vertex 48.2625 -24.6791 -2.5
-      vertex 48.2625 -24.6791 -4.5
+      vertex 10.1709 2.53615 0
+      vertex 6.5 6.5 0
+      vertex 10.2448 2.67446 0
     endloop
   endfacet
-  facet normal 0.587472 -0.809244 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.4295 -24.4925 -4.5
-      vertex 48.5 -24.4414 -2.5
-      vertex 48.4295 -24.4925 -2.5
+      vertex 10.1254 2.38607 0
+      vertex 6.5 6.5 0
+      vertex 10.1709 2.53615 0
     endloop
   endfacet
-  facet normal 0.587472 -0.809244 0
+  facet normal 0 0 -1
     outer loop
-      vertex 48.5 -24.4414 -2.5
-      vertex 48.4295 -24.4925 -4.5
-      vertex 48.5 -24.4414 -4.5
+      vertex 6.5 6.5 0
+      vertex 10.1254 2.38607 0
+      vertex 10.11 2.23 0
     endloop
   endfacet
-  facet normal -0.867284 -0.497814 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex 1.0682 -24.0199 -4.5
-      vertex 1 -23.9011 -2.5
-      vertex 1 -23.9011 -4.5
+      vertex 11.0661 1.44537 0
+      vertex 10.91 1.43 2
+      vertex 11.0661 1.44537 2
     endloop
   endfacet
-  facet normal -0.867284 -0.497814 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex 1 -23.9011 -2.5
-      vertex 1.0682 -24.0199 -4.5
-      vertex 1.0682 -24.0199 -2.5
+      vertex 10.91 1.43 2
+      vertex 11.0661 1.44537 0
+      vertex 10.91 1.43 0
     endloop
   endfacet
-  facet normal -0.95023 -0.311551 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 1.14633 -24.2582 -4.5
-      vertex 1.0682 -24.0199 -2.5
-      vertex 1.0682 -24.0199 -4.5
+      vertex 10.1254 2.07393 2
+      vertex 10.11 2.23 0
+      vertex 10.11 2.23 2
     endloop
   endfacet
-  facet normal -0.95023 -0.311551 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 1.0682 -24.0199 -2.5
-      vertex 1.14633 -24.2582 -4.5
-      vertex 1.14633 -24.2582 -2.5
+      vertex 10.11 2.23 0
+      vertex 10.1254 2.07393 2
+      vertex 10.1254 2.07393 0
     endloop
   endfacet
-  facet normal -0.994882 -0.101043 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 1.17172 -24.5082 -4.5
-      vertex 1.14633 -24.2582 -2.5
-      vertex 1.14633 -24.2582 -4.5
+      vertex 10.2448 2.67446 2
+      vertex 10.3443 2.79569 0
+      vertex 10.3443 2.79569 2
     endloop
   endfacet
-  facet normal -0.994882 -0.101043 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 1.14633 -24.2582 -2.5
-      vertex 1.17172 -24.5082 -4.5
-      vertex 1.17172 -24.5082 -2.5
+      vertex 10.3443 2.79569 0
+      vertex 10.2448 2.67446 2
+      vertex 10.2448 2.67446 0
     endloop
   endfacet
-  facet normal -0.994842 0.101435 0
+  facet normal -0.0979887 -0.995188 0
     outer loop
-      vertex 1.14633 -24.7572 -4.5
-      vertex 1.17172 -24.5082 -2.5
-      vertex 1.17172 -24.5082 -4.5
+      vertex 10.91 3.03 0
+      vertex 11.0661 3.01463 2
+      vertex 10.91 3.03 2
     endloop
   endfacet
-  facet normal -0.994842 0.101435 0
+  facet normal -0.0979887 -0.995188 -0
     outer loop
-      vertex 1.17172 -24.5082 -2.5
-      vertex 1.14633 -24.7572 -4.5
-      vertex 1.14633 -24.7572 -2.5
+      vertex 11.0661 3.01463 2
+      vertex 10.91 3.03 0
+      vertex 11.0661 3.01463 0
     endloop
   endfacet
-  facet normal -0.95023 0.311551 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 1.0682 -24.9955 -4.5
-      vertex 1.14633 -24.7572 -2.5
-      vertex 1.14633 -24.7572 -4.5
+      vertex 10.1254 2.38607 2
+      vertex 10.1709 2.53615 0
+      vertex 10.1709 2.53615 2
     endloop
   endfacet
-  facet normal -0.95023 0.311551 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 1.14633 -24.7572 -2.5
-      vertex 1.0682 -24.9955 -4.5
-      vertex 1.0682 -24.9955 -2.5
+      vertex 10.1709 2.53615 0
+      vertex 10.1254 2.38607 2
+      vertex 10.1254 2.38607 0
     endloop
   endfacet
-  facet normal -0.867284 0.497814 0
+  facet normal 0.471117 0.882071 -0
     outer loop
-      vertex 1 -25.1143 -4.5
-      vertex 1.0682 -24.9955 -2.5
-      vertex 1.0682 -24.9955 -4.5
+      vertex 10.6039 1.4909 0
+      vertex 10.4655 1.56482 2
+      vertex 10.6039 1.4909 2
     endloop
   endfacet
-  facet normal -0.867284 0.497814 0
+  facet normal 0.471117 0.882071 0
     outer loop
-      vertex 1.0682 -24.9955 -2.5
-      vertex 1 -25.1143 -4.5
-      vertex 1 -25.1143 -2.5
+      vertex 10.4655 1.56482 2
+      vertex 10.6039 1.4909 0
+      vertex 10.4655 1.56482 0
     endloop
   endfacet
-  facet normal 0.587472 0.809244 -0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 48.5 -23.7869 -4.5
-      vertex 48.4295 -23.7357 -2.5
-      vertex 48.5 -23.7869 -2.5
+      vertex 12.8843 1.66431 2
+      vertex 12.7848 1.78554 0
+      vertex 12.7848 1.78554 2
     endloop
   endfacet
-  facet normal 0.587472 0.809244 0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 48.4295 -23.7357 -2.5
-      vertex 48.5 -23.7869 -4.5
-      vertex 48.4295 -23.7357 -4.5
+      vertex 12.7848 1.78554 0
+      vertex 12.8843 1.66431 2
+      vertex 12.8843 1.66431 0
     endloop
   endfacet
-  facet normal 0.745037 0.667023 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 48.4295 -23.7357 -2.5
-      vertex 48.2625 -23.5492 -4.5
-      vertex 48.2625 -23.5492 -2.5
+      vertex 12.7109 2.53615 2
+      vertex 12.7848 2.67446 0
+      vertex 12.7848 2.67446 2
     endloop
   endfacet
-  facet normal 0.745037 0.667023 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 48.2625 -23.5492 -4.5
-      vertex 48.4295 -23.7357 -2.5
-      vertex 48.4295 -23.7357 -4.5
+      vertex 12.7848 2.67446 0
+      vertex 12.7109 2.53615 2
+      vertex 12.7109 2.53615 0
     endloop
   endfacet
-  facet normal 0.864625 0.502417 0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 48.2625 -23.5492 -2.5
-      vertex 48.1366 -23.3324 -4.5
-      vertex 48.1366 -23.3324 -2.5
+      vertex 14.2346 2.07393 0
+      vertex 14.25 2.23 2
+      vertex 14.25 2.23 0
     endloop
   endfacet
-  facet normal 0.864625 0.502417 0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 48.1366 -23.3324 -4.5
-      vertex 48.2625 -23.5492 -2.5
-      vertex 48.2625 -23.5492 -4.5
+      vertex 14.25 2.23 2
+      vertex 14.2346 2.07393 0
+      vertex 14.2346 2.07393 2
     endloop
   endfacet
-  facet normal 0.951745 0.306889 0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 48.1366 -23.3324 -2.5
-      vertex 48.0594 -23.0931 -4.5
-      vertex 48.0594 -23.0931 -2.5
+      vertex 14.1891 2.53615 0
+      vertex 14.1152 2.67446 2
+      vertex 14.1152 2.67446 0
     endloop
   endfacet
-  facet normal 0.951745 0.306889 0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 48.0594 -23.0931 -4.5
-      vertex 48.1366 -23.3324 -2.5
-      vertex 48.1366 -23.3324 -4.5
+      vertex 14.1152 2.67446 2
+      vertex 14.1891 2.53615 0
+      vertex 14.1891 2.53615 2
     endloop
   endfacet
-  facet normal 0.994441 0.105294 0
+  facet normal 0.290448 0.956891 -0
     outer loop
-      vertex 48.0594 -23.0931 -2.5
-      vertex 48.033 -22.8441 -4.5
-      vertex 48.033 -22.8441 -2.5
+      vertex 13.2939 1.44537 0
+      vertex 13.1439 1.4909 2
+      vertex 13.2939 1.44537 2
     endloop
   endfacet
-  facet normal 0.994441 0.105294 0
+  facet normal 0.290448 0.956891 0
     outer loop
-      vertex 48.033 -22.8441 -4.5
-      vertex 48.0594 -23.0931 -2.5
-      vertex 48.0594 -23.0931 -4.5
+      vertex 13.1439 1.4909 2
+      vertex 13.2939 1.44537 0
+      vertex 13.1439 1.4909 0
     endloop
   endfacet
-  facet normal 0.994441 -0.105294 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex 48.033 -22.8441 -2.5
-      vertex 48.0594 -22.5951 -4.5
-      vertex 48.0594 -22.5951 -2.5
+      vertex 14.1152 1.78554 0
+      vertex 14.1891 1.92385 2
+      vertex 14.1891 1.92385 0
     endloop
   endfacet
-  facet normal 0.994441 -0.105294 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex 48.0594 -22.5951 -4.5
-      vertex 48.033 -22.8441 -2.5
-      vertex 48.033 -22.8441 -4.5
+      vertex 14.1891 1.92385 2
+      vertex 14.1152 1.78554 0
+      vertex 14.1152 1.78554 2
     endloop
   endfacet
-  facet normal 0.951745 -0.306889 0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 48.0594 -22.5951 -2.5
-      vertex 48.1366 -22.3558 -4.5
-      vertex 48.1366 -22.3558 -2.5
+      vertex 14.25 2.23 0
+      vertex 14.2346 2.38607 2
+      vertex 14.2346 2.38607 0
     endloop
   endfacet
-  facet normal 0.951745 -0.306889 0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 48.1366 -22.3558 -4.5
-      vertex 48.0594 -22.5951 -2.5
-      vertex 48.0594 -22.5951 -4.5
+      vertex 14.2346 2.38607 2
+      vertex 14.25 2.23 0
+      vertex 14.25 2.23 2
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex 48.1366 -22.3558 -2.5
-      vertex 48.2625 -22.139 -4.5
-      vertex 48.2625 -22.139 -2.5
+      vertex 12.7109 1.92385 2
+      vertex 12.6654 2.07393 0
+      vertex 12.6654 2.07393 2
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex 48.2625 -22.139 -4.5
-      vertex 48.1366 -22.3558 -2.5
-      vertex 48.1366 -22.3558 -4.5
+      vertex 12.6654 2.07393 0
+      vertex 12.7109 1.92385 2
+      vertex 12.7109 1.92385 0
     endloop
   endfacet
-  facet normal 0.745037 -0.667023 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex 48.2625 -22.139 -2.5
-      vertex 48.4295 -21.9525 -4.5
-      vertex 48.4295 -21.9525 -2.5
+      vertex 12.65 2.23 2
+      vertex 12.6654 2.38607 0
+      vertex 12.6654 2.38607 2
     endloop
   endfacet
-  facet normal 0.745037 -0.667023 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex 48.4295 -21.9525 -4.5
-      vertex 48.2625 -22.139 -2.5
-      vertex 48.2625 -22.139 -4.5
+      vertex 12.6654 2.38607 0
+      vertex 12.65 2.23 2
+      vertex 12.65 2.23 0
     endloop
   endfacet
-  facet normal 0.587472 -0.809244 0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 48.4295 -21.9525 -4.5
-      vertex 48.5 -21.9013 -2.5
-      vertex 48.4295 -21.9525 -2.5
+      vertex 14.2346 2.38607 0
+      vertex 14.1891 2.53615 2
+      vertex 14.1891 2.53615 0
     endloop
   endfacet
-  facet normal 0.587472 -0.809244 0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 48.5 -21.9013 -2.5
-      vertex 48.4295 -21.9525 -4.5
-      vertex 48.5 -21.9013 -4.5
+      vertex 14.1891 2.53615 2
+      vertex 14.2346 2.38607 0
+      vertex 14.2346 2.38607 2
     endloop
   endfacet
-  facet normal -0.587471 -0.809245 0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 52.5 -21.8973 -4.5
-      vertex 52.576 -21.9525 -2.5
-      vertex 52.5 -21.8973 -2.5
+      vertex 12.7848 1.78554 2
+      vertex 12.7109 1.92385 0
+      vertex 12.7109 1.92385 2
     endloop
   endfacet
-  facet normal -0.587471 -0.809245 -0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 52.576 -21.9525 -2.5
-      vertex 52.5 -21.8973 -4.5
-      vertex 52.576 -21.9525 -4.5
+      vertex 12.7109 1.92385 0
+      vertex 12.7848 1.78554 2
+      vertex 12.7848 1.78554 0
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 52.744 -22.139 -4.5
-      vertex 52.576 -21.9525 -2.5
-      vertex 52.576 -21.9525 -4.5
+      vertex 14.0157 1.66431 0
+      vertex 13.8945 1.56482 2
+      vertex 14.0157 1.66431 2
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 52.576 -21.9525 -2.5
-      vertex 52.744 -22.139 -4.5
-      vertex 52.744 -22.139 -2.5
+      vertex 13.8945 1.56482 2
+      vertex 14.0157 1.66431 0
+      vertex 13.8945 1.56482 0
     endloop
   endfacet
-  facet normal -0.866315 -0.499497 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 52.869 -22.3558 -4.5
-      vertex 52.744 -22.139 -2.5
-      vertex 52.744 -22.139 -4.5
+      vertex 13.2939 3.01463 0
+      vertex 13.45 3.03 2
+      vertex 13.2939 3.01463 2
     endloop
   endfacet
-  facet normal -0.866315 -0.499497 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 52.744 -22.139 -2.5
-      vertex 52.869 -22.3558 -4.5
-      vertex 52.869 -22.3558 -2.5
+      vertex 13.45 3.03 2
+      vertex 13.2939 3.01463 0
+      vertex 13.45 3.03 0
     endloop
   endfacet
-  facet normal -0.950605 -0.310402 0
+  facet normal -0.290448 -0.956891 0
     outer loop
-      vertex 52.9471 -22.5951 -4.5
-      vertex 52.869 -22.3558 -2.5
-      vertex 52.869 -22.3558 -4.5
+      vertex 13.6061 3.01463 0
+      vertex 13.7561 2.9691 2
+      vertex 13.6061 3.01463 2
     endloop
   endfacet
-  facet normal -0.950605 -0.310402 0
+  facet normal -0.290448 -0.956891 -0
     outer loop
-      vertex 52.869 -22.3558 -2.5
-      vertex 52.9471 -22.5951 -4.5
-      vertex 52.9471 -22.5951 -2.5
+      vertex 13.7561 2.9691 2
+      vertex 13.6061 3.01463 0
+      vertex 13.7561 2.9691 0
     endloop
   endfacet
-  facet normal -0.994842 -0.101435 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex 52.9725 -22.8441 -4.5
-      vertex 52.9471 -22.5951 -2.5
-      vertex 52.9471 -22.5951 -4.5
+      vertex 12.8843 2.79569 0
+      vertex 13.0055 2.89518 2
+      vertex 12.8843 2.79569 2
     endloop
   endfacet
-  facet normal -0.994842 -0.101435 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex 52.9471 -22.5951 -2.5
-      vertex 52.9725 -22.8441 -4.5
-      vertex 52.9725 -22.8441 -2.5
+      vertex 13.0055 2.89518 2
+      vertex 12.8843 2.79569 0
+      vertex 13.0055 2.89518 0
     endloop
   endfacet
-  facet normal -0.994842 0.101435 0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 52.9471 -23.0931 -4.5
-      vertex 52.9725 -22.8441 -2.5
-      vertex 52.9725 -22.8441 -4.5
+      vertex 13.1439 2.9691 0
+      vertex 13.2939 3.01463 2
+      vertex 13.1439 2.9691 2
     endloop
   endfacet
-  facet normal -0.994842 0.101435 0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 52.9725 -22.8441 -2.5
-      vertex 52.9471 -23.0931 -4.5
-      vertex 52.9471 -23.0931 -2.5
+      vertex 13.2939 3.01463 2
+      vertex 13.1439 2.9691 0
+      vertex 13.2939 3.01463 0
     endloop
   endfacet
-  facet normal -0.950605 0.310402 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 52.869 -23.3324 -4.5
-      vertex 52.9471 -23.0931 -2.5
-      vertex 52.9471 -23.0931 -4.5
+      vertex 14.0157 1.66431 0
+      vertex 14.1152 1.78554 2
+      vertex 14.1152 1.78554 0
     endloop
   endfacet
-  facet normal -0.950605 0.310402 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 52.9471 -23.0931 -2.5
-      vertex 52.869 -23.3324 -4.5
-      vertex 52.869 -23.3324 -2.5
+      vertex 14.1152 1.78554 2
+      vertex 14.0157 1.66431 0
+      vertex 14.0157 1.66431 2
     endloop
   endfacet
-  facet normal -0.866315 0.499497 0
+  facet normal -0.634484 -0.772936 0
     outer loop
-      vertex 52.744 -23.5492 -4.5
-      vertex 52.869 -23.3324 -2.5
-      vertex 52.869 -23.3324 -4.5
+      vertex 13.8945 2.89518 0
+      vertex 14.0157 2.79569 2
+      vertex 13.8945 2.89518 2
     endloop
   endfacet
-  facet normal -0.866315 0.499497 0
+  facet normal -0.634484 -0.772936 -0
     outer loop
-      vertex 52.869 -23.3324 -2.5
-      vertex 52.744 -23.5492 -4.5
-      vertex 52.744 -23.5492 -2.5
+      vertex 14.0157 2.79569 2
+      vertex 13.8945 2.89518 0
+      vertex 14.0157 2.79569 0
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal 0.634484 0.772936 -0
     outer loop
-      vertex 52.576 -23.7357 -4.5
-      vertex 52.744 -23.5492 -2.5
-      vertex 52.744 -23.5492 -4.5
+      vertex 13.0055 1.56482 0
+      vertex 12.8843 1.66431 2
+      vertex 13.0055 1.56482 2
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal 0.634484 0.772936 0
     outer loop
-      vertex 52.744 -23.5492 -2.5
-      vertex 52.576 -23.7357 -4.5
-      vertex 52.576 -23.7357 -2.5
+      vertex 12.8843 1.66431 2
+      vertex 13.0055 1.56482 0
+      vertex 12.8843 1.66431 0
     endloop
   endfacet
-  facet normal -0.587471 0.809245 0
+  facet normal 0.0979887 0.995188 -0
     outer loop
-      vertex 52.576 -23.7357 -4.5
-      vertex 52.5 -23.7909 -2.5
-      vertex 52.576 -23.7357 -2.5
+      vertex 13.45 1.43 0
+      vertex 13.2939 1.44537 2
+      vertex 13.45 1.43 2
     endloop
   endfacet
-  facet normal -0.587471 0.809245 0
+  facet normal 0.0979887 0.995188 0
     outer loop
-      vertex 52.5 -23.7909 -2.5
-      vertex 52.576 -23.7357 -4.5
-      vertex 52.5 -23.7909 -4.5
+      vertex 13.2939 1.44537 2
+      vertex 13.45 1.43 0
+      vertex 13.2939 1.44537 0
     endloop
   endfacet
-  facet normal -0.407935 -0.913011 0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex 41 -21.5747 -4.5
-      vertex 41.1287 -21.6322 -2.5
-      vertex 41 -21.5747 -2.5
+      vertex 14.1891 1.92385 0
+      vertex 14.2346 2.07393 2
+      vertex 14.2346 2.07393 0
     endloop
   endfacet
-  facet normal -0.407935 -0.913011 -0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex 41.1287 -21.6322 -2.5
-      vertex 41 -21.5747 -4.5
-      vertex 41.1287 -21.6322 -4.5
+      vertex 14.2346 2.07393 2
+      vertex 14.1891 1.92385 0
+      vertex 14.1891 1.92385 2
     endloop
   endfacet
-  facet normal -0.589331 -0.807891 0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 41.1287 -21.6322 -4.5
-      vertex 41.3309 -21.7796 -2.5
-      vertex 41.1287 -21.6322 -2.5
+      vertex 13.8945 1.56482 0
+      vertex 13.7561 1.4909 2
+      vertex 13.8945 1.56482 2
     endloop
   endfacet
-  facet normal -0.589331 -0.807891 -0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 41.3309 -21.7796 -2.5
-      vertex 41.1287 -21.6322 -4.5
-      vertex 41.3309 -21.7796 -4.5
+      vertex 13.7561 1.4909 2
+      vertex 13.8945 1.56482 0
+      vertex 13.7561 1.4909 0
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 41.4989 -21.9662 -4.5
-      vertex 41.3309 -21.7796 -2.5
-      vertex 41.3309 -21.7796 -4.5
+      vertex 13.7561 1.4909 0
+      vertex 13.6061 1.44537 2
+      vertex 13.7561 1.4909 2
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 41.3309 -21.7796 -2.5
-      vertex 41.4989 -21.9662 -4.5
-      vertex 41.4989 -21.9662 -2.5
+      vertex 13.6061 1.44537 2
+      vertex 13.7561 1.4909 0
+      vertex 13.6061 1.44537 0
     endloop
   endfacet
-  facet normal -0.864625 -0.502417 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 41.6248 -22.183 -4.5
-      vertex 41.4989 -21.9662 -2.5
-      vertex 41.4989 -21.9662 -4.5
+      vertex 14.1152 2.67446 0
+      vertex 14.0157 2.79569 2
+      vertex 14.0157 2.79569 0
     endloop
   endfacet
-  facet normal -0.864625 -0.502417 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 41.4989 -21.9662 -2.5
-      vertex 41.6248 -22.183 -4.5
-      vertex 41.6248 -22.183 -2.5
+      vertex 14.0157 2.79569 2
+      vertex 14.1152 2.67446 0
+      vertex 14.1152 2.67446 2
     endloop
   endfacet
-  facet normal -0.951745 -0.306889 0
+  facet normal -0.471117 -0.882071 0
     outer loop
-      vertex 41.702 -22.4222 -4.5
-      vertex 41.6248 -22.183 -2.5
-      vertex 41.6248 -22.183 -4.5
+      vertex 13.7561 2.9691 0
+      vertex 13.8945 2.89518 2
+      vertex 13.7561 2.9691 2
     endloop
   endfacet
-  facet normal -0.951745 -0.306889 0
+  facet normal -0.471117 -0.882071 -0
     outer loop
-      vertex 41.6248 -22.183 -2.5
-      vertex 41.702 -22.4222 -4.5
-      vertex 41.702 -22.4222 -2.5
+      vertex 13.8945 2.89518 2
+      vertex 13.7561 2.9691 0
+      vertex 13.8945 2.89518 0
     endloop
   endfacet
-  facet normal -0.994441 -0.105294 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 41.7284 -22.6712 -4.5
-      vertex 41.702 -22.4222 -2.5
-      vertex 41.702 -22.4222 -4.5
+      vertex 13.0055 2.89518 0
+      vertex 13.1439 2.9691 2
+      vertex 13.0055 2.89518 2
     endloop
   endfacet
-  facet normal -0.994441 -0.105294 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 41.702 -22.4222 -2.5
-      vertex 41.7284 -22.6712 -4.5
-      vertex 41.7284 -22.6712 -2.5
+      vertex 13.1439 2.9691 2
+      vertex 13.0055 2.89518 0
+      vertex 13.1439 2.9691 0
     endloop
   endfacet
-  facet normal -0.994484 0.104887 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex 41.702 -22.9212 -4.5
-      vertex 41.7284 -22.6712 -2.5
-      vertex 41.7284 -22.6712 -4.5
+      vertex 13.6061 1.44537 0
+      vertex 13.45 1.43 2
+      vertex 13.6061 1.44537 2
     endloop
   endfacet
-  facet normal -0.994484 0.104887 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex 41.7284 -22.6712 -2.5
-      vertex 41.702 -22.9212 -4.5
-      vertex 41.702 -22.9212 -2.5
+      vertex 13.45 1.43 2
+      vertex 13.6061 1.44537 0
+      vertex 13.45 1.43 0
     endloop
   endfacet
-  facet normal -0.951377 0.308028 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 41.6248 -23.1595 -4.5
-      vertex 41.702 -22.9212 -2.5
-      vertex 41.702 -22.9212 -4.5
+      vertex 12.6654 2.07393 2
+      vertex 12.65 2.23 0
+      vertex 12.65 2.23 2
     endloop
   endfacet
-  facet normal -0.951377 0.308028 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 41.702 -22.9212 -2.5
-      vertex 41.6248 -23.1595 -4.5
-      vertex 41.6248 -23.1595 -2.5
+      vertex 12.65 2.23 0
+      vertex 12.6654 2.07393 2
+      vertex 12.6654 2.07393 0
     endloop
   endfacet
-  facet normal -0.864625 0.502417 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 41.4989 -23.3763 -4.5
-      vertex 41.6248 -23.1595 -2.5
-      vertex 41.6248 -23.1595 -4.5
+      vertex 12.7848 2.67446 2
+      vertex 12.8843 2.79569 0
+      vertex 12.8843 2.79569 2
     endloop
   endfacet
-  facet normal -0.864625 0.502417 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 41.6248 -23.1595 -2.5
-      vertex 41.4989 -23.3763 -4.5
-      vertex 41.4989 -23.3763 -2.5
+      vertex 12.8843 2.79569 0
+      vertex 12.7848 2.67446 2
+      vertex 12.7848 2.67446 0
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal 0.471117 0.882071 -0
     outer loop
-      vertex 41.3309 -23.5629 -4.5
-      vertex 41.4989 -23.3763 -2.5
-      vertex 41.4989 -23.3763 -4.5
+      vertex 13.1439 1.4909 0
+      vertex 13.0055 1.56482 2
+      vertex 13.1439 1.4909 2
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal 0.471117 0.882071 0
     outer loop
-      vertex 41.4989 -23.3763 -2.5
-      vertex 41.3309 -23.5629 -4.5
-      vertex 41.3309 -23.5629 -2.5
+      vertex 13.0055 1.56482 2
+      vertex 13.1439 1.4909 0
+      vertex 13.0055 1.56482 0
     endloop
   endfacet
-  facet normal -0.589331 0.807891 0
+  facet normal -0.0979887 -0.995188 0
     outer loop
-      vertex 41.3309 -23.5629 -4.5
-      vertex 41.1287 -23.7103 -2.5
-      vertex 41.3309 -23.5629 -2.5
+      vertex 13.45 3.03 0
+      vertex 13.6061 3.01463 2
+      vertex 13.45 3.03 2
     endloop
   endfacet
-  facet normal -0.589331 0.807891 0
+  facet normal -0.0979887 -0.995188 -0
     outer loop
-      vertex 41.1287 -23.7103 -2.5
-      vertex 41.3309 -23.5629 -4.5
-      vertex 41.1287 -23.7103 -4.5
+      vertex 13.6061 3.01463 2
+      vertex 13.45 3.03 0
+      vertex 13.6061 3.01463 0
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 41.1287 -23.7103 -4.5
-      vertex 40.8993 -23.8129 -2.5
-      vertex 41.1287 -23.7103 -2.5
+      vertex 12.6654 2.38607 2
+      vertex 12.7109 2.53615 0
+      vertex 12.7109 2.53615 2
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 40.8993 -23.8129 -2.5
-      vertex 41.1287 -23.7103 -4.5
-      vertex 40.8993 -23.8129 -4.5
+      vertex 12.7109 2.53615 0
+      vertex 12.6654 2.38607 2
+      vertex 12.6654 2.38607 0
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 40.8993 -23.8129 -4.5
-      vertex 40.6541 -23.8646 -2.5
-      vertex 40.8993 -23.8129 -2.5
+      vertex 16.5557 1.66431 0
+      vertex 16.4345 1.56482 2
+      vertex 16.5557 1.66431 2
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 40.6541 -23.8646 -2.5
-      vertex 40.8993 -23.8129 -4.5
-      vertex 40.6541 -23.8646 -4.5
+      vertex 16.4345 1.56482 2
+      vertex 16.5557 1.66431 0
+      vertex 16.4345 1.56482 0
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 40.6541 -23.8646 -4.5
-      vertex 40.4032 -23.8646 -2.5
-      vertex 40.6541 -23.8646 -2.5
+      vertex 16.7746 2.38607 0
+      vertex 16.7291 2.53615 2
+      vertex 16.7291 2.53615 0
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 40.4032 -23.8646 -2.5
-      vertex 40.6541 -23.8646 -4.5
-      vertex 40.4032 -23.8646 -4.5
+      vertex 16.7291 2.53615 2
+      vertex 16.7746 2.38607 0
+      vertex 16.7746 2.38607 2
     endloop
   endfacet
-  facet normal 0.2066 0.978426 -0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 40.4032 -23.8646 -4.5
-      vertex 40.158 -23.8129 -2.5
-      vertex 40.4032 -23.8646 -2.5
+      vertex 16.79 2.23 0
+      vertex 16.7746 2.38607 2
+      vertex 16.7746 2.38607 0
     endloop
   endfacet
-  facet normal 0.2066 0.978426 0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 40.158 -23.8129 -2.5
-      vertex 40.4032 -23.8646 -4.5
-      vertex 40.158 -23.8129 -4.5
+      vertex 16.7746 2.38607 2
+      vertex 16.79 2.23 0
+      vertex 16.79 2.23 2
     endloop
   endfacet
-  facet normal 0.40794 0.913009 -0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 40.158 -23.8129 -4.5
-      vertex 39.9286 -23.7103 -2.5
-      vertex 40.158 -23.8129 -2.5
+      vertex 16.7291 2.53615 0
+      vertex 16.6552 2.67446 2
+      vertex 16.6552 2.67446 0
     endloop
   endfacet
-  facet normal 0.40794 0.913009 0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 39.9286 -23.7103 -2.5
-      vertex 40.158 -23.8129 -4.5
-      vertex 39.9286 -23.7103 -4.5
+      vertex 16.6552 2.67446 2
+      vertex 16.7291 2.53615 0
+      vertex 16.7291 2.53615 2
     endloop
   endfacet
-  facet normal 0.587477 0.809241 -0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 39.9286 -23.7103 -4.5
-      vertex 39.7254 -23.5629 -2.5
-      vertex 39.9286 -23.7103 -2.5
+      vertex 16.7746 2.07393 0
+      vertex 16.79 2.23 2
+      vertex 16.79 2.23 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 39.7254 -23.5629 -2.5
-      vertex 39.9286 -23.7103 -4.5
-      vertex 39.7254 -23.5629 -4.5
+      vertex 16.79 2.23 2
+      vertex 16.7746 2.07393 0
+      vertex 16.7746 2.07393 2
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal 0.0979887 0.995188 -0
     outer loop
-      vertex 39.7254 -23.5629 -2.5
-      vertex 39.6688 -23.5 -4.5
-      vertex 39.6688 -23.5 -2.5
+      vertex 15.99 1.43 0
+      vertex 15.8339 1.44537 2
+      vertex 15.99 1.43 2
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal 0.0979887 0.995188 0
     outer loop
-      vertex 39.6688 -23.5 -4.5
-      vertex 39.7254 -23.5629 -2.5
-      vertex 39.7254 -23.5629 -4.5
+      vertex 15.8339 1.44537 2
+      vertex 15.99 1.43 0
+      vertex 15.8339 1.44537 0
     endloop
   endfacet
-  facet normal -0.743101 0.669179 0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 38.7909 -23.5629 -4.5
-      vertex 38.8475 -23.5 -2.5
-      vertex 38.8475 -23.5 -4.5
+      vertex 15.3248 1.78554 2
+      vertex 15.2509 1.92385 0
+      vertex 15.2509 1.92385 2
     endloop
   endfacet
-  facet normal -0.743101 0.669179 0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 38.8475 -23.5 -2.5
-      vertex 38.7909 -23.5629 -4.5
-      vertex 38.7909 -23.5629 -2.5
+      vertex 15.2509 1.92385 0
+      vertex 15.3248 1.78554 2
+      vertex 15.3248 1.78554 0
     endloop
   endfacet
-  facet normal -0.589331 0.807891 0
+  facet normal -0.290448 -0.956891 0
     outer loop
-      vertex 38.7909 -23.5629 -4.5
-      vertex 38.5887 -23.7103 -2.5
-      vertex 38.7909 -23.5629 -2.5
+      vertex 16.1461 3.01463 0
+      vertex 16.2961 2.9691 2
+      vertex 16.1461 3.01463 2
     endloop
   endfacet
-  facet normal -0.589331 0.807891 0
+  facet normal -0.290448 -0.956891 -0
     outer loop
-      vertex 38.5887 -23.7103 -2.5
-      vertex 38.7909 -23.5629 -4.5
-      vertex 38.5887 -23.7103 -4.5
+      vertex 16.2961 2.9691 2
+      vertex 16.1461 3.01463 0
+      vertex 16.2961 2.9691 0
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 38.5887 -23.7103 -4.5
-      vertex 38.3592 -23.8129 -2.5
-      vertex 38.5887 -23.7103 -2.5
+      vertex 16.5557 1.66431 0
+      vertex 16.6552 1.78554 2
+      vertex 16.6552 1.78554 0
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 38.3592 -23.8129 -2.5
-      vertex 38.5887 -23.7103 -4.5
-      vertex 38.3592 -23.8129 -4.5
+      vertex 16.6552 1.78554 2
+      vertex 16.5557 1.66431 0
+      vertex 16.5557 1.66431 2
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 38.3592 -23.8129 -4.5
-      vertex 38.1141 -23.8646 -2.5
-      vertex 38.3592 -23.8129 -2.5
+      vertex 16.6552 2.67446 0
+      vertex 16.5557 2.79569 2
+      vertex 16.5557 2.79569 0
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 38.1141 -23.8646 -2.5
-      vertex 38.3592 -23.8129 -4.5
-      vertex 38.1141 -23.8646 -4.5
+      vertex 16.5557 2.79569 2
+      vertex 16.6552 2.67446 0
+      vertex 16.6552 2.67446 2
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 38.1141 -23.8646 -4.5
-      vertex 37.8631 -23.8646 -2.5
-      vertex 38.1141 -23.8646 -2.5
+      vertex 15.5455 2.89518 0
+      vertex 15.6839 2.9691 2
+      vertex 15.5455 2.89518 2
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 37.8631 -23.8646 -2.5
-      vertex 38.1141 -23.8646 -4.5
-      vertex 37.8631 -23.8646 -4.5
+      vertex 15.6839 2.9691 2
+      vertex 15.5455 2.89518 0
+      vertex 15.6839 2.9691 0
     endloop
   endfacet
-  facet normal 0.2066 0.978426 -0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex 37.8631 -23.8646 -4.5
-      vertex 37.618 -23.8129 -2.5
-      vertex 37.8631 -23.8646 -2.5
+      vertex 16.7291 1.92385 0
+      vertex 16.7746 2.07393 2
+      vertex 16.7746 2.07393 0
     endloop
   endfacet
-  facet normal 0.2066 0.978426 0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex 37.618 -23.8129 -2.5
-      vertex 37.8631 -23.8646 -4.5
-      vertex 37.618 -23.8129 -4.5
+      vertex 16.7746 2.07393 2
+      vertex 16.7291 1.92385 0
+      vertex 16.7291 1.92385 2
     endloop
   endfacet
-  facet normal 0.40794 0.913009 -0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 37.618 -23.8129 -4.5
-      vertex 37.3885 -23.7103 -2.5
-      vertex 37.618 -23.8129 -2.5
+      vertex 15.4243 1.66431 2
+      vertex 15.3248 1.78554 0
+      vertex 15.3248 1.78554 2
     endloop
   endfacet
-  facet normal 0.40794 0.913009 0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 37.3885 -23.7103 -2.5
-      vertex 37.618 -23.8129 -4.5
-      vertex 37.3885 -23.7103 -4.5
+      vertex 15.3248 1.78554 0
+      vertex 15.4243 1.66431 2
+      vertex 15.4243 1.66431 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 -0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex 37.3885 -23.7103 -4.5
-      vertex 37.1854 -23.5629 -2.5
-      vertex 37.3885 -23.7103 -2.5
+      vertex 15.2509 1.92385 2
+      vertex 15.2054 2.07393 0
+      vertex 15.2054 2.07393 2
     endloop
   endfacet
-  facet normal 0.587477 0.809241 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex 37.1854 -23.5629 -2.5
-      vertex 37.3885 -23.7103 -4.5
-      vertex 37.1854 -23.5629 -4.5
+      vertex 15.2054 2.07393 0
+      vertex 15.2509 1.92385 2
+      vertex 15.2509 1.92385 0
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 37.1854 -23.5629 -2.5
-      vertex 37.1288 -23.5 -4.5
-      vertex 37.1288 -23.5 -2.5
+      vertex 16.2961 1.4909 0
+      vertex 16.1461 1.44537 2
+      vertex 16.2961 1.4909 2
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 37.1288 -23.5 -4.5
-      vertex 37.1854 -23.5629 -2.5
-      vertex 37.1854 -23.5629 -4.5
+      vertex 16.1461 1.44537 2
+      vertex 16.2961 1.4909 0
+      vertex 16.1461 1.44537 0
     endloop
   endfacet
-  facet normal -0.745032 0.667029 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 36.2518 -23.5629 -4.5
-      vertex 36.3081 -23.5 -2.5
-      vertex 36.3081 -23.5 -4.5
+      vertex 15.8339 3.01463 0
+      vertex 15.99 3.03 2
+      vertex 15.8339 3.01463 2
     endloop
   endfacet
-  facet normal -0.745032 0.667029 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 36.3081 -23.5 -2.5
-      vertex 36.2518 -23.5629 -4.5
-      vertex 36.2518 -23.5629 -2.5
+      vertex 15.99 3.03 2
+      vertex 15.8339 3.01463 0
+      vertex 15.99 3.03 0
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex 36.2518 -23.5629 -4.5
-      vertex 36.0487 -23.7103 -2.5
-      vertex 36.2518 -23.5629 -2.5
+      vertex 15.19 2.23 2
+      vertex 15.2054 2.38607 0
+      vertex 15.2054 2.38607 2
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex 36.0487 -23.7103 -2.5
-      vertex 36.2518 -23.5629 -4.5
-      vertex 36.0487 -23.7103 -4.5
+      vertex 15.2054 2.38607 0
+      vertex 15.19 2.23 2
+      vertex 15.19 2.23 0
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal 0.290448 0.956891 -0
     outer loop
-      vertex 36.0487 -23.7103 -4.5
-      vertex 35.8192 -23.8129 -2.5
-      vertex 36.0487 -23.7103 -2.5
+      vertex 15.8339 1.44537 0
+      vertex 15.6839 1.4909 2
+      vertex 15.8339 1.44537 2
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal 0.290448 0.956891 0
     outer loop
-      vertex 35.8192 -23.8129 -2.5
-      vertex 36.0487 -23.7103 -4.5
-      vertex 35.8192 -23.8129 -4.5
+      vertex 15.6839 1.4909 2
+      vertex 15.8339 1.44537 0
+      vertex 15.6839 1.4909 0
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex 35.8192 -23.8129 -4.5
-      vertex 35.5741 -23.8646 -2.5
-      vertex 35.8192 -23.8129 -2.5
+      vertex 15.4243 2.79569 0
+      vertex 15.5455 2.89518 2
+      vertex 15.4243 2.79569 2
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex 35.5741 -23.8646 -2.5
-      vertex 35.8192 -23.8129 -4.5
-      vertex 35.5741 -23.8646 -4.5
+      vertex 15.5455 2.89518 2
+      vertex 15.4243 2.79569 0
+      vertex 15.5455 2.89518 0
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 35.5741 -23.8646 -4.5
-      vertex 35.3231 -23.8646 -2.5
-      vertex 35.5741 -23.8646 -2.5
+      vertex 15.6839 2.9691 0
+      vertex 15.8339 3.01463 2
+      vertex 15.6839 2.9691 2
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 35.3231 -23.8646 -2.5
-      vertex 35.5741 -23.8646 -4.5
-      vertex 35.3231 -23.8646 -4.5
+      vertex 15.8339 3.01463 2
+      vertex 15.6839 2.9691 0
+      vertex 15.8339 3.01463 0
     endloop
   endfacet
-  facet normal 0.2066 0.978426 -0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 35.3231 -23.8646 -4.5
-      vertex 35.078 -23.8129 -2.5
-      vertex 35.3231 -23.8646 -2.5
+      vertex 16.4345 1.56482 0
+      vertex 16.2961 1.4909 2
+      vertex 16.4345 1.56482 2
     endloop
   endfacet
-  facet normal 0.2066 0.978426 0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 35.078 -23.8129 -2.5
-      vertex 35.3231 -23.8646 -4.5
-      vertex 35.078 -23.8129 -4.5
+      vertex 16.2961 1.4909 2
+      vertex 16.4345 1.56482 0
+      vertex 16.2961 1.4909 0
     endloop
   endfacet
-  facet normal 0.40794 0.913009 -0
+  facet normal 0.634484 0.772936 -0
     outer loop
-      vertex 35.078 -23.8129 -4.5
-      vertex 34.8485 -23.7103 -2.5
-      vertex 35.078 -23.8129 -2.5
+      vertex 15.5455 1.56482 0
+      vertex 15.4243 1.66431 2
+      vertex 15.5455 1.56482 2
     endloop
   endfacet
-  facet normal 0.40794 0.913009 0
+  facet normal 0.634484 0.772936 0
     outer loop
-      vertex 34.8485 -23.7103 -2.5
-      vertex 35.078 -23.8129 -4.5
-      vertex 34.8485 -23.7103 -4.5
+      vertex 15.4243 1.66431 2
+      vertex 15.5455 1.56482 0
+      vertex 15.4243 1.66431 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 -0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex 34.8485 -23.7103 -4.5
-      vertex 34.6454 -23.5629 -2.5
-      vertex 34.8485 -23.7103 -2.5
+      vertex 16.6552 1.78554 0
+      vertex 16.7291 1.92385 2
+      vertex 16.7291 1.92385 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex 34.6454 -23.5629 -2.5
-      vertex 34.8485 -23.7103 -4.5
-      vertex 34.6454 -23.5629 -4.5
+      vertex 16.7291 1.92385 2
+      vertex 16.6552 1.78554 0
+      vertex 16.6552 1.78554 2
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal -0.634484 -0.772936 0
     outer loop
-      vertex 34.6454 -23.5629 -2.5
-      vertex 34.5888 -23.5 -4.5
-      vertex 34.5888 -23.5 -2.5
+      vertex 16.4345 2.89518 0
+      vertex 16.5557 2.79569 2
+      vertex 16.4345 2.89518 2
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal -0.634484 -0.772936 -0
     outer loop
-      vertex 34.5888 -23.5 -4.5
-      vertex 34.6454 -23.5629 -2.5
-      vertex 34.6454 -23.5629 -4.5
+      vertex 16.5557 2.79569 2
+      vertex 16.4345 2.89518 0
+      vertex 16.5557 2.79569 0
     endloop
   endfacet
-  facet normal -0.745032 0.667029 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 33.7118 -23.5629 -4.5
-      vertex 33.768 -23.5 -2.5
-      vertex 33.768 -23.5 -4.5
+      vertex 15.2509 2.53615 2
+      vertex 15.3248 2.67446 0
+      vertex 15.3248 2.67446 2
     endloop
   endfacet
-  facet normal -0.745032 0.667029 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 33.768 -23.5 -2.5
-      vertex 33.7118 -23.5629 -4.5
-      vertex 33.7118 -23.5629 -2.5
+      vertex 15.3248 2.67446 0
+      vertex 15.2509 2.53615 2
+      vertex 15.2509 2.53615 0
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal -0.471117 -0.882071 0
     outer loop
-      vertex 33.7118 -23.5629 -4.5
-      vertex 33.5086 -23.7103 -2.5
-      vertex 33.7118 -23.5629 -2.5
+      vertex 16.2961 2.9691 0
+      vertex 16.4345 2.89518 2
+      vertex 16.2961 2.9691 2
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal -0.471117 -0.882071 -0
     outer loop
-      vertex 33.5086 -23.7103 -2.5
-      vertex 33.7118 -23.5629 -4.5
-      vertex 33.5086 -23.7103 -4.5
+      vertex 16.4345 2.89518 2
+      vertex 16.2961 2.9691 0
+      vertex 16.4345 2.89518 0
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex 33.5086 -23.7103 -4.5
-      vertex 33.2791 -23.8129 -2.5
-      vertex 33.5086 -23.7103 -2.5
+      vertex 16.1461 1.44537 0
+      vertex 15.99 1.43 2
+      vertex 16.1461 1.44537 2
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex 33.2791 -23.8129 -2.5
-      vertex 33.5086 -23.7103 -4.5
-      vertex 33.2791 -23.8129 -4.5
+      vertex 15.99 1.43 2
+      vertex 16.1461 1.44537 0
+      vertex 15.99 1.43 0
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 33.2791 -23.8129 -4.5
-      vertex 33.034 -23.8646 -2.5
-      vertex 33.2791 -23.8129 -2.5
+      vertex 15.2054 2.07393 2
+      vertex 15.19 2.23 0
+      vertex 15.19 2.23 2
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 33.034 -23.8646 -2.5
-      vertex 33.2791 -23.8129 -4.5
-      vertex 33.034 -23.8646 -4.5
+      vertex 15.19 2.23 0
+      vertex 15.2054 2.07393 2
+      vertex 15.2054 2.07393 0
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 33.034 -23.8646 -4.5
-      vertex 32.783 -23.8646 -2.5
-      vertex 33.034 -23.8646 -2.5
+      vertex 15.3248 2.67446 2
+      vertex 15.4243 2.79569 0
+      vertex 15.4243 2.79569 2
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 32.783 -23.8646 -2.5
-      vertex 33.034 -23.8646 -4.5
-      vertex 32.783 -23.8646 -4.5
+      vertex 15.4243 2.79569 0
+      vertex 15.3248 2.67446 2
+      vertex 15.3248 2.67446 0
     endloop
   endfacet
-  facet normal 0.2066 0.978426 -0
+  facet normal 0.471117 0.882071 -0
     outer loop
-      vertex 32.783 -23.8646 -4.5
-      vertex 32.5379 -23.8129 -2.5
-      vertex 32.783 -23.8646 -2.5
+      vertex 15.6839 1.4909 0
+      vertex 15.5455 1.56482 2
+      vertex 15.6839 1.4909 2
     endloop
   endfacet
-  facet normal 0.2066 0.978426 0
+  facet normal 0.471117 0.882071 0
     outer loop
-      vertex 32.5379 -23.8129 -2.5
-      vertex 32.783 -23.8646 -4.5
-      vertex 32.5379 -23.8129 -4.5
+      vertex 15.5455 1.56482 2
+      vertex 15.6839 1.4909 0
+      vertex 15.5455 1.56482 0
     endloop
   endfacet
-  facet normal 0.40794 0.913009 -0
+  facet normal -0.0979887 -0.995188 0
     outer loop
-      vertex 32.5379 -23.8129 -4.5
-      vertex 32.3084 -23.7103 -2.5
-      vertex 32.5379 -23.8129 -2.5
+      vertex 15.99 3.03 0
+      vertex 16.1461 3.01463 2
+      vertex 15.99 3.03 2
     endloop
   endfacet
-  facet normal 0.40794 0.913009 0
+  facet normal -0.0979887 -0.995188 -0
     outer loop
-      vertex 32.3084 -23.7103 -2.5
-      vertex 32.5379 -23.8129 -4.5
-      vertex 32.3084 -23.7103 -4.5
+      vertex 16.1461 3.01463 2
+      vertex 15.99 3.03 0
+      vertex 16.1461 3.01463 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 -0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 32.3084 -23.7103 -4.5
-      vertex 32.1053 -23.5629 -2.5
-      vertex 32.3084 -23.7103 -2.5
+      vertex 15.2054 2.38607 2
+      vertex 15.2509 2.53615 0
+      vertex 15.2509 2.53615 2
     endloop
   endfacet
-  facet normal 0.587477 0.809241 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 32.1053 -23.5629 -2.5
-      vertex 32.3084 -23.7103 -4.5
-      vertex 32.1053 -23.5629 -4.5
+      vertex 15.2509 2.53615 0
+      vertex 15.2054 2.38607 2
+      vertex 15.2054 2.38607 0
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal -0.290448 -0.956891 0
     outer loop
-      vertex 32.1053 -23.5629 -2.5
-      vertex 32.0487 -23.5 -4.5
-      vertex 32.0487 -23.5 -2.5
+      vertex 18.6861 3.01463 0
+      vertex 18.8361 2.9691 2
+      vertex 18.6861 3.01463 2
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal -0.290448 -0.956891 -0
     outer loop
-      vertex 32.0487 -23.5 -4.5
-      vertex 32.1053 -23.5629 -2.5
-      vertex 32.1053 -23.5629 -4.5
+      vertex 18.8361 2.9691 2
+      vertex 18.6861 3.01463 0
+      vertex 18.8361 2.9691 0
     endloop
   endfacet
-  facet normal -0.743101 0.669179 0
+  facet normal 0.471117 0.882071 -0
     outer loop
-      vertex 31.1717 -23.5629 -4.5
-      vertex 31.2283 -23.5 -2.5
-      vertex 31.2283 -23.5 -4.5
+      vertex 18.2239 1.4909 0
+      vertex 18.0855 1.56482 2
+      vertex 18.2239 1.4909 2
     endloop
   endfacet
-  facet normal -0.743101 0.669179 0
+  facet normal 0.471117 0.882071 0
     outer loop
-      vertex 31.2283 -23.5 -2.5
-      vertex 31.1717 -23.5629 -4.5
-      vertex 31.1717 -23.5629 -2.5
+      vertex 18.0855 1.56482 2
+      vertex 18.2239 1.4909 0
+      vertex 18.0855 1.56482 0
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex 31.1717 -23.5629 -4.5
-      vertex 30.9686 -23.7103 -2.5
-      vertex 31.1717 -23.5629 -2.5
+      vertex 17.9643 2.79569 0
+      vertex 18.0855 2.89518 2
+      vertex 17.9643 2.79569 2
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex 30.9686 -23.7103 -2.5
-      vertex 31.1717 -23.5629 -4.5
-      vertex 30.9686 -23.7103 -4.5
+      vertex 18.0855 2.89518 2
+      vertex 17.9643 2.79569 0
+      vertex 18.0855 2.89518 0
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 30.9686 -23.7103 -4.5
-      vertex 30.7391 -23.8129 -2.5
-      vertex 30.9686 -23.7103 -2.5
+      vertex 19.3146 2.07393 0
+      vertex 19.33 2.23 2
+      vertex 19.33 2.23 0
     endloop
   endfacet
-  facet normal -0.40794 0.913009 0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 30.7391 -23.8129 -2.5
-      vertex 30.9686 -23.7103 -4.5
-      vertex 30.7391 -23.8129 -4.5
+      vertex 19.33 2.23 2
+      vertex 19.3146 2.07393 0
+      vertex 19.3146 2.07393 2
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 30.7391 -23.8129 -4.5
-      vertex 30.494 -23.8646 -2.5
-      vertex 30.7391 -23.8129 -2.5
+      vertex 19.2691 2.53615 0
+      vertex 19.1952 2.67446 2
+      vertex 19.1952 2.67446 0
     endloop
   endfacet
-  facet normal -0.2066 0.978426 0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 30.494 -23.8646 -2.5
-      vertex 30.7391 -23.8129 -4.5
-      vertex 30.494 -23.8646 -4.5
+      vertex 19.1952 2.67446 2
+      vertex 19.2691 2.53615 0
+      vertex 19.2691 2.53615 2
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 30.494 -23.8646 -4.5
-      vertex 30.243 -23.8646 -2.5
-      vertex 30.494 -23.8646 -2.5
+      vertex 19.33 2.23 0
+      vertex 19.3146 2.38607 2
+      vertex 19.3146 2.38607 0
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 30.243 -23.8646 -2.5
-      vertex 30.494 -23.8646 -4.5
-      vertex 30.243 -23.8646 -4.5
+      vertex 19.3146 2.38607 2
+      vertex 19.33 2.23 0
+      vertex 19.33 2.23 2
     endloop
   endfacet
-  facet normal 0.2066 0.978426 -0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 30.243 -23.8646 -4.5
-      vertex 29.9979 -23.8129 -2.5
-      vertex 30.243 -23.8646 -2.5
+      vertex 17.7454 2.07393 2
+      vertex 17.73 2.23 0
+      vertex 17.73 2.23 2
     endloop
   endfacet
-  facet normal 0.2066 0.978426 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 29.9979 -23.8129 -2.5
-      vertex 30.243 -23.8646 -4.5
-      vertex 29.9979 -23.8129 -4.5
+      vertex 17.73 2.23 0
+      vertex 17.7454 2.07393 2
+      vertex 17.7454 2.07393 0
     endloop
   endfacet
-  facet normal 0.40794 0.913009 -0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 29.9979 -23.8129 -4.5
-      vertex 29.7684 -23.7103 -2.5
-      vertex 29.9979 -23.8129 -2.5
+      vertex 18.9745 1.56482 0
+      vertex 18.8361 1.4909 2
+      vertex 18.9745 1.56482 2
     endloop
   endfacet
-  facet normal 0.40794 0.913009 0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 29.7684 -23.7103 -2.5
-      vertex 29.9979 -23.8129 -4.5
-      vertex 29.7684 -23.7103 -4.5
+      vertex 18.8361 1.4909 2
+      vertex 18.9745 1.56482 0
+      vertex 18.8361 1.4909 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 -0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 29.7684 -23.7103 -4.5
-      vertex 29.5653 -23.5629 -2.5
-      vertex 29.7684 -23.7103 -2.5
+      vertex 17.7454 2.38607 2
+      vertex 17.7909 2.53615 0
+      vertex 17.7909 2.53615 2
     endloop
   endfacet
-  facet normal 0.587477 0.809241 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 29.5653 -23.5629 -2.5
-      vertex 29.7684 -23.7103 -4.5
-      vertex 29.5653 -23.5629 -4.5
+      vertex 17.7909 2.53615 0
+      vertex 17.7454 2.38607 2
+      vertex 17.7454 2.38607 0
     endloop
   endfacet
-  facet normal 0.743101 0.66918 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 29.5653 -23.5629 -2.5
-      vertex 29.3973 -23.3763 -4.5
-      vertex 29.3973 -23.3763 -2.5
+      vertex 18.8361 1.4909 0
+      vertex 18.6861 1.44537 2
+      vertex 18.8361 1.4909 2
     endloop
   endfacet
-  facet normal 0.743101 0.66918 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 29.3973 -23.3763 -4.5
-      vertex 29.5653 -23.5629 -2.5
-      vertex 29.5653 -23.5629 -4.5
+      vertex 18.6861 1.44537 2
+      vertex 18.8361 1.4909 0
+      vertex 18.6861 1.44537 0
     endloop
   endfacet
-  facet normal 0.866315 0.499497 0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 29.3973 -23.3763 -2.5
-      vertex 29.2723 -23.1595 -4.5
-      vertex 29.2723 -23.1595 -2.5
+      vertex 19.3146 2.38607 0
+      vertex 19.2691 2.53615 2
+      vertex 19.2691 2.53615 0
     endloop
   endfacet
-  facet normal 0.866315 0.499497 0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 29.2723 -23.1595 -4.5
-      vertex 29.3973 -23.3763 -2.5
-      vertex 29.3973 -23.3763 -4.5
+      vertex 19.2691 2.53615 2
+      vertex 19.3146 2.38607 0
+      vertex 19.3146 2.38607 2
     endloop
   endfacet
-  facet normal 0.95023 0.311551 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 29.2723 -23.1595 -2.5
-      vertex 29.1942 -22.9212 -4.5
-      vertex 29.1942 -22.9212 -2.5
+      vertex 19.0957 1.66431 0
+      vertex 18.9745 1.56482 2
+      vertex 19.0957 1.66431 2
     endloop
   endfacet
-  facet normal 0.95023 0.311551 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 29.1942 -22.9212 -4.5
-      vertex 29.2723 -23.1595 -2.5
-      vertex 29.2723 -23.1595 -4.5
+      vertex 18.9745 1.56482 2
+      vertex 19.0957 1.66431 0
+      vertex 18.9745 1.56482 0
     endloop
   endfacet
-  facet normal 0.994882 0.101043 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 29.1942 -22.9212 -2.5
-      vertex 29.1688 -22.6712 -4.5
-      vertex 29.1688 -22.6712 -2.5
+      vertex 18.3739 3.01463 0
+      vertex 18.53 3.03 2
+      vertex 18.3739 3.01463 2
     endloop
   endfacet
-  facet normal 0.994882 0.101043 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 29.1688 -22.6712 -4.5
-      vertex 29.1942 -22.9212 -2.5
-      vertex 29.1942 -22.9212 -4.5
+      vertex 18.53 3.03 2
+      vertex 18.3739 3.01463 0
+      vertex 18.53 3.03 0
     endloop
   endfacet
-  facet normal 0.994842 -0.101435 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 29.1688 -22.6712 -2.5
-      vertex 29.1942 -22.4222 -4.5
-      vertex 29.1942 -22.4222 -2.5
+      vertex 17.8648 2.67446 2
+      vertex 17.9643 2.79569 0
+      vertex 17.9643 2.79569 2
     endloop
   endfacet
-  facet normal 0.994842 -0.101435 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 29.1942 -22.4222 -4.5
-      vertex 29.1688 -22.6712 -2.5
-      vertex 29.1688 -22.6712 -4.5
+      vertex 17.9643 2.79569 0
+      vertex 17.8648 2.67446 2
+      vertex 17.8648 2.67446 0
     endloop
   endfacet
-  facet normal 0.950605 -0.310402 0
+  facet normal 0.634484 0.772936 -0
     outer loop
-      vertex 29.1942 -22.4222 -2.5
-      vertex 29.2723 -22.183 -4.5
-      vertex 29.2723 -22.183 -2.5
+      vertex 18.0855 1.56482 0
+      vertex 17.9643 1.66431 2
+      vertex 18.0855 1.56482 2
     endloop
   endfacet
-  facet normal 0.950605 -0.310402 0
+  facet normal 0.634484 0.772936 0
     outer loop
-      vertex 29.2723 -22.183 -4.5
-      vertex 29.1942 -22.4222 -2.5
-      vertex 29.1942 -22.4222 -4.5
+      vertex 17.9643 1.66431 2
+      vertex 18.0855 1.56482 0
+      vertex 17.9643 1.66431 0
     endloop
   endfacet
-  facet normal 0.866315 -0.499497 0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 29.2723 -22.183 -2.5
-      vertex 29.3973 -21.9662 -4.5
-      vertex 29.3973 -21.9662 -2.5
+      vertex 18.2239 2.9691 0
+      vertex 18.3739 3.01463 2
+      vertex 18.2239 2.9691 2
     endloop
   endfacet
-  facet normal 0.866315 -0.499497 0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 29.3973 -21.9662 -4.5
-      vertex 29.2723 -22.183 -2.5
-      vertex 29.2723 -22.183 -4.5
+      vertex 18.3739 3.01463 2
+      vertex 18.2239 2.9691 0
+      vertex 18.3739 3.01463 0
     endloop
   endfacet
-  facet normal 0.743101 -0.66918 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex 29.3973 -21.9662 -2.5
-      vertex 29.5653 -21.7796 -4.5
-      vertex 29.5653 -21.7796 -2.5
+      vertex 19.1952 1.78554 0
+      vertex 19.2691 1.92385 2
+      vertex 19.2691 1.92385 0
     endloop
   endfacet
-  facet normal 0.743101 -0.66918 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex 29.5653 -21.7796 -4.5
-      vertex 29.3973 -21.9662 -2.5
-      vertex 29.3973 -21.9662 -4.5
+      vertex 19.2691 1.92385 2
+      vertex 19.1952 1.78554 0
+      vertex 19.1952 1.78554 2
     endloop
   endfacet
-  facet normal 0.587477 -0.809241 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 29.5653 -21.7796 -4.5
-      vertex 29.7684 -21.6322 -2.5
-      vertex 29.5653 -21.7796 -2.5
+      vertex 19.0957 1.66431 0
+      vertex 19.1952 1.78554 2
+      vertex 19.1952 1.78554 0
     endloop
   endfacet
-  facet normal 0.587477 -0.809241 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 29.7684 -21.6322 -2.5
-      vertex 29.5653 -21.7796 -4.5
-      vertex 29.7684 -21.6322 -4.5
+      vertex 19.1952 1.78554 2
+      vertex 19.0957 1.66431 0
+      vertex 19.0957 1.66431 2
     endloop
   endfacet
-  facet normal 0.40794 -0.913009 0
+  facet normal -0.634484 -0.772936 0
     outer loop
-      vertex 29.7684 -21.6322 -4.5
-      vertex 29.9979 -21.5296 -2.5
-      vertex 29.7684 -21.6322 -2.5
+      vertex 18.9745 2.89518 0
+      vertex 19.0957 2.79569 2
+      vertex 18.9745 2.89518 2
     endloop
   endfacet
-  facet normal 0.40794 -0.913009 0
+  facet normal -0.634484 -0.772936 -0
     outer loop
-      vertex 29.9979 -21.5296 -2.5
-      vertex 29.7684 -21.6322 -4.5
-      vertex 29.9979 -21.5296 -4.5
+      vertex 19.0957 2.79569 2
+      vertex 18.9745 2.89518 0
+      vertex 19.0957 2.79569 0
     endloop
   endfacet
-  facet normal 0.206991 -0.978343 0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex 29.9979 -21.5296 -4.5
-      vertex 30 -21.5292 -2.5
-      vertex 29.9979 -21.5296 -2.5
+      vertex 19.2691 1.92385 0
+      vertex 19.3146 2.07393 2
+      vertex 19.3146 2.07393 0
     endloop
   endfacet
-  facet normal 0.206991 -0.978343 0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex 30 -21.5292 -2.5
-      vertex 29.9979 -21.5296 -4.5
-      vertex 30 -21.5292 -4.5
+      vertex 19.3146 2.07393 2
+      vertex 19.2691 1.92385 0
+      vertex 19.2691 1.92385 2
     endloop
   endfacet
-  facet normal 0.587472 0.809244 -0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 48.5 -21.2468 -4.5
-      vertex 48.4295 -21.1957 -2.5
-      vertex 48.5 -21.2468 -2.5
+      vertex 17.9643 1.66431 2
+      vertex 17.8648 1.78554 0
+      vertex 17.8648 1.78554 2
     endloop
   endfacet
-  facet normal 0.587472 0.809244 0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 48.4295 -21.1957 -2.5
-      vertex 48.5 -21.2468 -4.5
-      vertex 48.4295 -21.1957 -4.5
+      vertex 17.8648 1.78554 0
+      vertex 17.9643 1.66431 2
+      vertex 17.9643 1.66431 0
     endloop
   endfacet
-  facet normal 0.745037 0.667023 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 48.4295 -21.1957 -2.5
-      vertex 48.2625 -21.0091 -4.5
-      vertex 48.2625 -21.0091 -2.5
+      vertex 19.1952 2.67446 0
+      vertex 19.0957 2.79569 2
+      vertex 19.0957 2.79569 0
     endloop
   endfacet
-  facet normal 0.745037 0.667023 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 48.2625 -21.0091 -4.5
-      vertex 48.4295 -21.1957 -2.5
-      vertex 48.4295 -21.1957 -4.5
+      vertex 19.0957 2.79569 2
+      vertex 19.1952 2.67446 0
+      vertex 19.1952 2.67446 2
     endloop
   endfacet
-  facet normal 0.864625 0.502417 0
+  facet normal -0.471117 -0.882071 0
     outer loop
-      vertex 48.2625 -21.0091 -2.5
-      vertex 48.1366 -20.7923 -4.5
-      vertex 48.1366 -20.7923 -2.5
+      vertex 18.8361 2.9691 0
+      vertex 18.9745 2.89518 2
+      vertex 18.8361 2.9691 2
     endloop
   endfacet
-  facet normal 0.864625 0.502417 0
+  facet normal -0.471117 -0.882071 -0
     outer loop
-      vertex 48.1366 -20.7923 -4.5
-      vertex 48.2625 -21.0091 -2.5
-      vertex 48.2625 -21.0091 -4.5
+      vertex 18.9745 2.89518 2
+      vertex 18.8361 2.9691 0
+      vertex 18.9745 2.89518 0
     endloop
   endfacet
-  facet normal 0.951377 0.308028 0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 48.1366 -20.7923 -2.5
-      vertex 48.0594 -20.5541 -4.5
-      vertex 48.0594 -20.5541 -2.5
+      vertex 17.8648 1.78554 2
+      vertex 17.7909 1.92385 0
+      vertex 17.7909 1.92385 2
     endloop
   endfacet
-  facet normal 0.951377 0.308028 0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 48.0594 -20.5541 -4.5
-      vertex 48.1366 -20.7923 -2.5
-      vertex 48.1366 -20.7923 -4.5
+      vertex 17.7909 1.92385 0
+      vertex 17.8648 1.78554 2
+      vertex 17.8648 1.78554 0
     endloop
   endfacet
-  facet normal 0.994484 0.104887 0
+  facet normal 0.290448 0.956891 -0
     outer loop
-      vertex 48.0594 -20.5541 -2.5
-      vertex 48.033 -20.3041 -4.5
-      vertex 48.033 -20.3041 -2.5
+      vertex 18.3739 1.44537 0
+      vertex 18.2239 1.4909 2
+      vertex 18.3739 1.44537 2
     endloop
   endfacet
-  facet normal 0.994484 0.104887 0
+  facet normal 0.290448 0.956891 0
     outer loop
-      vertex 48.033 -20.3041 -4.5
-      vertex 48.0594 -20.5541 -2.5
-      vertex 48.0594 -20.5541 -4.5
+      vertex 18.2239 1.4909 2
+      vertex 18.3739 1.44537 0
+      vertex 18.2239 1.4909 0
     endloop
   endfacet
-  facet normal 0.994441 -0.105294 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 48.033 -20.3041 -2.5
-      vertex 48.0594 -20.055 -4.5
-      vertex 48.0594 -20.055 -2.5
+      vertex 18.0855 2.89518 0
+      vertex 18.2239 2.9691 2
+      vertex 18.0855 2.89518 2
     endloop
   endfacet
-  facet normal 0.994441 -0.105294 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 48.0594 -20.055 -4.5
-      vertex 48.033 -20.3041 -2.5
-      vertex 48.033 -20.3041 -4.5
+      vertex 18.2239 2.9691 2
+      vertex 18.0855 2.89518 0
+      vertex 18.2239 2.9691 0
     endloop
   endfacet
-  facet normal 0.951751 -0.306872 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex 48.0594 -20.055 -2.5
-      vertex 48.0772 -20 -4.5
-      vertex 48.0772 -20 -2.5
+      vertex 17.73 2.23 2
+      vertex 17.7454 2.38607 0
+      vertex 17.7454 2.38607 2
     endloop
   endfacet
-  facet normal 0.951751 -0.306872 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex 48.0772 -20 -4.5
-      vertex 48.0594 -20.055 -2.5
-      vertex 48.0594 -20.055 -4.5
+      vertex 17.7454 2.38607 0
+      vertex 17.73 2.23 2
+      vertex 17.73 2.23 0
     endloop
   endfacet
-  facet normal -0.950609 -0.310391 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex 52.9471 -20.055 -4.5
-      vertex 52.9291 -20 -2.5
-      vertex 52.9291 -20 -4.5
+      vertex 18.6861 1.44537 0
+      vertex 18.53 1.43 2
+      vertex 18.6861 1.44537 2
     endloop
   endfacet
-  facet normal -0.950609 -0.310391 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex 52.9291 -20 -2.5
-      vertex 52.9471 -20.055 -4.5
-      vertex 52.9471 -20.055 -2.5
+      vertex 18.53 1.43 2
+      vertex 18.6861 1.44537 0
+      vertex 18.53 1.43 0
     endloop
   endfacet
-  facet normal -0.994842 -0.101435 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex 52.9725 -20.3041 -4.5
-      vertex 52.9471 -20.055 -2.5
-      vertex 52.9471 -20.055 -4.5
+      vertex 17.7909 1.92385 2
+      vertex 17.7454 2.07393 0
+      vertex 17.7454 2.07393 2
     endloop
   endfacet
-  facet normal -0.994842 -0.101435 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex 52.9471 -20.055 -2.5
-      vertex 52.9725 -20.3041 -4.5
-      vertex 52.9725 -20.3041 -2.5
+      vertex 17.7454 2.07393 0
+      vertex 17.7909 1.92385 2
+      vertex 17.7909 1.92385 0
     endloop
   endfacet
-  facet normal -0.994882 0.101043 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 52.9471 -20.5541 -4.5
-      vertex 52.9725 -20.3041 -2.5
-      vertex 52.9725 -20.3041 -4.5
+      vertex 17.7909 2.53615 2
+      vertex 17.8648 2.67446 0
+      vertex 17.8648 2.67446 2
     endloop
   endfacet
-  facet normal -0.994882 0.101043 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 52.9725 -20.3041 -2.5
-      vertex 52.9471 -20.5541 -4.5
-      vertex 52.9471 -20.5541 -2.5
+      vertex 17.8648 2.67446 0
+      vertex 17.7909 2.53615 2
+      vertex 17.7909 2.53615 0
     endloop
   endfacet
-  facet normal -0.95023 0.311551 0
+  facet normal -0.0979887 -0.995188 0
     outer loop
-      vertex 52.869 -20.7923 -4.5
-      vertex 52.9471 -20.5541 -2.5
-      vertex 52.9471 -20.5541 -4.5
+      vertex 18.53 3.03 0
+      vertex 18.6861 3.01463 2
+      vertex 18.53 3.03 2
     endloop
   endfacet
-  facet normal -0.95023 0.311551 0
+  facet normal -0.0979887 -0.995188 -0
     outer loop
-      vertex 52.9471 -20.5541 -2.5
-      vertex 52.869 -20.7923 -4.5
-      vertex 52.869 -20.7923 -2.5
+      vertex 18.6861 3.01463 2
+      vertex 18.53 3.03 0
+      vertex 18.6861 3.01463 0
     endloop
   endfacet
-  facet normal -0.866315 0.499497 0
+  facet normal 0.0979887 0.995188 -0
     outer loop
-      vertex 52.744 -21.0091 -4.5
-      vertex 52.869 -20.7923 -2.5
-      vertex 52.869 -20.7923 -4.5
+      vertex 18.53 1.43 0
+      vertex 18.3739 1.44537 2
+      vertex 18.53 1.43 2
     endloop
   endfacet
-  facet normal -0.866315 0.499497 0
+  facet normal 0.0979887 0.995188 0
     outer loop
-      vertex 52.869 -20.7923 -2.5
-      vertex 52.744 -21.0091 -4.5
-      vertex 52.744 -21.0091 -2.5
+      vertex 18.3739 1.44537 2
+      vertex 18.53 1.43 0
+      vertex 18.3739 1.44537 0
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 52.576 -21.1957 -4.5
-      vertex 52.744 -21.0091 -2.5
-      vertex 52.744 -21.0091 -4.5
+      vertex 26.4561 1.4909 0
+      vertex 26.3061 1.44537 2
+      vertex 26.4561 1.4909 2
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 52.744 -21.0091 -2.5
-      vertex 52.576 -21.1957 -4.5
-      vertex 52.576 -21.1957 -2.5
+      vertex 26.3061 1.44537 2
+      vertex 26.4561 1.4909 0
+      vertex 26.3061 1.44537 0
     endloop
   endfacet
-  facet normal -0.587471 0.809245 0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 52.576 -21.1957 -4.5
-      vertex 52.5 -21.2508 -2.5
-      vertex 52.576 -21.1957 -2.5
+      vertex 26.9346 2.38607 0
+      vertex 26.8891 2.53615 2
+      vertex 26.8891 2.53615 0
     endloop
   endfacet
-  facet normal -0.587471 0.809245 0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 52.5 -21.2508 -2.5
-      vertex 52.576 -21.1957 -4.5
-      vertex 52.5 -21.2508 -4.5
+      vertex 26.8891 2.53615 2
+      vertex 26.9346 2.38607 0
+      vertex 26.9346 2.38607 2
     endloop
   endfacet
-  facet normal -0.994441 -0.105296 0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 41.7284 -20.1312 -4.5
-      vertex 41.7145 -20 -2.5
-      vertex 41.7145 -20 -4.5
+      vertex 26.95 2.23 0
+      vertex 26.9346 2.38607 2
+      vertex 26.9346 2.38607 0
     endloop
   endfacet
-  facet normal -0.994441 -0.105296 0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 41.7145 -20 -2.5
-      vertex 41.7284 -20.1312 -4.5
-      vertex 41.7284 -20.1312 -2.5
+      vertex 26.9346 2.38607 2
+      vertex 26.95 2.23 0
+      vertex 26.95 2.23 2
     endloop
   endfacet
-  facet normal -0.994484 0.104887 0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 41.702 -20.3812 -4.5
-      vertex 41.7284 -20.1312 -2.5
-      vertex 41.7284 -20.1312 -4.5
+      vertex 26.8891 2.53615 0
+      vertex 26.8152 2.67446 2
+      vertex 26.8152 2.67446 0
     endloop
   endfacet
-  facet normal -0.994484 0.104887 0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 41.7284 -20.1312 -2.5
-      vertex 41.702 -20.3812 -4.5
-      vertex 41.702 -20.3812 -2.5
+      vertex 26.8152 2.67446 2
+      vertex 26.8891 2.53615 0
+      vertex 26.8891 2.53615 2
     endloop
   endfacet
-  facet normal -0.951377 0.308028 0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 41.6248 -20.6195 -4.5
-      vertex 41.702 -20.3812 -2.5
-      vertex 41.702 -20.3812 -4.5
+      vertex 25.4848 1.78554 2
+      vertex 25.4109 1.92385 0
+      vertex 25.4109 1.92385 2
     endloop
   endfacet
-  facet normal -0.951377 0.308028 0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 41.702 -20.3812 -2.5
-      vertex 41.6248 -20.6195 -4.5
-      vertex 41.6248 -20.6195 -2.5
+      vertex 25.4109 1.92385 0
+      vertex 25.4848 1.78554 2
+      vertex 25.4848 1.78554 0
     endloop
   endfacet
-  facet normal -0.864625 0.502417 0
+  facet normal -0.290448 -0.956891 0
     outer loop
-      vertex 41.4989 -20.8363 -4.5
-      vertex 41.6248 -20.6195 -2.5
-      vertex 41.6248 -20.6195 -4.5
+      vertex 26.3061 3.01463 0
+      vertex 26.4561 2.9691 2
+      vertex 26.3061 3.01463 2
     endloop
   endfacet
-  facet normal -0.864625 0.502417 0
+  facet normal -0.290448 -0.956891 -0
     outer loop
-      vertex 41.6248 -20.6195 -2.5
-      vertex 41.4989 -20.8363 -4.5
-      vertex 41.4989 -20.8363 -2.5
+      vertex 26.4561 2.9691 2
+      vertex 26.3061 3.01463 0
+      vertex 26.4561 2.9691 0
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 41.3309 -21.0228 -4.5
-      vertex 41.4989 -20.8363 -2.5
-      vertex 41.4989 -20.8363 -4.5
+      vertex 25.9939 3.01463 0
+      vertex 26.15 3.03 2
+      vertex 25.9939 3.01463 2
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 41.4989 -20.8363 -2.5
-      vertex 41.3309 -21.0228 -4.5
-      vertex 41.3309 -21.0228 -2.5
+      vertex 26.15 3.03 2
+      vertex 25.9939 3.01463 0
+      vertex 26.15 3.03 0
     endloop
   endfacet
-  facet normal -0.589331 0.807891 0
+  facet normal 0.471117 0.882071 -0
     outer loop
-      vertex 41.3309 -21.0228 -4.5
-      vertex 41.1287 -21.1703 -2.5
-      vertex 41.3309 -21.0228 -2.5
+      vertex 25.8439 1.4909 0
+      vertex 25.7055 1.56482 2
+      vertex 25.8439 1.4909 2
     endloop
   endfacet
-  facet normal -0.589331 0.807891 0
+  facet normal 0.471117 0.882071 0
     outer loop
-      vertex 41.1287 -21.1703 -2.5
-      vertex 41.3309 -21.0228 -4.5
-      vertex 41.1287 -21.1703 -4.5
+      vertex 25.7055 1.56482 2
+      vertex 25.8439 1.4909 0
+      vertex 25.7055 1.56482 0
     endloop
   endfacet
-  facet normal -0.407935 0.913011 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 41.1287 -21.1703 -4.5
-      vertex 41 -21.2278 -2.5
-      vertex 41.1287 -21.1703 -2.5
+      vertex 25.7055 2.89518 0
+      vertex 25.8439 2.9691 2
+      vertex 25.7055 2.89518 2
     endloop
   endfacet
-  facet normal -0.407935 0.913011 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 41 -21.2278 -2.5
-      vertex 41.1287 -21.1703 -4.5
-      vertex 41 -21.2278 -4.5
+      vertex 25.8439 2.9691 2
+      vertex 25.7055 2.89518 0
+      vertex 25.8439 2.9691 0
     endloop
   endfacet
-  facet normal 0.206991 0.978343 -0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 30 -21.2733 -4.5
-      vertex 29.9979 -21.2728 -2.5
-      vertex 30 -21.2733 -2.5
+      vertex 26.5945 1.56482 0
+      vertex 26.4561 1.4909 2
+      vertex 26.5945 1.56482 2
     endloop
   endfacet
-  facet normal 0.206991 0.978343 0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 29.9979 -21.2728 -2.5
-      vertex 30 -21.2733 -4.5
-      vertex 29.9979 -21.2728 -4.5
+      vertex 26.4561 1.4909 2
+      vertex 26.5945 1.56482 0
+      vertex 26.4561 1.4909 0
     endloop
   endfacet
-  facet normal 0.40794 0.913009 -0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 29.9979 -21.2728 -4.5
-      vertex 29.7684 -21.1703 -2.5
-      vertex 29.9979 -21.2728 -2.5
+      vertex 25.4848 2.67446 2
+      vertex 25.5843 2.79569 0
+      vertex 25.5843 2.79569 2
     endloop
   endfacet
-  facet normal 0.40794 0.913009 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 29.7684 -21.1703 -2.5
-      vertex 29.9979 -21.2728 -4.5
-      vertex 29.7684 -21.1703 -4.5
+      vertex 25.5843 2.79569 0
+      vertex 25.4848 2.67446 2
+      vertex 25.4848 2.67446 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 -0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 29.7684 -21.1703 -4.5
-      vertex 29.5653 -21.0228 -2.5
-      vertex 29.7684 -21.1703 -2.5
+      vertex 26.8152 2.67446 0
+      vertex 26.7157 2.79569 2
+      vertex 26.7157 2.79569 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 29.5653 -21.0228 -2.5
-      vertex 29.7684 -21.1703 -4.5
-      vertex 29.5653 -21.0228 -4.5
+      vertex 26.7157 2.79569 2
+      vertex 26.8152 2.67446 0
+      vertex 26.8152 2.67446 2
     endloop
   endfacet
-  facet normal 0.743101 0.66918 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 29.5653 -21.0228 -2.5
-      vertex 29.3973 -20.8363 -4.5
-      vertex 29.3973 -20.8363 -2.5
+      vertex 26.7157 1.66431 0
+      vertex 26.8152 1.78554 2
+      vertex 26.8152 1.78554 0
     endloop
   endfacet
-  facet normal 0.743101 0.66918 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 29.3973 -20.8363 -4.5
-      vertex 29.5653 -21.0228 -2.5
-      vertex 29.5653 -21.0228 -4.5
+      vertex 26.8152 1.78554 2
+      vertex 26.7157 1.66431 0
+      vertex 26.7157 1.66431 2
     endloop
   endfacet
-  facet normal 0.866315 0.499497 0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 29.3973 -20.8363 -2.5
-      vertex 29.2723 -20.6195 -4.5
-      vertex 29.2723 -20.6195 -2.5
+      vertex 25.8439 2.9691 0
+      vertex 25.9939 3.01463 2
+      vertex 25.8439 2.9691 2
     endloop
   endfacet
-  facet normal 0.866315 0.499497 0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 29.2723 -20.6195 -4.5
-      vertex 29.3973 -20.8363 -2.5
-      vertex 29.3973 -20.8363 -4.5
+      vertex 25.9939 3.01463 2
+      vertex 25.8439 2.9691 0
+      vertex 25.9939 3.01463 0
     endloop
   endfacet
-  facet normal 0.95023 0.311551 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 29.2723 -20.6195 -2.5
-      vertex 29.1942 -20.3812 -4.5
-      vertex 29.1942 -20.3812 -2.5
+      vertex 26.7157 1.66431 0
+      vertex 26.5945 1.56482 2
+      vertex 26.7157 1.66431 2
     endloop
   endfacet
-  facet normal 0.95023 0.311551 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex 29.1942 -20.3812 -4.5
-      vertex 29.2723 -20.6195 -2.5
-      vertex 29.2723 -20.6195 -4.5
+      vertex 26.5945 1.56482 2
+      vertex 26.7157 1.66431 0
+      vertex 26.5945 1.56482 0
     endloop
   endfacet
-  facet normal 0.994882 0.101043 0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 29.1942 -20.3812 -2.5
-      vertex 29.1688 -20.1312 -4.5
-      vertex 29.1688 -20.1312 -2.5
+      vertex 26.9346 2.07393 0
+      vertex 26.95 2.23 2
+      vertex 26.95 2.23 0
     endloop
   endfacet
-  facet normal 0.994882 0.101043 0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex 29.1688 -20.1312 -4.5
-      vertex 29.1942 -20.3812 -2.5
-      vertex 29.1942 -20.3812 -4.5
+      vertex 26.95 2.23 2
+      vertex 26.9346 2.07393 0
+      vertex 26.9346 2.07393 2
     endloop
   endfacet
-  facet normal 0.994842 -0.101434 0
+  facet normal 0.290448 0.956891 -0
     outer loop
-      vertex 29.1688 -20.1312 -2.5
-      vertex 29.1822 -20 -4.5
-      vertex 29.1822 -20 -2.5
+      vertex 25.9939 1.44537 0
+      vertex 25.8439 1.4909 2
+      vertex 25.9939 1.44537 2
     endloop
   endfacet
-  facet normal 0.994842 -0.101434 0
+  facet normal 0.290448 0.956891 0
     outer loop
-      vertex 29.1822 -20 -4.5
-      vertex 29.1688 -20.1312 -2.5
-      vertex 29.1688 -20.1312 -4.5
+      vertex 25.8439 1.4909 2
+      vertex 25.9939 1.44537 0
+      vertex 25.8439 1.4909 0
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex -0.360507 -18.3714 -4.5
-      vertex -0.296169 -18.3 -2.5
-      vertex -0.296169 -18.3 -4.5
+      vertex 26.8891 1.92385 0
+      vertex 26.9346 2.07393 2
+      vertex 26.9346 2.07393 0
     endloop
   endfacet
-  facet normal -0.743101 0.66918 0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex -0.296169 -18.3 -2.5
-      vertex -0.360507 -18.3714 -4.5
-      vertex -0.360507 -18.3714 -2.5
+      vertex 26.9346 2.07393 2
+      vertex 26.8891 1.92385 0
+      vertex 26.8891 1.92385 2
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex -0.360507 -18.3714 -4.5
-      vertex -0.563632 -18.5189 -2.5
-      vertex -0.360507 -18.3714 -2.5
+      vertex 25.4109 1.92385 2
+      vertex 25.3654 2.07393 0
+      vertex 25.3654 2.07393 2
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex -0.563632 -18.5189 -2.5
-      vertex -0.360507 -18.3714 -4.5
-      vertex -0.563632 -18.5189 -4.5
+      vertex 25.3654 2.07393 0
+      vertex 25.4109 1.92385 2
+      vertex 25.4109 1.92385 0
     endloop
   endfacet
-  facet normal -0.406138 0.913812 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex -0.563632 -18.5189 -4.5
-      vertex -0.792148 -18.6205 -2.5
-      vertex -0.563632 -18.5189 -2.5
+      vertex 26.8152 1.78554 0
+      vertex 26.8891 1.92385 2
+      vertex 26.8891 1.92385 0
     endloop
   endfacet
-  facet normal -0.406138 0.913812 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex -0.792148 -18.6205 -2.5
-      vertex -0.563632 -18.5189 -4.5
-      vertex -0.792148 -18.6205 -4.5
+      vertex 26.8891 1.92385 2
+      vertex 26.8152 1.78554 0
+      vertex 26.8152 1.78554 2
     endloop
   endfacet
-  facet normal -0.210327 0.977631 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex -0.792148 -18.6205 -4.5
-      vertex -1.03726 -18.6732 -2.5
-      vertex -0.792148 -18.6205 -2.5
+      vertex 25.35 2.23 2
+      vertex 25.3654 2.38607 0
+      vertex 25.3654 2.38607 2
     endloop
   endfacet
-  facet normal -0.210327 0.977631 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex -1.03726 -18.6732 -2.5
-      vertex -0.792148 -18.6205 -4.5
-      vertex -1.03726 -18.6732 -4.5
+      vertex 25.3654 2.38607 0
+      vertex 25.35 2.23 2
+      vertex 25.35 2.23 0
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal -0.0979887 -0.995188 0
     outer loop
-      vertex -1.03726 -18.6732 -4.5
-      vertex -1.28824 -18.6732 -2.5
-      vertex -1.03726 -18.6732 -2.5
+      vertex 26.15 3.03 0
+      vertex 26.3061 3.01463 2
+      vertex 26.15 3.03 2
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal -0.0979887 -0.995188 -0
     outer loop
-      vertex -1.28824 -18.6732 -2.5
-      vertex -1.03726 -18.6732 -4.5
-      vertex -1.28824 -18.6732 -4.5
+      vertex 26.3061 3.01463 2
+      vertex 26.15 3.03 0
+      vertex 26.3061 3.01463 0
     endloop
   endfacet
-  facet normal 0.209529 0.977802 -0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex -1.28824 -18.6732 -4.5
-      vertex -1.53434 -18.6205 -2.5
-      vertex -1.28824 -18.6732 -2.5
+      vertex 25.5843 2.79569 0
+      vertex 25.7055 2.89518 2
+      vertex 25.5843 2.79569 2
     endloop
   endfacet
-  facet normal 0.209529 0.977802 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex -1.53434 -18.6205 -2.5
-      vertex -1.28824 -18.6732 -4.5
-      vertex -1.53434 -18.6205 -4.5
+      vertex 25.7055 2.89518 2
+      vertex 25.5843 2.79569 0
+      vertex 25.7055 2.89518 0
     endloop
   endfacet
-  facet normal 0.406138 0.913812 -0
+  facet normal -0.634484 -0.772936 0
     outer loop
-      vertex -1.53434 -18.6205 -4.5
-      vertex -1.76285 -18.5189 -2.5
-      vertex -1.53434 -18.6205 -2.5
+      vertex 26.5945 2.89518 0
+      vertex 26.7157 2.79569 2
+      vertex 26.5945 2.89518 2
     endloop
   endfacet
-  facet normal 0.406138 0.913812 0
+  facet normal -0.634484 -0.772936 -0
     outer loop
-      vertex -1.76285 -18.5189 -2.5
-      vertex -1.53434 -18.6205 -4.5
-      vertex -1.76285 -18.5189 -4.5
+      vertex 26.7157 2.79569 2
+      vertex 26.5945 2.89518 0
+      vertex 26.7157 2.79569 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 -0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex -1.76285 -18.5189 -4.5
-      vertex -1.96598 -18.3714 -2.5
-      vertex -1.76285 -18.5189 -2.5
+      vertex 26.3061 1.44537 0
+      vertex 26.15 1.43 2
+      vertex 26.3061 1.44537 2
     endloop
   endfacet
-  facet normal 0.587477 0.809241 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex -1.96598 -18.3714 -2.5
-      vertex -1.76285 -18.5189 -4.5
-      vertex -1.96598 -18.3714 -4.5
+      vertex 26.15 1.43 2
+      vertex 26.3061 1.44537 0
+      vertex 26.15 1.43 0
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal -0.471117 -0.882071 0
     outer loop
-      vertex -1.96598 -18.3714 -2.5
-      vertex -2.03031 -18.3 -4.5
-      vertex -2.03031 -18.3 -2.5
+      vertex 26.4561 2.9691 0
+      vertex 26.5945 2.89518 2
+      vertex 26.4561 2.9691 2
     endloop
   endfacet
-  facet normal 0.743101 0.669179 0
+  facet normal -0.471117 -0.882071 -0
     outer loop
-      vertex -2.03031 -18.3 -4.5
-      vertex -1.96598 -18.3714 -2.5
-      vertex -1.96598 -18.3714 -4.5
+      vertex 26.5945 2.89518 2
+      vertex 26.4561 2.9691 0
+      vertex 26.5945 2.89518 0
     endloop
   endfacet
-  facet normal -0.743101 0.669179 0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 2.17953 -18.3714 -4.5
-      vertex 2.24387 -18.3 -2.5
-      vertex 2.24387 -18.3 -4.5
+      vertex 25.5843 1.66431 2
+      vertex 25.4848 1.78554 0
+      vertex 25.4848 1.78554 2
     endloop
   endfacet
-  facet normal -0.743101 0.669179 0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 2.24387 -18.3 -2.5
-      vertex 2.17953 -18.3714 -4.5
-      vertex 2.17953 -18.3714 -2.5
+      vertex 25.4848 1.78554 0
+      vertex 25.5843 1.66431 2
+      vertex 25.5843 1.66431 0
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal 0.0979887 0.995188 -0
     outer loop
-      vertex 2.17953 -18.3714 -4.5
-      vertex 1.97641 -18.5189 -2.5
-      vertex 2.17953 -18.3714 -2.5
+      vertex 26.15 1.43 0
+      vertex 25.9939 1.44537 2
+      vertex 26.15 1.43 2
     endloop
   endfacet
-  facet normal -0.587477 0.809241 0
+  facet normal 0.0979887 0.995188 0
     outer loop
-      vertex 1.97641 -18.5189 -2.5
-      vertex 2.17953 -18.3714 -4.5
-      vertex 1.97641 -18.5189 -4.5
+      vertex 25.9939 1.44537 2
+      vertex 26.15 1.43 0
+      vertex 25.9939 1.44537 0
     endloop
   endfacet
-  facet normal -0.406138 0.913812 0
+  facet normal 0.634484 0.772936 -0
     outer loop
-      vertex 1.97641 -18.5189 -4.5
-      vertex 1.74789 -18.6205 -2.5
-      vertex 1.97641 -18.5189 -2.5
+      vertex 25.7055 1.56482 0
+      vertex 25.5843 1.66431 2
+      vertex 25.7055 1.56482 2
     endloop
   endfacet
-  facet normal -0.406138 0.913812 0
+  facet normal 0.634484 0.772936 0
     outer loop
-      vertex 1.74789 -18.6205 -2.5
-      vertex 1.97641 -18.5189 -4.5
-      vertex 1.74789 -18.6205 -4.5
+      vertex 25.5843 1.66431 2
+      vertex 25.7055 1.56482 0
+      vertex 25.5843 1.66431 0
     endloop
   endfacet
-  facet normal -0.209529 0.977802 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 1.74789 -18.6205 -4.5
-      vertex 1.5018 -18.6732 -2.5
-      vertex 1.74789 -18.6205 -2.5
+      vertex 25.3654 2.38607 2
+      vertex 25.4109 2.53615 0
+      vertex 25.4109 2.53615 2
     endloop
   endfacet
-  facet normal -0.209529 0.977802 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex 1.5018 -18.6732 -2.5
-      vertex 1.74789 -18.6205 -4.5
-      vertex 1.5018 -18.6732 -4.5
+      vertex 25.4109 2.53615 0
+      vertex 25.3654 2.38607 2
+      vertex 25.3654 2.38607 0
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 1.5018 -18.6732 -4.5
-      vertex 1.2518 -18.6732 -2.5
-      vertex 1.5018 -18.6732 -2.5
+      vertex 25.4109 2.53615 2
+      vertex 25.4848 2.67446 0
+      vertex 25.4848 2.67446 2
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex 1.2518 -18.6732 -2.5
-      vertex 1.5018 -18.6732 -4.5
-      vertex 1.2518 -18.6732 -4.5
+      vertex 25.4848 2.67446 0
+      vertex 25.4109 2.53615 2
+      vertex 25.4109 2.53615 0
     endloop
   endfacet
-  facet normal 0.209529 0.977802 -0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 1.2518 -18.6732 -4.5
-      vertex 1.0057 -18.6205 -2.5
-      vertex 1.2518 -18.6732 -2.5
+      vertex 25.3654 2.07393 2
+      vertex 25.35 2.23 0
+      vertex 25.35 2.23 2
     endloop
   endfacet
-  facet normal 0.209529 0.977802 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex 1.0057 -18.6205 -2.5
-      vertex 1.2518 -18.6732 -4.5
-      vertex 1.0057 -18.6205 -4.5
+      vertex 25.35 2.23 0
+      vertex 25.3654 2.07393 2
+      vertex 25.3654 2.07393 0
     endloop
   endfacet
-  facet normal 0.406138 0.913812 -0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 1.0057 -18.6205 -4.5
-      vertex 0.777187 -18.5189 -2.5
-      vertex 1.0057 -18.6205 -2.5
+      vertex 26.4561 4.0309 0
+      vertex 26.3061 3.98537 2
+      vertex 26.4561 4.0309 2
     endloop
   endfacet
-  facet normal 0.406138 0.913812 0
+  facet normal -0.290448 0.956891 0
     outer loop
-      vertex 0.777187 -18.5189 -2.5
-      vertex 1.0057 -18.6205 -4.5
-      vertex 0.777187 -18.5189 -4.5
+      vertex 26.3061 3.98537 2
+      vertex 26.4561 4.0309 0
+      vertex 26.3061 3.98537 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 -0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 0.777187 -18.5189 -4.5
-      vertex 0.574062 -18.3714 -2.5
-      vertex 0.777187 -18.5189 -2.5
+      vertex 26.9346 4.92607 0
+      vertex 26.8891 5.07615 2
+      vertex 26.8891 5.07615 0
     endloop
   endfacet
-  facet normal 0.587477 0.809241 0
+  facet normal -0.956987 -0.290131 0
     outer loop
-      vertex 0.574062 -18.3714 -2.5
-      vertex 0.777187 -18.5189 -4.5
-      vertex 0.574062 -18.3714 -4.5
+      vertex 26.8891 5.07615 2
+      vertex 26.9346 4.92607 0
+      vertex 26.9346 4.92607 2
     endloop
   endfacet
-  facet normal 0.743101 0.66918 0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 0.574062 -18.3714 -2.5
-      vertex 0.509724 -18.3 -4.5
-      vertex 0.509724 -18.3 -2.5
+      vertex 26.95 4.77 0
+      vertex 26.9346 4.92607 2
+      vertex 26.9346 4.92607 0
     endloop
   endfacet
-  facet normal 0.743101 0.66918 0
+  facet normal -0.995167 -0.0981968 0
     outer loop
-      vertex 0.509724 -18.3 -4.5
-      vertex 0.574062 -18.3714 -2.5
-      vertex 0.574062 -18.3714 -4.5
+      vertex 26.9346 4.92607 2
+      vertex 26.95 4.77 0
+      vertex 26.95 4.77 2
     endloop
   endfacet
-  facet normal -0.409392 -0.912359 0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 1.74789 -13.7982 -4.5
-      vertex 1.97641 -13.9007 -2.5
-      vertex 1.74789 -13.7982 -2.5
+      vertex 26.8891 5.07615 0
+      vertex 26.8152 5.21446 2
+      vertex 26.8152 5.21446 0
     endloop
   endfacet
-  facet normal -0.409392 -0.912359 -0
+  facet normal -0.881996 -0.471257 0
     outer loop
-      vertex 1.97641 -13.9007 -2.5
-      vertex 1.74789 -13.7982 -4.5
-      vertex 1.97641 -13.9007 -4.5
+      vertex 26.8152 5.21446 2
+      vertex 26.8891 5.07615 0
+      vertex 26.8891 5.07615 2
     endloop
   endfacet
-  facet normal -0.587477 -0.809241 0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 1.97641 -13.9007 -4.5
-      vertex 2.17953 -14.0482 -2.5
-      vertex 1.97641 -13.9007 -2.5
+      vertex 25.4848 4.32554 2
+      vertex 25.4109 4.46385 0
+      vertex 25.4109 4.46385 2
     endloop
   endfacet
-  facet normal -0.587477 -0.809241 -0
+  facet normal 0.881996 0.471257 0
     outer loop
-      vertex 2.17953 -14.0482 -2.5
-      vertex 1.97641 -13.9007 -4.5
-      vertex 2.17953 -14.0482 -4.5
+      vertex 25.4109 4.46385 0
+      vertex 25.4848 4.32554 2
+      vertex 25.4848 4.32554 0
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal -0.290448 -0.956891 0
     outer loop
-      vertex 2.3475 -14.2347 -4.5
-      vertex 2.17953 -14.0482 -2.5
-      vertex 2.17953 -14.0482 -4.5
+      vertex 26.3061 5.55463 0
+      vertex 26.4561 5.5091 2
+      vertex 26.3061 5.55463 2
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal -0.290448 -0.956891 -0
     outer loop
-      vertex 2.17953 -14.0482 -2.5
-      vertex 2.3475 -14.2347 -4.5
-      vertex 2.3475 -14.2347 -2.5
+      vertex 26.4561 5.5091 2
+      vertex 26.3061 5.55463 0
+      vertex 26.4561 5.5091 0
     endloop
   endfacet
-  facet normal -0.864625 -0.502417 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 2.38543 -14.3 -4.5
-      vertex 2.3475 -14.2347 -2.5
-      vertex 2.3475 -14.2347 -4.5
+      vertex 25.9939 5.55463 0
+      vertex 26.15 5.57 2
+      vertex 25.9939 5.55463 2
     endloop
   endfacet
-  facet normal -0.864625 -0.502417 0
+  facet normal 0.0979887 -0.995188 0
     outer loop
-      vertex 2.3475 -14.2347 -2.5
-      vertex 2.38543 -14.3 -4.5
-      vertex 2.38543 -14.3 -2.5
+      vertex 26.15 5.57 2
+      vertex 25.9939 5.55463 0
+      vertex 26.15 5.57 0
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal 0.471117 0.882071 -0
     outer loop
-      vertex 0.368165 -14.3 -2.5
-      vertex 0.406094 -14.2347 -4.5
-      vertex 0.406094 -14.2347 -2.5
+      vertex 25.8439 4.0309 0
+      vertex 25.7055 4.10482 2
+      vertex 25.8439 4.0309 2
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal 0.471117 0.882071 0
     outer loop
-      vertex 0.406094 -14.2347 -4.5
-      vertex 0.368165 -14.3 -2.5
-      vertex 0.368165 -14.3 -4.5
+      vertex 25.7055 4.10482 2
+      vertex 25.8439 4.0309 0
+      vertex 25.7055 4.10482 0
     endloop
   endfacet
-  facet normal 0.743101 -0.66918 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 0.406094 -14.2347 -2.5
-      vertex 0.574062 -14.0482 -4.5
-      vertex 0.574062 -14.0482 -2.5
+      vertex 25.7055 5.43518 0
+      vertex 25.8439 5.5091 2
+      vertex 25.7055 5.43518 2
     endloop
   endfacet
-  facet normal 0.743101 -0.66918 0
+  facet normal 0.471117 -0.882071 0
     outer loop
-      vertex 0.574062 -14.0482 -4.5
-      vertex 0.406094 -14.2347 -2.5
-      vertex 0.406094 -14.2347 -4.5
+      vertex 25.8439 5.5091 2
+      vertex 25.7055 5.43518 0
+      vertex 25.8439 5.5091 0
     endloop
   endfacet
-  facet normal 0.587477 -0.809241 0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 0.574062 -14.0482 -4.5
-      vertex 0.777187 -13.9007 -2.5
-      vertex 0.574062 -14.0482 -2.5
+      vertex 26.5945 4.10482 0
+      vertex 26.4561 4.0309 2
+      vertex 26.5945 4.10482 2
     endloop
   endfacet
-  facet normal 0.587477 -0.809241 0
+  facet normal -0.471117 0.882071 0
     outer loop
-      vertex 0.777187 -13.9007 -2.5
-      vertex 0.574062 -14.0482 -4.5
-      vertex 0.777187 -13.9007 -4.5
+      vertex 26.4561 4.0309 2
+      vertex 26.5945 4.10482 0
+      vertex 26.4561 4.0309 0
     endloop
   endfacet
-  facet normal 0.409392 -0.912359 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 0.777187 -13.9007 -4.5
-      vertex 1.0057 -13.7982 -2.5
-      vertex 0.777187 -13.9007 -2.5
+      vertex 25.4848 5.21446 2
+      vertex 25.5843 5.33569 0
+      vertex 25.5843 5.33569 2
     endloop
   endfacet
-  facet normal 0.409392 -0.912359 0
+  facet normal 0.772982 -0.634428 0
     outer loop
-      vertex 1.0057 -13.7982 -2.5
-      vertex 0.777187 -13.9007 -4.5
-      vertex 1.0057 -13.7982 -4.5
+      vertex 25.5843 5.33569 0
+      vertex 25.4848 5.21446 2
+      vertex 25.4848 5.21446 0
     endloop
   endfacet
-  facet normal 0.205815 -0.978591 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 1.0057 -13.7982 -4.5
-      vertex 1.2518 -13.7464 -2.5
-      vertex 1.0057 -13.7982 -2.5
+      vertex 26.8152 5.21446 0
+      vertex 26.7157 5.33569 2
+      vertex 26.7157 5.33569 0
     endloop
   endfacet
-  facet normal 0.205815 -0.978591 0
+  facet normal -0.772982 -0.634428 0
     outer loop
-      vertex 1.2518 -13.7464 -2.5
-      vertex 1.0057 -13.7982 -4.5
-      vertex 1.2518 -13.7464 -4.5
+      vertex 26.7157 5.33569 2
+      vertex 26.8152 5.21446 0
+      vertex 26.8152 5.21446 2
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 1.2518 -13.7464 -4.5
-      vertex 1.5018 -13.7464 -2.5
-      vertex 1.2518 -13.7464 -2.5
+      vertex 26.7157 4.20431 0
+      vertex 26.8152 4.32554 2
+      vertex 26.8152 4.32554 0
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.772982 0.634428 0
     outer loop
-      vertex 1.5018 -13.7464 -2.5
-      vertex 1.2518 -13.7464 -4.5
-      vertex 1.5018 -13.7464 -4.5
+      vertex 26.8152 4.32554 2
+      vertex 26.7157 4.20431 0
+      vertex 26.7157 4.20431 2
     endloop
   endfacet
-  facet normal -0.205815 -0.978591 0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 1.5018 -13.7464 -4.5
-      vertex 1.74789 -13.7982 -2.5
-      vertex 1.5018 -13.7464 -2.5
+      vertex 25.8439 5.5091 0
+      vertex 25.9939 5.55463 2
+      vertex 25.8439 5.5091 2
     endloop
   endfacet
-  facet normal -0.205815 -0.978591 -0
+  facet normal 0.290448 -0.956891 0
     outer loop
-      vertex 1.74789 -13.7982 -2.5
-      vertex 1.5018 -13.7464 -4.5
-      vertex 1.74789 -13.7982 -4.5
+      vertex 25.9939 5.55463 2
+      vertex 25.8439 5.5091 0
+      vertex 25.9939 5.55463 0
     endloop
   endfacet
-  facet normal -0.409392 -0.912359 0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex -0.792148 -13.7982 -4.5
-      vertex -0.563632 -13.9007 -2.5
-      vertex -0.792148 -13.7982 -2.5
+      vertex 26.7157 4.20431 0
+      vertex 26.5945 4.10482 2
+      vertex 26.7157 4.20431 2
     endloop
   endfacet
-  facet normal -0.409392 -0.912359 -0
+  facet normal -0.634484 0.772936 0
     outer loop
-      vertex -0.563632 -13.9007 -2.5
-      vertex -0.792148 -13.7982 -4.5
-      vertex -0.563632 -13.9007 -4.5
+      vertex 26.5945 4.10482 2
+      vertex 26.7157 4.20431 0
+      vertex 26.5945 4.10482 0
     endloop
   endfacet
-  facet normal -0.587477 -0.809241 0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex -0.563632 -13.9007 -4.5
-      vertex -0.360507 -14.0482 -2.5
-      vertex -0.563632 -13.9007 -2.5
+      vertex 26.9346 4.61393 0
+      vertex 26.95 4.77 2
+      vertex 26.95 4.77 0
     endloop
   endfacet
-  facet normal -0.587477 -0.809241 -0
+  facet normal -0.995167 0.0981968 0
     outer loop
-      vertex -0.360507 -14.0482 -2.5
-      vertex -0.563632 -13.9007 -4.5
-      vertex -0.360507 -14.0482 -4.5
+      vertex 26.95 4.77 2
+      vertex 26.9346 4.61393 0
+      vertex 26.9346 4.61393 2
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal 0.290448 0.956891 -0
     outer loop
-      vertex -0.192538 -14.2347 -4.5
-      vertex -0.360507 -14.0482 -2.5
-      vertex -0.360507 -14.0482 -4.5
+      vertex 25.9939 3.98537 0
+      vertex 25.8439 4.0309 2
+      vertex 25.9939 3.98537 2
     endloop
   endfacet
-  facet normal -0.743101 -0.66918 0
+  facet normal 0.290448 0.956891 0
     outer loop
-      vertex -0.360507 -14.0482 -2.5
-      vertex -0.192538 -14.2347 -4.5
-      vertex -0.192538 -14.2347 -2.5
+      vertex 25.8439 4.0309 2
+      vertex 25.9939 3.98537 0
+      vertex 25.8439 4.0309 0
     endloop
   endfacet
-  facet normal -0.864625 -0.502417 0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex -0.154609 -14.3 -4.5
-      vertex -0.192538 -14.2347 -2.5
-      vertex -0.192538 -14.2347 -4.5
+      vertex 26.8891 4.46385 0
+      vertex 26.9346 4.61393 2
+      vertex 26.9346 4.61393 0
     endloop
   endfacet
-  facet normal -0.864625 -0.502417 0
+  facet normal -0.956987 0.290131 0
     outer loop
-      vertex -0.192538 -14.2347 -2.5
-      vertex -0.154609 -14.3 -4.5
-      vertex -0.154609 -14.3 -2.5
+      vertex 26.9346 4.61393 2
+      vertex 26.8891 4.46385 0
+      vertex 26.8891 4.46385 2
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex -2.17187 -14.3 -2.5
-      vertex -2.13394 -14.2347 -4.5
-      vertex -2.13394 -14.2347 -2.5
+      vertex 25.4109 4.46385 2
+      vertex 25.3654 4.61393 0
+      vertex 25.3654 4.61393 2
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal 0.956987 0.290131 0
     outer loop
-      vertex -2.13394 -14.2347 -4.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -2.17187 -14.3 -4.5
+      vertex 25.3654 4.61393 0
+      vertex 25.4109 4.46385 2
+      vertex 25.4109 4.46385 0
     endloop
   endfacet
-  facet normal 0.743101 -0.66918 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex -2.13394 -14.2347 -2.5
-      vertex -1.96598 -14.0482 -4.5
-      vertex -1.96598 -14.0482 -2.5
+      vertex 26.8152 4.32554 0
+      vertex 26.8891 4.46385 2
+      vertex 26.8891 4.46385 0
     endloop
   endfacet
-  facet normal 0.743101 -0.66918 0
+  facet normal -0.881996 0.471257 0
     outer loop
-      vertex -1.96598 -14.0482 -4.5
-      vertex -2.13394 -14.2347 -2.5
-      vertex -2.13394 -14.2347 -4.5
+      vertex 26.8891 4.46385 2
+      vertex 26.8152 4.32554 0
+      vertex 26.8152 4.32554 2
     endloop
   endfacet
-  facet normal 0.587477 -0.809241 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex -1.96598 -14.0482 -4.5
-      vertex -1.76285 -13.9007 -2.5
-      vertex -1.96598 -14.0482 -2.5
+      vertex 25.35 4.77 2
+      vertex 25.3654 4.92607 0
+      vertex 25.3654 4.92607 2
     endloop
   endfacet
-  facet normal 0.587477 -0.809241 0
+  facet normal 0.995167 -0.0981968 0
     outer loop
-      vertex -1.76285 -13.9007 -2.5
-      vertex -1.96598 -14.0482 -4.5
-      vertex -1.76285 -13.9007 -4.5
+      vertex 25.3654 4.92607 0
+      vertex 25.35 4.77 2
+      vertex 25.35 4.77 0
     endloop
   endfacet
-  facet normal 0.409392 -0.912359 0
+  facet normal -0.0979887 -0.995188 0
     outer loop
-      vertex -1.76285 -13.9007 -4.5
-      vertex -1.53434 -13.7982 -2.5
-      vertex -1.76285 -13.9007 -2.5
+      vertex 26.15 5.57 0
+      vertex 26.3061 5.55463 2
+      vertex 26.15 5.57 2
     endloop
   endfacet
-  facet normal 0.409392 -0.912359 0
+  facet normal -0.0979887 -0.995188 -0
     outer loop
-      vertex -1.53434 -13.7982 -2.5
-      vertex -1.76285 -13.9007 -4.5
-      vertex -1.53434 -13.7982 -4.5
+      vertex 26.3061 5.55463 2
+      vertex 26.15 5.57 0
+      vertex 26.3061 5.55463 0
     endloop
   endfacet
-  facet normal 0.205815 -0.978591 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex -1.53434 -13.7982 -4.5
-      vertex -1.28824 -13.7464 -2.5
-      vertex -1.53434 -13.7982 -2.5
+      vertex 25.5843 5.33569 0
+      vertex 25.7055 5.43518 2
+      vertex 25.5843 5.33569 2
     endloop
   endfacet
-  facet normal 0.205815 -0.978591 0
+  facet normal 0.634484 -0.772936 0
     outer loop
-      vertex -1.28824 -13.7464 -2.5
-      vertex -1.53434 -13.7982 -4.5
-      vertex -1.28824 -13.7464 -4.5
+      vertex 25.7055 5.43518 2
+      vertex 25.5843 5.33569 0
+      vertex 25.7055 5.43518 0
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0.634484 -0.772936 0
     outer loop
-      vertex -1.28824 -13.7464 -4.5
-      vertex -1.03726 -13.7464 -2.5
-      vertex -1.28824 -13.7464 -2.5
+      vertex 26.5945 5.43518 0
+      vertex 26.7157 5.33569 2
+      vertex 26.5945 5.43518 2
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal -0.634484 -0.772936 -0
     outer loop
-      vertex -1.03726 -13.7464 -2.5
-      vertex -1.28824 -13.7464 -4.5
-      vertex -1.03726 -13.7464 -4.5
+      vertex 26.7157 5.33569 2
+      vertex 26.5945 5.43518 0
+      vertex 26.7157 5.33569 0
     endloop
   endfacet
-  facet normal -0.2066 -0.978426 0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex -1.03726 -13.7464 -4.5
-      vertex -0.792148 -13.7982 -2.5
-      vertex -1.03726 -13.7464 -2.5
+      vertex 26.3061 3.98537 0
+      vertex 26.15 3.97 2
+      vertex 26.3061 3.98537 2
     endloop
   endfacet
-  facet normal -0.2066 -0.978426 -0
+  facet normal -0.0979887 0.995188 0
     outer loop
-      vertex -0.792148 -13.7982 -2.5
-      vertex -1.03726 -13.7464 -4.5
-      vertex -0.792148 -13.7982 -4.5
+      vertex 26.15 3.97 2
+      vertex 26.3061 3.98537 0
+      vertex 26.15 3.97 0
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal -0.471117 -0.882071 0
     outer loop
-      vertex 2.9082 -14.3 -2.5
-      vertex 2.94613 -14.2347 -4.5
-      vertex 2.94613 -14.2347 -2.5
+      vertex 26.4561 5.5091 0
+      vertex 26.5945 5.43518 2
+      vertex 26.4561 5.5091 2
     endloop
   endfacet
-  facet normal 0.864625 -0.502417 0
+  facet normal -0.471117 -0.882071 -0
     outer loop
-      vertex 2.94613 -14.2347 -4.5
-      vertex 2.9082 -14.3 -2.5
-      vertex 2.9082 -14.3 -4.5
+      vertex 26.5945 5.43518 2
+      vertex 26.4561 5.5091 0
+      vertex 26.5945 5.43518 0
     endloop
   endfacet
-  facet normal 0.743103 -0.669177 0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 2.94613 -14.2347 -2.5
-      vertex 3 -14.1749 -4.5
-      vertex 3 -14.1749 -2.5
+      vertex 25.5843 4.20431 2
+      vertex 25.4848 4.32554 0
+      vertex 25.4848 4.32554 2
     endloop
   endfacet
-  facet normal 0.743103 -0.669177 0
+  facet normal 0.772982 0.634428 0
     outer loop
-      vertex 3 -14.1749 -4.5
-      vertex 2.94613 -14.2347 -2.5
-      vertex 2.94613 -14.2347 -4.5
+      vertex 25.4848 4.32554 0
+      vertex 25.5843 4.20431 2
+      vertex 25.5843 4.20431 0
     endloop
   endfacet
-  facet normal -0.409501 -0.91231 0
+  facet normal 0.0979887 0.995188 -0
     outer loop
-      vertex -3 -4.07166 -4.5
-      vertex -2.91519 -4.10973 -2.5
-      vertex -3 -4.07166 -2.5
+      vertex 26.15 3.97 0
+      vertex 25.9939 3.98537 2
+      vertex 26.15 3.97 2
     endloop
   endfacet
-  facet normal -0.409501 -0.91231 -0
+  facet normal 0.0979887 0.995188 0
     outer loop
-      vertex -2.91519 -4.10973 -2.5
-      vertex -3 -4.07166 -4.5
-      vertex -2.91519 -4.10973 -4.5
+      vertex 25.9939 3.98537 2
+      vertex 26.15 3.97 0
+      vertex 25.9939 3.98537 0
     endloop
   endfacet
-  facet normal -0.586627 -0.809857 0
+  facet normal 0.634484 0.772936 -0
     outer loop
-      vertex -2.91519 -4.10973 -4.5
-      vertex -2.76285 -4.22008 -2.5
-      vertex -2.91519 -4.10973 -2.5
+      vertex 25.7055 4.10482 0
+      vertex 25.5843 4.20431 2
+      vertex 25.7055 4.10482 2
     endloop
   endfacet
-  facet normal -0.586627 -0.809857 -0
+  facet normal 0.634484 0.772936 0
     outer loop
-      vertex -2.76285 -4.22008 -2.5
-      vertex -2.91519 -4.10973 -4.5
-      vertex -2.76285 -4.22008 -4.5
+      vertex 25.5843 4.20431 2
+      vertex 25.7055 4.10482 0
+      vertex 25.5843 4.20431 0
     endloop
   endfacet
-  facet normal -0.742519 -0.669825 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex -2.63687 -4.35973 -4.5
-      vertex -2.76285 -4.22008 -2.5
-      vertex -2.76285 -4.22008 -4.5
+      vertex 25.3654 4.92607 2
+      vertex 25.4109 5.07615 0
+      vertex 25.4109 5.07615 2
     endloop
   endfacet
-  facet normal -0.742519 -0.669825 0
+  facet normal 0.956987 -0.290131 0
     outer loop
-      vertex -2.76285 -4.22008 -2.5
-      vertex -2.63687 -4.35973 -4.5
-      vertex -2.63687 -4.35973 -2.5
+      vertex 25.4109 5.07615 0
+      vertex 25.3654 4.92607 2
+      vertex 25.3654 4.92607 0
     endloop
   endfacet
-  facet normal -0.866962 -0.498374 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex -2.54312 -4.52281 -4.5
-      vertex -2.63687 -4.35973 -2.5
-      vertex -2.63687 -4.35973 -4.5
+      vertex 25.4109 5.07615 2
+      vertex 25.4848 5.21446 0
+      vertex 25.4848 5.21446 2
     endloop
   endfacet
-  facet normal -0.866962 -0.498374 0
+  facet normal 0.881996 -0.471257 0
     outer loop
-      vertex -2.63687 -4.35973 -2.5
-      vertex -2.54312 -4.52281 -4.5
-      vertex -2.54312 -4.52281 -2.5
+      vertex 25.4848 5.21446 0
+      vertex 25.4109 5.07615 2
+      vertex 25.4109 5.07615 0
     endloop
   endfacet
-  facet normal -0.951758 -0.306851 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex -2.48551 -4.70152 -4.5
-      vertex -2.54312 -4.52281 -2.5
-      vertex -2.54312 -4.52281 -4.5
+      vertex 25.3654 4.61393 2
+      vertex 25.35 4.77 0
+      vertex 25.35 4.77 2
     endloop
   endfacet
-  facet normal -0.951758 -0.306851 0
+  facet normal 0.995167 0.0981968 0
     outer loop
-      vertex -2.54312 -4.52281 -2.5
-      vertex -2.48551 -4.70152 -4.5
-      vertex -2.48551 -4.70152 -2.5
+      vertex 25.35 4.77 0
+      vertex 25.3654 4.61393 2
+      vertex 25.3654 4.61393 0
     endloop
   endfacet
-  facet normal -0.994072 -0.108727 0
+  facet normal -0.290715 0.95681 0
     outer loop
-      vertex -2.465 -4.88902 -4.5
-      vertex -2.48551 -4.70152 -2.5
-      vertex -2.48551 -4.70152 -4.5
+      vertex 57.3913 24.5381 2.1
+      vertex 57.2975 24.5096 2.4
+      vertex 57.3913 24.5381 2.4
     endloop
   endfacet
-  facet normal -0.994072 -0.108727 0
+  facet normal -0.290715 0.95681 0
     outer loop
-      vertex -2.48551 -4.70152 -2.5
-      vertex -2.465 -4.88902 -4.5
-      vertex -2.465 -4.88902 -2.5
+      vertex 57.2975 24.5096 2.4
+      vertex 57.3913 24.5381 2.1
+      vertex 57.2975 24.5096 2.1
     endloop
   endfacet
-  facet normal -0.99401 0.109289 0
+  facet normal 0.773548 0.633738 0
     outer loop
-      vertex -2.48551 -5.07555 -4.5
-      vertex -2.465 -4.88902 -2.5
-      vertex -2.465 -4.88902 -4.5
+      vertex 37.8464 24.6464 2.4
+      vertex 37.7843 24.7222 2.1
+      vertex 37.7843 24.7222 2.4
     endloop
   endfacet
-  facet normal -0.99401 0.109289 0
+  facet normal 0.773548 0.633738 0
     outer loop
-      vertex -2.465 -4.88902 -2.5
-      vertex -2.48551 -5.07555 -4.5
-      vertex -2.48551 -5.07555 -2.5
-    endloop
-  endfacet
-  facet normal -0.952244 0.305339 0
-    outer loop
-      vertex -2.54312 -5.25523 -4.5
-      vertex -2.48551 -5.07555 -2.5
-      vertex -2.48551 -5.07555 -4.5
-    endloop
-  endfacet
-  facet normal -0.952244 0.305339 0
-    outer loop
-      vertex -2.48551 -5.07555 -2.5
-      vertex -2.54312 -5.25523 -4.5
-      vertex -2.54312 -5.25523 -2.5
-    endloop
-  endfacet
-  facet normal -0.866962 0.498374 0
-    outer loop
-      vertex -2.63687 -5.41832 -4.5
-      vertex -2.54312 -5.25523 -2.5
-      vertex -2.54312 -5.25523 -4.5
-    endloop
-  endfacet
-  facet normal -0.866962 0.498374 0
-    outer loop
-      vertex -2.54312 -5.25523 -2.5
-      vertex -2.63687 -5.41832 -4.5
-      vertex -2.63687 -5.41832 -2.5
-    endloop
-  endfacet
-  facet normal -0.742519 0.669825 0
-    outer loop
-      vertex -2.76285 -5.55797 -4.5
-      vertex -2.63687 -5.41832 -2.5
-      vertex -2.63687 -5.41832 -4.5
-    endloop
-  endfacet
-  facet normal -0.742519 0.669825 0
-    outer loop
-      vertex -2.63687 -5.41832 -2.5
-      vertex -2.76285 -5.55797 -4.5
-      vertex -2.76285 -5.55797 -2.5
-    endloop
-  endfacet
-  facet normal -0.586627 0.809857 0
-    outer loop
-      vertex -2.76285 -5.55797 -4.5
-      vertex -2.91519 -5.66832 -2.5
-      vertex -2.76285 -5.55797 -2.5
-    endloop
-  endfacet
-  facet normal -0.586627 0.809857 0
-    outer loop
-      vertex -2.91519 -5.66832 -2.5
-      vertex -2.76285 -5.55797 -4.5
-      vertex -2.91519 -5.66832 -4.5
-    endloop
-  endfacet
-  facet normal -0.405175 0.914239 0
-    outer loop
-      vertex -2.91519 -5.66832 -4.5
-      vertex -3 -5.7059 -2.5
-      vertex -2.91519 -5.66832 -2.5
-    endloop
-  endfacet
-  facet normal -0.405175 0.914239 0
-    outer loop
-      vertex -3 -5.7059 -2.5
-      vertex -2.91519 -5.66832 -4.5
-      vertex -3 -5.7059 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 0
-    outer loop
-      vertex 45.3797 -2.26891 -4.5
-      vertex 45.6092 -2.37144 -3
-      vertex 45.3797 -2.26891 -3
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 -0
-    outer loop
-      vertex 45.6092 -2.37144 -3
-      vertex 45.3797 -2.26891 -4.5
-      vertex 45.6092 -2.37144 -4.5
-    endloop
-  endfacet
-  facet normal -0.587477 -0.809241 0
-    outer loop
-      vertex 45.6092 -2.37144 -4.5
-      vertex 45.8123 -2.51891 -3
-      vertex 45.6092 -2.37144 -3
-    endloop
-  endfacet
-  facet normal -0.587477 -0.809241 -0
-    outer loop
-      vertex 45.8123 -2.51891 -3
-      vertex 45.6092 -2.37144 -4.5
-      vertex 45.8123 -2.51891 -4.5
-    endloop
-  endfacet
-  facet normal -0.745037 -0.667023 0
-    outer loop
-      vertex 45.9793 -2.70543 -4.5
-      vertex 45.8123 -2.51891 -3
-      vertex 45.8123 -2.51891 -4.5
-    endloop
-  endfacet
-  facet normal -0.745037 -0.667023 0
-    outer loop
-      vertex 45.8123 -2.51891 -3
-      vertex 45.9793 -2.70543 -4.5
-      vertex 45.9793 -2.70543 -3
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 46.1053 -2.92223 -4.5
-      vertex 45.9793 -2.70543 -3
-      vertex 45.9793 -2.70543 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 45.9793 -2.70543 -3
-      vertex 46.1053 -2.92223 -4.5
-      vertex 46.1053 -2.92223 -3
-    endloop
-  endfacet
-  facet normal -0.951746 -0.306885 0
-    outer loop
-      vertex 46.1304 -3 -4.5
-      vertex 46.1053 -2.92223 -3
-      vertex 46.1053 -2.92223 -4.5
-    endloop
-  endfacet
-  facet normal -0.951746 -0.306885 0
-    outer loop
-      vertex 46.1053 -2.92223 -3
-      vertex 46.1304 -3 -4.5
-      vertex 46.1304 -3 -3
-    endloop
-  endfacet
-  facet normal 0.95061 -0.310389 0
-    outer loop
-      vertex 43.8875 -3 -3
-      vertex 43.9129 -2.92223 -4.5
-      vertex 43.9129 -2.92223 -3
-    endloop
-  endfacet
-  facet normal 0.95061 -0.310389 0
-    outer loop
-      vertex 43.9129 -2.92223 -4.5
-      vertex 43.8875 -3 -3
-      vertex 43.8875 -3 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 43.9129 -2.92223 -3
-      vertex 44.0379 -2.70543 -4.5
-      vertex 44.0379 -2.70543 -3
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 44.0379 -2.70543 -4.5
-      vertex 43.9129 -2.92223 -3
-      vertex 43.9129 -2.92223 -4.5
-    endloop
-  endfacet
-  facet normal 0.743101 -0.66918 0
-    outer loop
-      vertex 44.0379 -2.70543 -3
-      vertex 44.2059 -2.51891 -4.5
-      vertex 44.2059 -2.51891 -3
-    endloop
-  endfacet
-  facet normal 0.743101 -0.66918 0
-    outer loop
-      vertex 44.2059 -2.51891 -4.5
-      vertex 44.0379 -2.70543 -3
-      vertex 44.0379 -2.70543 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 44.2059 -2.51891 -4.5
-      vertex 44.409 -2.37144 -3
-      vertex 44.2059 -2.51891 -3
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 44.409 -2.37144 -3
-      vertex 44.2059 -2.51891 -4.5
-      vertex 44.409 -2.37144 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 44.409 -2.37144 -4.5
-      vertex 44.6385 -2.26891 -3
-      vertex 44.409 -2.37144 -3
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 44.6385 -2.26891 -3
-      vertex 44.409 -2.37144 -4.5
-      vertex 44.6385 -2.26891 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 44.6385 -2.26891 -4.5
-      vertex 44.8836 -2.21715 -3
-      vertex 44.6385 -2.26891 -3
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 44.8836 -2.21715 -3
-      vertex 44.6385 -2.26891 -4.5
-      vertex 44.8836 -2.21715 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 44.8836 -2.21715 -4.5
-      vertex 45.1346 -2.21715 -3
-      vertex 44.8836 -2.21715 -3
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 45.1346 -2.21715 -3
-      vertex 44.8836 -2.21715 -4.5
-      vertex 45.1346 -2.21715 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 0
-    outer loop
-      vertex 45.1346 -2.21715 -4.5
-      vertex 45.3797 -2.26891 -3
-      vertex 45.1346 -2.21715 -3
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 -0
-    outer loop
-      vertex 45.3797 -2.26891 -3
-      vertex 45.1346 -2.21715 -4.5
-      vertex 45.3797 -2.26891 -4.5
-    endloop
-  endfacet
-  facet normal -0.409503 -0.912309 0
-    outer loop
-      vertex -3 -1.55213 -4.5
-      vertex -2.91519 -1.59019 -2.5
-      vertex -3 -1.55213 -2.5
-    endloop
-  endfacet
-  facet normal -0.409503 -0.912309 -0
-    outer loop
-      vertex -2.91519 -1.59019 -2.5
-      vertex -3 -1.55213 -4.5
-      vertex -2.91519 -1.59019 -4.5
-    endloop
-  endfacet
-  facet normal -0.586627 -0.809857 0
-    outer loop
-      vertex -2.91519 -1.59019 -4.5
-      vertex -2.76285 -1.70055 -2.5
-      vertex -2.91519 -1.59019 -2.5
-    endloop
-  endfacet
-  facet normal -0.586627 -0.809857 -0
-    outer loop
-      vertex -2.76285 -1.70055 -2.5
-      vertex -2.91519 -1.59019 -4.5
-      vertex -2.76285 -1.70055 -4.5
-    endloop
-  endfacet
-  facet normal -0.742519 -0.669825 0
-    outer loop
-      vertex -2.63687 -1.84019 -4.5
-      vertex -2.76285 -1.70055 -2.5
-      vertex -2.76285 -1.70055 -4.5
-    endloop
-  endfacet
-  facet normal -0.742519 -0.669825 0
-    outer loop
-      vertex -2.76285 -1.70055 -2.5
-      vertex -2.63687 -1.84019 -4.5
-      vertex -2.63687 -1.84019 -2.5
-    endloop
-  endfacet
-  facet normal -0.866962 -0.498374 0
-    outer loop
-      vertex -2.54312 -2.00328 -4.5
-      vertex -2.63687 -1.84019 -2.5
-      vertex -2.63687 -1.84019 -4.5
-    endloop
-  endfacet
-  facet normal -0.866962 -0.498374 0
-    outer loop
-      vertex -2.63687 -1.84019 -2.5
-      vertex -2.54312 -2.00328 -4.5
-      vertex -2.54312 -2.00328 -2.5
-    endloop
-  endfacet
-  facet normal -0.951758 -0.306851 0
-    outer loop
-      vertex -2.48551 -2.18199 -4.5
-      vertex -2.54312 -2.00328 -2.5
-      vertex -2.54312 -2.00328 -4.5
-    endloop
-  endfacet
-  facet normal -0.951758 -0.306851 0
-    outer loop
-      vertex -2.54312 -2.00328 -2.5
-      vertex -2.48551 -2.18199 -4.5
-      vertex -2.48551 -2.18199 -2.5
-    endloop
-  endfacet
-  facet normal -0.994072 -0.108727 0
-    outer loop
-      vertex -2.465 -2.36949 -4.5
-      vertex -2.48551 -2.18199 -2.5
-      vertex -2.48551 -2.18199 -4.5
-    endloop
-  endfacet
-  facet normal -0.994072 -0.108727 0
-    outer loop
-      vertex -2.48551 -2.18199 -2.5
-      vertex -2.465 -2.36949 -4.5
-      vertex -2.465 -2.36949 -2.5
-    endloop
-  endfacet
-  facet normal -0.99401 0.109289 0
-    outer loop
-      vertex -2.48551 -2.55602 -4.5
-      vertex -2.465 -2.36949 -2.5
-      vertex -2.465 -2.36949 -4.5
-    endloop
-  endfacet
-  facet normal -0.99401 0.109289 0
-    outer loop
-      vertex -2.465 -2.36949 -2.5
-      vertex -2.48551 -2.55602 -4.5
-      vertex -2.48551 -2.55602 -2.5
-    endloop
-  endfacet
-  facet normal -0.952244 0.305339 0
-    outer loop
-      vertex -2.54312 -2.7357 -4.5
-      vertex -2.48551 -2.55602 -2.5
-      vertex -2.48551 -2.55602 -4.5
-    endloop
-  endfacet
-  facet normal -0.952244 0.305339 0
-    outer loop
-      vertex -2.48551 -2.55602 -2.5
-      vertex -2.54312 -2.7357 -4.5
-      vertex -2.54312 -2.7357 -2.5
-    endloop
-  endfacet
-  facet normal -0.865664 0.500625 0
-    outer loop
-      vertex -2.63687 -2.89781 -4.5
-      vertex -2.54312 -2.7357 -2.5
-      vertex -2.54312 -2.7357 -4.5
-    endloop
-  endfacet
-  facet normal -0.865664 0.500625 0
-    outer loop
-      vertex -2.54312 -2.7357 -2.5
-      vertex -2.63687 -2.89781 -4.5
-      vertex -2.63687 -2.89781 -2.5
-    endloop
-  endfacet
-  facet normal -0.744835 0.667248 0
-    outer loop
-      vertex -2.76285 -3.03844 -4.5
-      vertex -2.63687 -2.89781 -2.5
-      vertex -2.63687 -2.89781 -4.5
-    endloop
-  endfacet
-  facet normal -0.744835 0.667248 0
-    outer loop
-      vertex -2.63687 -2.89781 -2.5
-      vertex -2.76285 -3.03844 -4.5
-      vertex -2.76285 -3.03844 -2.5
-    endloop
-  endfacet
-  facet normal -0.586627 0.809857 0
-    outer loop
-      vertex -2.76285 -3.03844 -4.5
-      vertex -2.91519 -3.14879 -2.5
-      vertex -2.76285 -3.03844 -2.5
-    endloop
-  endfacet
-  facet normal -0.586627 0.809857 0
-    outer loop
-      vertex -2.91519 -3.14879 -2.5
-      vertex -2.76285 -3.03844 -4.5
-      vertex -2.91519 -3.14879 -4.5
-    endloop
-  endfacet
-  facet normal -0.405175 0.914239 0
-    outer loop
-      vertex -2.91519 -3.14879 -4.5
-      vertex -3 -3.18637 -2.5
-      vertex -2.91519 -3.14879 -2.5
-    endloop
-  endfacet
-  facet normal -0.405175 0.914239 0
-    outer loop
-      vertex -3 -3.18637 -2.5
-      vertex -2.91519 -3.14879 -4.5
-      vertex -3 -3.18637 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 0
-    outer loop
-      vertex 45.3797 0.271132 -4.5
-      vertex 45.6092 0.168593 -3.1
-      vertex 45.3797 0.271132 -3.1
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 -0
-    outer loop
-      vertex 45.6092 0.168593 -3.1
-      vertex 45.3797 0.271132 -4.5
-      vertex 45.6092 0.168593 -4.5
-    endloop
-  endfacet
-  facet normal -0.587477 -0.809241 0
-    outer loop
-      vertex 45.6092 0.168593 -4.5
-      vertex 45.8123 0.0211325 -3.1
-      vertex 45.6092 0.168593 -3.1
-    endloop
-  endfacet
-  facet normal -0.587477 -0.809241 -0
-    outer loop
-      vertex 45.8123 0.0211325 -3.1
-      vertex 45.6092 0.168593 -4.5
-      vertex 45.8123 0.0211325 -4.5
-    endloop
-  endfacet
-  facet normal -0.745036 -0.667025 0
-    outer loop
-      vertex 45.9793 -0.16539 -4.5
-      vertex 45.8123 0.0211325 -3.1
-      vertex 45.8123 0.0211325 -4.5
-    endloop
-  endfacet
-  facet normal -0.745036 -0.667025 0
-    outer loop
-      vertex 45.8123 0.0211325 -3.1
-      vertex 45.9793 -0.16539 -4.5
-      vertex 45.9793 -0.16539 -3.1
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 46.1053 -0.382187 -4.5
-      vertex 45.9793 -0.16539 -3.1
-      vertex 45.9793 -0.16539 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 45.9793 -0.16539 -3.1
-      vertex 46.1053 -0.382187 -4.5
-      vertex 46.1053 -0.382187 -3.1
-    endloop
-  endfacet
-  facet normal -0.951745 -0.306889 0
-    outer loop
-      vertex 46.1825 -0.621445 -4.5
-      vertex 46.1053 -0.382187 -3.1
-      vertex 46.1053 -0.382187 -4.5
-    endloop
-  endfacet
-  facet normal -0.951745 -0.306889 0
-    outer loop
-      vertex 46.1053 -0.382187 -3.1
-      vertex 46.1825 -0.621445 -4.5
-      vertex 46.1825 -0.621445 -3.1
-    endloop
-  endfacet
-  facet normal -0.994441 -0.105294 0
-    outer loop
-      vertex 46.2088 -0.870468 -4.5
-      vertex 46.1825 -0.621445 -3.1
-      vertex 46.1825 -0.621445 -4.5
-    endloop
-  endfacet
-  facet normal -0.994441 -0.105294 0
-    outer loop
-      vertex 46.1825 -0.621445 -3.1
-      vertex 46.2088 -0.870468 -4.5
-      vertex 46.2088 -0.870468 -3.1
-    endloop
-  endfacet
-  facet normal -0.994485 0.104878 0
-    outer loop
-      vertex 46.2088 -0.870468 -4.5
-      vertex 46.1952 -1 -3.1
-      vertex 46.2088 -0.870468 -3.1
-    endloop
-  endfacet
-  facet normal -0.994484 0.104887 8.04458e-07
-    outer loop
-      vertex 46.1825 -1.12047 -4.5
-      vertex 46.1952 -1 -3.1
-      vertex 46.2088 -0.870468 -4.5
-    endloop
-  endfacet
-  facet normal -0.994483 0.104896 0
-    outer loop
-      vertex 46.1825 -1.12047 -3
-      vertex 46.1952 -1 -3.1
-      vertex 46.1825 -1.12047 -4.5
-    endloop
-  endfacet
-  facet normal -0.994483 0.104896 0
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 46.1825 -1.12047 -3
-      vertex 46.1952 -1 -3
-    endloop
-  endfacet
-  facet normal -0.951377 0.308028 0
-    outer loop
-      vertex 46.1053 -1.35875 -4.5
-      vertex 46.1825 -1.12047 -3
-      vertex 46.1825 -1.12047 -4.5
-    endloop
-  endfacet
-  facet normal -0.951377 0.308028 0
-    outer loop
-      vertex 46.1825 -1.12047 -3
-      vertex 46.1053 -1.35875 -4.5
-      vertex 46.1053 -1.35875 -3
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 45.9793 -1.57555 -4.5
-      vertex 46.1053 -1.35875 -3
-      vertex 46.1053 -1.35875 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 46.1053 -1.35875 -3
-      vertex 45.9793 -1.57555 -4.5
-      vertex 45.9793 -1.57555 -3
-    endloop
-  endfacet
-  facet normal -0.745037 0.667023 0
-    outer loop
-      vertex 45.8123 -1.76207 -4.5
-      vertex 45.9793 -1.57555 -3
-      vertex 45.9793 -1.57555 -4.5
-    endloop
-  endfacet
-  facet normal -0.745037 0.667023 0
-    outer loop
-      vertex 45.9793 -1.57555 -3
-      vertex 45.8123 -1.76207 -4.5
-      vertex 45.8123 -1.76207 -3
-    endloop
-  endfacet
-  facet normal -0.587477 0.809241 0
-    outer loop
-      vertex 45.8123 -1.76207 -4.5
-      vertex 45.6092 -1.90953 -3
-      vertex 45.8123 -1.76207 -3
-    endloop
-  endfacet
-  facet normal -0.587477 0.809241 0
-    outer loop
-      vertex 45.6092 -1.90953 -3
-      vertex 45.8123 -1.76207 -4.5
-      vertex 45.6092 -1.90953 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 45.6092 -1.90953 -4.5
-      vertex 45.3797 -2.01207 -3
-      vertex 45.6092 -1.90953 -3
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 45.3797 -2.01207 -3
-      vertex 45.6092 -1.90953 -4.5
-      vertex 45.3797 -2.01207 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 45.3797 -2.01207 -4.5
-      vertex 45.1346 -2.06383 -3
-      vertex 45.3797 -2.01207 -3
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 45.1346 -2.06383 -3
-      vertex 45.3797 -2.01207 -4.5
-      vertex 45.1346 -2.06383 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 45.1346 -2.06383 -4.5
-      vertex 44.8836 -2.06383 -3
-      vertex 45.1346 -2.06383 -3
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 44.8836 -2.06383 -3
-      vertex 45.1346 -2.06383 -4.5
-      vertex 44.8836 -2.06383 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 0.978426 -0
-    outer loop
-      vertex 44.8836 -2.06383 -4.5
-      vertex 44.6385 -2.01207 -3
-      vertex 44.8836 -2.06383 -3
-    endloop
-  endfacet
-  facet normal 0.2066 0.978426 0
-    outer loop
-      vertex 44.6385 -2.01207 -3
-      vertex 44.8836 -2.06383 -4.5
-      vertex 44.6385 -2.01207 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 0.913009 -0
-    outer loop
-      vertex 44.6385 -2.01207 -4.5
-      vertex 44.409 -1.90953 -3
-      vertex 44.6385 -2.01207 -3
-    endloop
-  endfacet
-  facet normal 0.40794 0.913009 0
-    outer loop
-      vertex 44.409 -1.90953 -3
-      vertex 44.6385 -2.01207 -4.5
-      vertex 44.409 -1.90953 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 0.809241 -0
-    outer loop
-      vertex 44.409 -1.90953 -4.5
-      vertex 44.2059 -1.76207 -3
-      vertex 44.409 -1.90953 -3
-    endloop
-  endfacet
-  facet normal 0.587477 0.809241 0
-    outer loop
-      vertex 44.2059 -1.76207 -3
-      vertex 44.409 -1.90953 -4.5
-      vertex 44.2059 -1.76207 -4.5
-    endloop
-  endfacet
-  facet normal 0.743101 0.66918 0
-    outer loop
-      vertex 44.2059 -1.76207 -3
-      vertex 44.0379 -1.57555 -4.5
-      vertex 44.0379 -1.57555 -3
-    endloop
-  endfacet
-  facet normal 0.743101 0.66918 0
-    outer loop
-      vertex 44.0379 -1.57555 -4.5
-      vertex 44.2059 -1.76207 -3
-      vertex 44.2059 -1.76207 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 0.499497 0
-    outer loop
-      vertex 44.0379 -1.57555 -3
-      vertex 43.9129 -1.35875 -4.5
-      vertex 43.9129 -1.35875 -3
-    endloop
-  endfacet
-  facet normal 0.866315 0.499497 0
-    outer loop
-      vertex 43.9129 -1.35875 -4.5
-      vertex 44.0379 -1.57555 -3
-      vertex 44.0379 -1.57555 -4.5
-    endloop
-  endfacet
-  facet normal 0.95023 0.311551 0
-    outer loop
-      vertex 43.9129 -1.35875 -3
-      vertex 43.8348 -1.12047 -4.5
-      vertex 43.8348 -1.12047 -3
-    endloop
-  endfacet
-  facet normal 0.95023 0.311551 0
-    outer loop
-      vertex 43.8348 -1.12047 -4.5
-      vertex 43.9129 -1.35875 -3
-      vertex 43.9129 -1.35875 -4.5
-    endloop
-  endfacet
-  facet normal 0.994883 0.101032 0
-    outer loop
-      vertex 43.8226 -1 -3
-      vertex 43.8348 -1.12047 -3
-      vertex 43.8226 -1 -3.1
-    endloop
-  endfacet
-  facet normal 0.994881 0.101053 0
-    outer loop
-      vertex 43.8226 -1 -3.1
-      vertex 43.8094 -0.870468 -4.5
-      vertex 43.8094 -0.870468 -3.1
-    endloop
-  endfacet
-  facet normal 0.994883 0.101032 -0
-    outer loop
-      vertex 43.8348 -1.12047 -4.5
-      vertex 43.8226 -1 -3.1
-      vertex 43.8348 -1.12047 -3
-    endloop
-  endfacet
-  facet normal 0.994882 0.101043 -9.3185e-07
-    outer loop
-      vertex 43.8226 -1 -3.1
-      vertex 43.8348 -1.12047 -4.5
-      vertex 43.8094 -0.870468 -4.5
-    endloop
-  endfacet
-  facet normal 0.994842 -0.101435 0
-    outer loop
-      vertex 43.8094 -0.870468 -3.1
-      vertex 43.8348 -0.621445 -4.5
-      vertex 43.8348 -0.621445 -3.1
-    endloop
-  endfacet
-  facet normal 0.994842 -0.101435 0
-    outer loop
-      vertex 43.8348 -0.621445 -4.5
-      vertex 43.8094 -0.870468 -3.1
-      vertex 43.8094 -0.870468 -4.5
-    endloop
-  endfacet
-  facet normal 0.950605 -0.310402 0
-    outer loop
-      vertex 43.8348 -0.621445 -3.1
-      vertex 43.9129 -0.382187 -4.5
-      vertex 43.9129 -0.382187 -3.1
-    endloop
-  endfacet
-  facet normal 0.950605 -0.310402 0
-    outer loop
-      vertex 43.9129 -0.382187 -4.5
-      vertex 43.8348 -0.621445 -3.1
-      vertex 43.8348 -0.621445 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 43.9129 -0.382187 -3.1
-      vertex 44.0379 -0.16539 -4.5
-      vertex 44.0379 -0.16539 -3.1
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 44.0379 -0.16539 -4.5
-      vertex 43.9129 -0.382187 -3.1
-      vertex 43.9129 -0.382187 -4.5
-    endloop
-  endfacet
-  facet normal 0.743099 -0.669182 0
-    outer loop
-      vertex 44.0379 -0.16539 -3.1
-      vertex 44.2059 0.0211325 -4.5
-      vertex 44.2059 0.0211325 -3.1
-    endloop
-  endfacet
-  facet normal 0.743099 -0.669182 0
-    outer loop
-      vertex 44.2059 0.0211325 -4.5
-      vertex 44.0379 -0.16539 -3.1
-      vertex 44.0379 -0.16539 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 44.2059 0.0211325 -4.5
-      vertex 44.409 0.168593 -3.1
-      vertex 44.2059 0.0211325 -3.1
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 44.409 0.168593 -3.1
-      vertex 44.2059 0.0211325 -4.5
-      vertex 44.409 0.168593 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 44.409 0.168593 -4.5
-      vertex 44.6385 0.271132 -3.1
-      vertex 44.409 0.168593 -3.1
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 44.6385 0.271132 -3.1
-      vertex 44.409 0.168593 -4.5
-      vertex 44.6385 0.271132 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 44.6385 0.271132 -4.5
-      vertex 44.8836 0.32289 -3.1
-      vertex 44.6385 0.271132 -3.1
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 44.8836 0.32289 -3.1
-      vertex 44.6385 0.271132 -4.5
-      vertex 44.8836 0.32289 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 44.8836 0.32289 -4.5
-      vertex 45.1346 0.32289 -3.1
-      vertex 44.8836 0.32289 -3.1
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 45.1346 0.32289 -3.1
-      vertex 44.8836 0.32289 -4.5
-      vertex 45.1346 0.32289 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 0
-    outer loop
-      vertex 45.1346 0.32289 -4.5
-      vertex 45.3797 0.271132 -3.1
-      vertex 45.1346 0.32289 -3.1
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 -0
-    outer loop
-      vertex 45.3797 0.271132 -3.1
-      vertex 45.1346 0.32289 -4.5
-      vertex 45.3797 0.271132 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 0
-    outer loop
-      vertex 51.5418 0.364882 -4.5
-      vertex 51.7713 0.262343 -3.1
-      vertex 51.5418 0.364882 -3.1
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 -0
-    outer loop
-      vertex 51.7713 0.262343 -3.1
-      vertex 51.5418 0.364882 -4.5
-      vertex 51.7713 0.262343 -4.5
-    endloop
-  endfacet
-  facet normal -0.589331 -0.807891 0
-    outer loop
-      vertex 51.7713 0.262343 -4.5
-      vertex 51.9735 0.114882 -3.1
-      vertex 51.7713 0.262343 -3.1
-    endloop
-  endfacet
-  facet normal -0.589331 -0.807891 -0
-    outer loop
-      vertex 51.9735 0.114882 -3.1
-      vertex 51.7713 0.262343 -4.5
-      vertex 51.9735 0.114882 -4.5
-    endloop
-  endfacet
-  facet normal -0.743099 -0.669182 0
-    outer loop
-      vertex 52.1414 -0.07164 -4.5
-      vertex 51.9735 0.114882 -3.1
-      vertex 51.9735 0.114882 -4.5
-    endloop
-  endfacet
-  facet normal -0.743099 -0.669182 0
-    outer loop
-      vertex 51.9735 0.114882 -3.1
-      vertex 52.1414 -0.07164 -4.5
-      vertex 52.1414 -0.07164 -3.1
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 52.2674 -0.288437 -4.5
-      vertex 52.1414 -0.07164 -3.1
-      vertex 52.1414 -0.07164 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 52.1414 -0.07164 -3.1
-      vertex 52.2674 -0.288437 -4.5
-      vertex 52.2674 -0.288437 -3.1
-    endloop
-  endfacet
-  facet normal -0.951377 -0.308028 0
-    outer loop
-      vertex 52.3446 -0.526718 -4.5
-      vertex 52.2674 -0.288437 -3.1
-      vertex 52.2674 -0.288437 -4.5
-    endloop
-  endfacet
-  facet normal -0.951377 -0.308028 0
-    outer loop
-      vertex 52.2674 -0.288437 -3.1
-      vertex 52.3446 -0.526718 -4.5
-      vertex 52.3446 -0.526718 -3.1
-    endloop
-  endfacet
-  facet normal -0.994484 -0.104887 0
-    outer loop
-      vertex 52.3709 -0.776718 -4.5
-      vertex 52.3446 -0.526718 -3.1
-      vertex 52.3446 -0.526718 -4.5
-    endloop
-  endfacet
-  facet normal -0.994484 -0.104887 0
-    outer loop
-      vertex 52.3446 -0.526718 -3.1
-      vertex 52.3709 -0.776718 -4.5
-      vertex 52.3709 -0.776718 -3.1
-    endloop
-  endfacet
-  facet normal -0.99444 0.105302 0
-    outer loop
-      vertex 52.3709 -0.776718 -4.5
-      vertex 52.3473 -1 -3.1
-      vertex 52.3709 -0.776718 -3.1
-    endloop
-  endfacet
-  facet normal -0.994441 0.105294 -1.33888e-06
-    outer loop
-      vertex 52.3446 -1.02574 -4.5
-      vertex 52.3473 -1 -3.1
-      vertex 52.3709 -0.776718 -4.5
-    endloop
-  endfacet
-  facet normal -0.994449 0.105222 0
-    outer loop
-      vertex 52.3446 -1.02574 -3
-      vertex 52.3473 -1 -3.1
-      vertex 52.3446 -1.02574 -4.5
-    endloop
-  endfacet
-  facet normal -0.994449 0.105222 0
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 52.3446 -1.02574 -3
-      vertex 52.3473 -1 -3
-    endloop
-  endfacet
-  facet normal -0.951745 0.306889 0
-    outer loop
-      vertex 52.2674 -1.265 -4.5
-      vertex 52.3446 -1.02574 -3
-      vertex 52.3446 -1.02574 -4.5
-    endloop
-  endfacet
-  facet normal -0.951745 0.306889 0
-    outer loop
-      vertex 52.3446 -1.02574 -3
-      vertex 52.2674 -1.265 -4.5
-      vertex 52.2674 -1.265 -3
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 52.1414 -1.4818 -4.5
-      vertex 52.2674 -1.265 -3
-      vertex 52.2674 -1.265 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 52.2674 -1.265 -3
-      vertex 52.1414 -1.4818 -4.5
-      vertex 52.1414 -1.4818 -3
-    endloop
-  endfacet
-  facet normal -0.743101 0.66918 0
-    outer loop
-      vertex 51.9735 -1.66832 -4.5
-      vertex 52.1414 -1.4818 -3
-      vertex 52.1414 -1.4818 -4.5
-    endloop
-  endfacet
-  facet normal -0.743101 0.66918 0
-    outer loop
-      vertex 52.1414 -1.4818 -3
-      vertex 51.9735 -1.66832 -4.5
-      vertex 51.9735 -1.66832 -3
-    endloop
-  endfacet
-  facet normal -0.589331 0.807891 0
-    outer loop
-      vertex 51.9735 -1.66832 -4.5
-      vertex 51.7713 -1.81578 -3
-      vertex 51.9735 -1.66832 -3
-    endloop
-  endfacet
-  facet normal -0.589331 0.807891 0
-    outer loop
-      vertex 51.7713 -1.81578 -3
-      vertex 51.9735 -1.66832 -4.5
-      vertex 51.7713 -1.81578 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 51.7713 -1.81578 -4.5
-      vertex 51.5418 -1.91832 -3
-      vertex 51.7713 -1.81578 -3
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 51.5418 -1.91832 -3
-      vertex 51.7713 -1.81578 -4.5
-      vertex 51.5418 -1.91832 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 51.5418 -1.91832 -4.5
-      vertex 51.2967 -1.97008 -3
-      vertex 51.5418 -1.91832 -3
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 51.2967 -1.97008 -3
-      vertex 51.5418 -1.91832 -4.5
-      vertex 51.2967 -1.97008 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 51.2967 -1.97008 -4.5
-      vertex 51.0457 -1.97008 -3
-      vertex 51.2967 -1.97008 -3
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 51.0457 -1.97008 -3
-      vertex 51.2967 -1.97008 -4.5
-      vertex 51.0457 -1.97008 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 0.978426 -0
-    outer loop
-      vertex 51.0457 -1.97008 -4.5
-      vertex 50.8006 -1.91832 -3
-      vertex 51.0457 -1.97008 -3
-    endloop
-  endfacet
-  facet normal 0.2066 0.978426 0
-    outer loop
-      vertex 50.8006 -1.91832 -3
-      vertex 51.0457 -1.97008 -4.5
-      vertex 50.8006 -1.91832 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 0.913009 -0
-    outer loop
-      vertex 50.8006 -1.91832 -4.5
-      vertex 50.5711 -1.81578 -3
-      vertex 50.8006 -1.91832 -3
-    endloop
-  endfacet
-  facet normal 0.40794 0.913009 0
-    outer loop
-      vertex 50.5711 -1.81578 -3
-      vertex 50.8006 -1.91832 -4.5
-      vertex 50.5711 -1.81578 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 0.809241 -0
-    outer loop
-      vertex 50.5711 -1.81578 -4.5
-      vertex 50.368 -1.66832 -3
-      vertex 50.5711 -1.81578 -3
-    endloop
-  endfacet
-  facet normal 0.587477 0.809241 0
-    outer loop
-      vertex 50.368 -1.66832 -3
-      vertex 50.5711 -1.81578 -4.5
-      vertex 50.368 -1.66832 -4.5
-    endloop
-  endfacet
-  facet normal 0.743101 0.66918 0
-    outer loop
-      vertex 50.368 -1.66832 -3
-      vertex 50.2 -1.4818 -4.5
-      vertex 50.2 -1.4818 -3
-    endloop
-  endfacet
-  facet normal 0.743101 0.66918 0
-    outer loop
-      vertex 50.2 -1.4818 -4.5
-      vertex 50.368 -1.66832 -3
-      vertex 50.368 -1.66832 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 0.499497 0
-    outer loop
-      vertex 50.2 -1.4818 -3
-      vertex 50.075 -1.265 -4.5
-      vertex 50.075 -1.265 -3
-    endloop
-  endfacet
-  facet normal 0.866315 0.499497 0
-    outer loop
-      vertex 50.075 -1.265 -4.5
-      vertex 50.2 -1.4818 -3
-      vertex 50.2 -1.4818 -4.5
-    endloop
-  endfacet
-  facet normal 0.950605 0.310402 0
-    outer loop
-      vertex 50.075 -1.265 -3
-      vertex 49.9969 -1.02574 -4.5
-      vertex 49.9969 -1.02574 -3
-    endloop
-  endfacet
-  facet normal 0.950605 0.310402 0
-    outer loop
-      vertex 49.9969 -1.02574 -4.5
-      vertex 50.075 -1.265 -3
-      vertex 50.075 -1.265 -4.5
-    endloop
-  endfacet
-  facet normal 0.994449 0.105222 0
-    outer loop
-      vertex 49.9942 -1 -3
-      vertex 49.9969 -1.02574 -3
-      vertex 49.9942 -1 -3.1
-    endloop
-  endfacet
-  facet normal 0.99444 0.105302 0
-    outer loop
-      vertex 49.9942 -1 -3.1
-      vertex 49.9705 -0.776718 -4.5
-      vertex 49.9705 -0.776718 -3.1
-    endloop
-  endfacet
-  facet normal 0.994449 0.105222 -0
-    outer loop
-      vertex 49.9969 -1.02574 -4.5
-      vertex 49.9942 -1 -3.1
-      vertex 49.9969 -1.02574 -3
-    endloop
-  endfacet
-  facet normal 0.994441 0.105294 -1.33888e-06
-    outer loop
-      vertex 49.9942 -1 -3.1
-      vertex 49.9969 -1.02574 -4.5
-      vertex 49.9705 -0.776718 -4.5
-    endloop
-  endfacet
-  facet normal 0.994484 -0.104887 0
-    outer loop
-      vertex 49.9705 -0.776718 -3.1
-      vertex 49.9969 -0.526718 -4.5
-      vertex 49.9969 -0.526718 -3.1
-    endloop
-  endfacet
-  facet normal 0.994484 -0.104887 0
-    outer loop
-      vertex 49.9969 -0.526718 -4.5
-      vertex 49.9705 -0.776718 -3.1
-      vertex 49.9705 -0.776718 -4.5
-    endloop
-  endfacet
-  facet normal 0.95023 -0.311551 0
-    outer loop
-      vertex 49.9969 -0.526718 -3.1
-      vertex 50.075 -0.288437 -4.5
-      vertex 50.075 -0.288437 -3.1
-    endloop
-  endfacet
-  facet normal 0.95023 -0.311551 0
-    outer loop
-      vertex 50.075 -0.288437 -4.5
-      vertex 49.9969 -0.526718 -3.1
-      vertex 49.9969 -0.526718 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 50.075 -0.288437 -3.1
-      vertex 50.2 -0.07164 -4.5
-      vertex 50.2 -0.07164 -3.1
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 50.2 -0.07164 -4.5
-      vertex 50.075 -0.288437 -3.1
-      vertex 50.075 -0.288437 -4.5
-    endloop
-  endfacet
-  facet normal 0.743099 -0.669182 0
-    outer loop
-      vertex 50.2 -0.07164 -3.1
-      vertex 50.368 0.114882 -4.5
-      vertex 50.368 0.114882 -3.1
-    endloop
-  endfacet
-  facet normal 0.743099 -0.669182 0
-    outer loop
-      vertex 50.368 0.114882 -4.5
-      vertex 50.2 -0.07164 -3.1
-      vertex 50.2 -0.07164 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 50.368 0.114882 -4.5
-      vertex 50.5711 0.262343 -3.1
-      vertex 50.368 0.114882 -3.1
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 50.5711 0.262343 -3.1
-      vertex 50.368 0.114882 -4.5
-      vertex 50.5711 0.262343 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 50.5711 0.262343 -4.5
-      vertex 50.8006 0.364882 -3.1
-      vertex 50.5711 0.262343 -3.1
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 50.8006 0.364882 -3.1
-      vertex 50.5711 0.262343 -4.5
-      vertex 50.8006 0.364882 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 50.8006 0.364882 -4.5
-      vertex 51.0457 0.41664 -3.1
-      vertex 50.8006 0.364882 -3.1
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 51.0457 0.41664 -3.1
-      vertex 50.8006 0.364882 -4.5
-      vertex 51.0457 0.41664 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 51.0457 0.41664 -4.5
-      vertex 51.2967 0.41664 -3.1
-      vertex 51.0457 0.41664 -3.1
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 51.2967 0.41664 -3.1
-      vertex 51.0457 0.41664 -4.5
-      vertex 51.2967 0.41664 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 0
-    outer loop
-      vertex 51.2967 0.41664 -4.5
-      vertex 51.5418 0.364882 -3.1
-      vertex 51.2967 0.41664 -3.1
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 -0
-    outer loop
-      vertex 51.5418 0.364882 -3.1
-      vertex 51.2967 0.41664 -4.5
-      vertex 51.5418 0.364882 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 0
-    outer loop
-      vertex 51.5418 2.90492 -4.5
-      vertex 51.7713 2.80238 -3.1
-      vertex 51.5418 2.90492 -3.1
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 -0
-    outer loop
-      vertex 51.7713 2.80238 -3.1
-      vertex 51.5418 2.90492 -4.5
-      vertex 51.7713 2.80238 -4.5
-    endloop
-  endfacet
-  facet normal -0.589331 -0.807891 0
-    outer loop
-      vertex 51.7713 2.80238 -4.5
-      vertex 51.9735 2.65492 -3.1
-      vertex 51.7713 2.80238 -3.1
-    endloop
-  endfacet
-  facet normal -0.589331 -0.807891 -0
-    outer loop
-      vertex 51.9735 2.65492 -3.1
-      vertex 51.7713 2.80238 -4.5
-      vertex 51.9735 2.65492 -4.5
-    endloop
-  endfacet
-  facet normal -0.743101 -0.66918 0
-    outer loop
-      vertex 52.1414 2.4684 -4.5
-      vertex 51.9735 2.65492 -3.1
-      vertex 51.9735 2.65492 -4.5
-    endloop
-  endfacet
-  facet normal -0.743101 -0.66918 0
-    outer loop
-      vertex 51.9735 2.65492 -3.1
-      vertex 52.1414 2.4684 -4.5
-      vertex 52.1414 2.4684 -3.1
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 52.2674 2.2516 -4.5
-      vertex 52.1414 2.4684 -3.1
-      vertex 52.1414 2.4684 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 52.1414 2.4684 -3.1
-      vertex 52.2674 2.2516 -4.5
-      vertex 52.2674 2.2516 -3.1
-    endloop
-  endfacet
-  facet normal -0.951377 -0.308028 0
-    outer loop
-      vertex 52.3446 2.01332 -4.5
-      vertex 52.2674 2.2516 -3.1
-      vertex 52.2674 2.2516 -4.5
-    endloop
-  endfacet
-  facet normal -0.951377 -0.308028 0
-    outer loop
-      vertex 52.2674 2.2516 -3.1
-      vertex 52.3446 2.01332 -4.5
-      vertex 52.3446 2.01332 -3.1
-    endloop
-  endfacet
-  facet normal -0.994484 -0.104887 0
-    outer loop
-      vertex 52.3709 1.76332 -4.5
-      vertex 52.3446 2.01332 -3.1
-      vertex 52.3446 2.01332 -4.5
-    endloop
-  endfacet
-  facet normal -0.994484 -0.104887 0
-    outer loop
-      vertex 52.3446 2.01332 -3.1
-      vertex 52.3709 1.76332 -4.5
-      vertex 52.3709 1.76332 -3.1
-    endloop
-  endfacet
-  facet normal -0.994441 0.105294 0
-    outer loop
-      vertex 52.3446 1.5143 -4.5
-      vertex 52.3709 1.76332 -3.1
-      vertex 52.3709 1.76332 -4.5
-    endloop
-  endfacet
-  facet normal -0.994441 0.105294 0
-    outer loop
-      vertex 52.3709 1.76332 -3.1
-      vertex 52.3446 1.5143 -4.5
-      vertex 52.3446 1.5143 -3.1
-    endloop
-  endfacet
-  facet normal -0.951745 0.306889 0
-    outer loop
-      vertex 52.2674 1.27504 -4.5
-      vertex 52.3446 1.5143 -3.1
-      vertex 52.3446 1.5143 -4.5
-    endloop
-  endfacet
-  facet normal -0.951745 0.306889 0
-    outer loop
-      vertex 52.3446 1.5143 -3.1
-      vertex 52.2674 1.27504 -4.5
-      vertex 52.2674 1.27504 -3.1
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 52.1414 1.05824 -4.5
-      vertex 52.2674 1.27504 -3.1
-      vertex 52.2674 1.27504 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 52.2674 1.27504 -3.1
-      vertex 52.1414 1.05824 -4.5
-      vertex 52.1414 1.05824 -3.1
-    endloop
-  endfacet
-  facet normal -0.743101 0.66918 0
-    outer loop
-      vertex 51.9735 0.871718 -4.5
-      vertex 52.1414 1.05824 -3.1
-      vertex 52.1414 1.05824 -4.5
-    endloop
-  endfacet
-  facet normal -0.743101 0.66918 0
-    outer loop
-      vertex 52.1414 1.05824 -3.1
-      vertex 51.9735 0.871718 -4.5
-      vertex 51.9735 0.871718 -3.1
-    endloop
-  endfacet
-  facet normal -0.589331 0.807891 0
-    outer loop
-      vertex 51.9735 0.871718 -4.5
-      vertex 51.7713 0.724257 -3.1
-      vertex 51.9735 0.871718 -3.1
-    endloop
-  endfacet
-  facet normal -0.589331 0.807891 0
-    outer loop
-      vertex 51.7713 0.724257 -3.1
-      vertex 51.9735 0.871718 -4.5
-      vertex 51.7713 0.724257 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 51.7713 0.724257 -4.5
-      vertex 51.5418 0.621718 -3.1
-      vertex 51.7713 0.724257 -3.1
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 51.5418 0.621718 -3.1
-      vertex 51.7713 0.724257 -4.5
-      vertex 51.5418 0.621718 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 51.5418 0.621718 -4.5
-      vertex 51.2967 0.569961 -3.1
-      vertex 51.5418 0.621718 -3.1
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 51.2967 0.569961 -3.1
-      vertex 51.5418 0.621718 -4.5
-      vertex 51.2967 0.569961 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 51.2967 0.569961 -4.5
-      vertex 51.0457 0.569961 -3.1
-      vertex 51.2967 0.569961 -3.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 51.0457 0.569961 -3.1
-      vertex 51.2967 0.569961 -4.5
-      vertex 51.0457 0.569961 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 0.978426 -0
-    outer loop
-      vertex 51.0457 0.569961 -4.5
-      vertex 50.8006 0.621718 -3.1
-      vertex 51.0457 0.569961 -3.1
-    endloop
-  endfacet
-  facet normal 0.2066 0.978426 0
-    outer loop
-      vertex 50.8006 0.621718 -3.1
-      vertex 51.0457 0.569961 -4.5
-      vertex 50.8006 0.621718 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 0.913009 -0
-    outer loop
-      vertex 50.8006 0.621718 -4.5
-      vertex 50.5711 0.724257 -3.1
-      vertex 50.8006 0.621718 -3.1
-    endloop
-  endfacet
-  facet normal 0.40794 0.913009 0
-    outer loop
-      vertex 50.5711 0.724257 -3.1
-      vertex 50.8006 0.621718 -4.5
-      vertex 50.5711 0.724257 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 0.809241 -0
-    outer loop
-      vertex 50.5711 0.724257 -4.5
-      vertex 50.368 0.871718 -3.1
-      vertex 50.5711 0.724257 -3.1
-    endloop
-  endfacet
-  facet normal 0.587477 0.809241 0
-    outer loop
-      vertex 50.368 0.871718 -3.1
-      vertex 50.5711 0.724257 -4.5
-      vertex 50.368 0.871718 -4.5
-    endloop
-  endfacet
-  facet normal 0.743101 0.66918 0
-    outer loop
-      vertex 50.368 0.871718 -3.1
-      vertex 50.2 1.05824 -4.5
-      vertex 50.2 1.05824 -3.1
-    endloop
-  endfacet
-  facet normal 0.743101 0.66918 0
-    outer loop
-      vertex 50.2 1.05824 -4.5
-      vertex 50.368 0.871718 -3.1
-      vertex 50.368 0.871718 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 0.499497 0
-    outer loop
-      vertex 50.2 1.05824 -3.1
-      vertex 50.075 1.27504 -4.5
-      vertex 50.075 1.27504 -3.1
-    endloop
-  endfacet
-  facet normal 0.866315 0.499497 0
-    outer loop
-      vertex 50.075 1.27504 -4.5
-      vertex 50.2 1.05824 -3.1
-      vertex 50.2 1.05824 -4.5
-    endloop
-  endfacet
-  facet normal 0.950605 0.310402 0
-    outer loop
-      vertex 50.075 1.27504 -3.1
-      vertex 49.9969 1.5143 -4.5
-      vertex 49.9969 1.5143 -3.1
-    endloop
-  endfacet
-  facet normal 0.950605 0.310402 0
-    outer loop
-      vertex 49.9969 1.5143 -4.5
-      vertex 50.075 1.27504 -3.1
-      vertex 50.075 1.27504 -4.5
-    endloop
-  endfacet
-  facet normal 0.994441 0.105294 0
-    outer loop
-      vertex 49.9969 1.5143 -3.1
-      vertex 49.9705 1.76332 -4.5
-      vertex 49.9705 1.76332 -3.1
-    endloop
-  endfacet
-  facet normal 0.994441 0.105294 0
-    outer loop
-      vertex 49.9705 1.76332 -4.5
-      vertex 49.9969 1.5143 -3.1
-      vertex 49.9969 1.5143 -4.5
-    endloop
-  endfacet
-  facet normal 0.994484 -0.104887 0
-    outer loop
-      vertex 49.9705 1.76332 -3.1
-      vertex 49.9969 2.01332 -4.5
-      vertex 49.9969 2.01332 -3.1
-    endloop
-  endfacet
-  facet normal 0.994484 -0.104887 0
-    outer loop
-      vertex 49.9969 2.01332 -4.5
-      vertex 49.9705 1.76332 -3.1
-      vertex 49.9705 1.76332 -4.5
-    endloop
-  endfacet
-  facet normal 0.95023 -0.311551 0
-    outer loop
-      vertex 49.9969 2.01332 -3.1
-      vertex 50.075 2.2516 -4.5
-      vertex 50.075 2.2516 -3.1
-    endloop
-  endfacet
-  facet normal 0.95023 -0.311551 0
-    outer loop
-      vertex 50.075 2.2516 -4.5
-      vertex 49.9969 2.01332 -3.1
-      vertex 49.9969 2.01332 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 50.075 2.2516 -3.1
-      vertex 50.2 2.4684 -4.5
-      vertex 50.2 2.4684 -3.1
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 50.2 2.4684 -4.5
-      vertex 50.075 2.2516 -3.1
-      vertex 50.075 2.2516 -4.5
-    endloop
-  endfacet
-  facet normal 0.743101 -0.66918 0
-    outer loop
-      vertex 50.2 2.4684 -3.1
-      vertex 50.368 2.65492 -4.5
-      vertex 50.368 2.65492 -3.1
-    endloop
-  endfacet
-  facet normal 0.743101 -0.66918 0
-    outer loop
-      vertex 50.368 2.65492 -4.5
-      vertex 50.2 2.4684 -3.1
-      vertex 50.2 2.4684 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 50.368 2.65492 -4.5
-      vertex 50.5711 2.80238 -3.1
-      vertex 50.368 2.65492 -3.1
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 50.5711 2.80238 -3.1
-      vertex 50.368 2.65492 -4.5
-      vertex 50.5711 2.80238 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 50.5711 2.80238 -4.5
-      vertex 50.8006 2.90492 -3.1
-      vertex 50.5711 2.80238 -3.1
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 50.8006 2.90492 -3.1
-      vertex 50.5711 2.80238 -4.5
-      vertex 50.8006 2.90492 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 50.8006 2.90492 -4.5
-      vertex 51.0457 2.95668 -3.1
-      vertex 50.8006 2.90492 -3.1
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 51.0457 2.95668 -3.1
-      vertex 50.8006 2.90492 -4.5
-      vertex 51.0457 2.95668 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 51.0457 2.95668 -4.5
-      vertex 51.2967 2.95668 -3.1
-      vertex 51.0457 2.95668 -3.1
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 51.2967 2.95668 -3.1
-      vertex 51.0457 2.95668 -4.5
-      vertex 51.2967 2.95668 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 0
-    outer loop
-      vertex 51.2967 2.95668 -4.5
-      vertex 51.5418 2.90492 -3.1
-      vertex 51.2967 2.95668 -3.1
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 -0
-    outer loop
-      vertex 51.5418 2.90492 -3.1
-      vertex 51.2967 2.95668 -4.5
-      vertex 51.5418 2.90492 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 0
-    outer loop
-      vertex 51.5418 5.44496 -4.5
-      vertex 51.7713 5.34242 -3.1
-      vertex 51.5418 5.44496 -3.1
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 -0
-    outer loop
-      vertex 51.7713 5.34242 -3.1
-      vertex 51.5418 5.44496 -4.5
-      vertex 51.7713 5.34242 -4.5
-    endloop
-  endfacet
-  facet normal -0.589331 -0.807891 0
-    outer loop
-      vertex 51.7713 5.34242 -4.5
-      vertex 51.9735 5.19496 -3.1
-      vertex 51.7713 5.34242 -3.1
-    endloop
-  endfacet
-  facet normal -0.589331 -0.807891 -0
-    outer loop
-      vertex 51.9735 5.19496 -3.1
-      vertex 51.7713 5.34242 -4.5
-      vertex 51.9735 5.19496 -4.5
-    endloop
-  endfacet
-  facet normal -0.743101 -0.66918 0
-    outer loop
-      vertex 52.1414 5.00844 -4.5
-      vertex 51.9735 5.19496 -3.1
-      vertex 51.9735 5.19496 -4.5
-    endloop
-  endfacet
-  facet normal -0.743101 -0.66918 0
-    outer loop
-      vertex 51.9735 5.19496 -3.1
-      vertex 52.1414 5.00844 -4.5
-      vertex 52.1414 5.00844 -3.1
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 52.2674 4.79164 -4.5
-      vertex 52.1414 5.00844 -3.1
-      vertex 52.1414 5.00844 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 52.1414 5.00844 -3.1
-      vertex 52.2674 4.79164 -4.5
-      vertex 52.2674 4.79164 -3.1
-    endloop
-  endfacet
-  facet normal -0.951377 -0.308028 0
-    outer loop
-      vertex 52.3446 4.55336 -4.5
-      vertex 52.2674 4.79164 -3.1
-      vertex 52.2674 4.79164 -4.5
-    endloop
-  endfacet
-  facet normal -0.951377 -0.308028 0
-    outer loop
-      vertex 52.2674 4.79164 -3.1
-      vertex 52.3446 4.55336 -4.5
-      vertex 52.3446 4.55336 -3.1
-    endloop
-  endfacet
-  facet normal -0.994484 -0.104887 0
-    outer loop
-      vertex 52.3709 4.30336 -4.5
-      vertex 52.3446 4.55336 -3.1
-      vertex 52.3446 4.55336 -4.5
-    endloop
-  endfacet
-  facet normal -0.994484 -0.104887 0
-    outer loop
-      vertex 52.3446 4.55336 -3.1
-      vertex 52.3709 4.30336 -4.5
-      vertex 52.3709 4.30336 -3.1
-    endloop
-  endfacet
-  facet normal -0.994441 0.105294 0
-    outer loop
-      vertex 52.3446 4.05434 -4.5
-      vertex 52.3709 4.30336 -3.1
-      vertex 52.3709 4.30336 -4.5
-    endloop
-  endfacet
-  facet normal -0.994441 0.105294 0
-    outer loop
-      vertex 52.3709 4.30336 -3.1
-      vertex 52.3446 4.05434 -4.5
-      vertex 52.3446 4.05434 -3.1
-    endloop
-  endfacet
-  facet normal -0.951745 0.306889 0
-    outer loop
-      vertex 52.2674 3.81508 -4.5
-      vertex 52.3446 4.05434 -3.1
-      vertex 52.3446 4.05434 -4.5
-    endloop
-  endfacet
-  facet normal -0.951745 0.306889 0
-    outer loop
-      vertex 52.3446 4.05434 -3.1
-      vertex 52.2674 3.81508 -4.5
-      vertex 52.2674 3.81508 -3.1
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 52.1414 3.59828 -4.5
-      vertex 52.2674 3.81508 -3.1
-      vertex 52.2674 3.81508 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 52.2674 3.81508 -3.1
-      vertex 52.1414 3.59828 -4.5
-      vertex 52.1414 3.59828 -3.1
-    endloop
-  endfacet
-  facet normal -0.743101 0.66918 0
-    outer loop
-      vertex 51.9735 3.41176 -4.5
-      vertex 52.1414 3.59828 -3.1
-      vertex 52.1414 3.59828 -4.5
-    endloop
-  endfacet
-  facet normal -0.743101 0.66918 0
-    outer loop
-      vertex 52.1414 3.59828 -3.1
-      vertex 51.9735 3.41176 -4.5
-      vertex 51.9735 3.41176 -3.1
-    endloop
-  endfacet
-  facet normal -0.589331 0.807891 0
-    outer loop
-      vertex 51.9735 3.41176 -4.5
-      vertex 51.7713 3.2643 -3.1
-      vertex 51.9735 3.41176 -3.1
-    endloop
-  endfacet
-  facet normal -0.589331 0.807891 0
-    outer loop
-      vertex 51.7713 3.2643 -3.1
-      vertex 51.9735 3.41176 -4.5
-      vertex 51.7713 3.2643 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 51.7713 3.2643 -4.5
-      vertex 51.5418 3.16176 -3.1
-      vertex 51.7713 3.2643 -3.1
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 51.5418 3.16176 -3.1
-      vertex 51.7713 3.2643 -4.5
-      vertex 51.5418 3.16176 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 51.5418 3.16176 -4.5
-      vertex 51.2967 3.11 -3.1
-      vertex 51.5418 3.16176 -3.1
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 51.2967 3.11 -3.1
-      vertex 51.5418 3.16176 -4.5
-      vertex 51.2967 3.11 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 51.2967 3.11 -4.5
-      vertex 51.0457 3.11 -3.1
-      vertex 51.2967 3.11 -3.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 51.0457 3.11 -3.1
-      vertex 51.2967 3.11 -4.5
-      vertex 51.0457 3.11 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 0.978426 -0
-    outer loop
-      vertex 51.0457 3.11 -4.5
-      vertex 50.8006 3.16176 -3.1
-      vertex 51.0457 3.11 -3.1
-    endloop
-  endfacet
-  facet normal 0.2066 0.978426 0
-    outer loop
-      vertex 50.8006 3.16176 -3.1
-      vertex 51.0457 3.11 -4.5
-      vertex 50.8006 3.16176 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 0.913009 -0
-    outer loop
-      vertex 50.8006 3.16176 -4.5
-      vertex 50.5711 3.2643 -3.1
-      vertex 50.8006 3.16176 -3.1
-    endloop
-  endfacet
-  facet normal 0.40794 0.913009 0
-    outer loop
-      vertex 50.5711 3.2643 -3.1
-      vertex 50.8006 3.16176 -4.5
-      vertex 50.5711 3.2643 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 0.809241 -0
-    outer loop
-      vertex 50.5711 3.2643 -4.5
-      vertex 50.368 3.41176 -3.1
-      vertex 50.5711 3.2643 -3.1
-    endloop
-  endfacet
-  facet normal 0.587477 0.809241 0
-    outer loop
-      vertex 50.368 3.41176 -3.1
-      vertex 50.5711 3.2643 -4.5
-      vertex 50.368 3.41176 -4.5
-    endloop
-  endfacet
-  facet normal 0.743101 0.66918 0
-    outer loop
-      vertex 50.368 3.41176 -3.1
-      vertex 50.2 3.59828 -4.5
-      vertex 50.2 3.59828 -3.1
-    endloop
-  endfacet
-  facet normal 0.743101 0.66918 0
-    outer loop
-      vertex 50.2 3.59828 -4.5
-      vertex 50.368 3.41176 -3.1
-      vertex 50.368 3.41176 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 0.499497 0
-    outer loop
-      vertex 50.2 3.59828 -3.1
-      vertex 50.075 3.81508 -4.5
-      vertex 50.075 3.81508 -3.1
-    endloop
-  endfacet
-  facet normal 0.866315 0.499497 0
-    outer loop
-      vertex 50.075 3.81508 -4.5
-      vertex 50.2 3.59828 -3.1
-      vertex 50.2 3.59828 -4.5
-    endloop
-  endfacet
-  facet normal 0.950605 0.310402 0
-    outer loop
-      vertex 50.075 3.81508 -3.1
-      vertex 49.9969 4.05434 -4.5
-      vertex 49.9969 4.05434 -3.1
-    endloop
-  endfacet
-  facet normal 0.950605 0.310402 0
-    outer loop
-      vertex 49.9969 4.05434 -4.5
-      vertex 50.075 3.81508 -3.1
-      vertex 50.075 3.81508 -4.5
-    endloop
-  endfacet
-  facet normal 0.994441 0.105294 0
-    outer loop
-      vertex 49.9969 4.05434 -3.1
-      vertex 49.9705 4.30336 -4.5
-      vertex 49.9705 4.30336 -3.1
-    endloop
-  endfacet
-  facet normal 0.994441 0.105294 0
-    outer loop
-      vertex 49.9705 4.30336 -4.5
-      vertex 49.9969 4.05434 -3.1
-      vertex 49.9969 4.05434 -4.5
-    endloop
-  endfacet
-  facet normal 0.994484 -0.104887 0
-    outer loop
-      vertex 49.9705 4.30336 -3.1
-      vertex 49.9969 4.55336 -4.5
-      vertex 49.9969 4.55336 -3.1
-    endloop
-  endfacet
-  facet normal 0.994484 -0.104887 0
-    outer loop
-      vertex 49.9969 4.55336 -4.5
-      vertex 49.9705 4.30336 -3.1
-      vertex 49.9705 4.30336 -4.5
-    endloop
-  endfacet
-  facet normal 0.95023 -0.311551 0
-    outer loop
-      vertex 49.9969 4.55336 -3.1
-      vertex 50.075 4.79164 -4.5
-      vertex 50.075 4.79164 -3.1
-    endloop
-  endfacet
-  facet normal 0.95023 -0.311551 0
-    outer loop
-      vertex 50.075 4.79164 -4.5
-      vertex 49.9969 4.55336 -3.1
-      vertex 49.9969 4.55336 -4.5
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 50.075 4.79164 -3.1
-      vertex 50.2 5.00844 -4.5
-      vertex 50.2 5.00844 -3.1
-    endloop
-  endfacet
-  facet normal 0.866315 -0.499497 0
-    outer loop
-      vertex 50.2 5.00844 -4.5
-      vertex 50.075 4.79164 -3.1
-      vertex 50.075 4.79164 -4.5
-    endloop
-  endfacet
-  facet normal 0.743101 -0.66918 0
-    outer loop
-      vertex 50.2 5.00844 -3.1
-      vertex 50.368 5.19496 -4.5
-      vertex 50.368 5.19496 -3.1
-    endloop
-  endfacet
-  facet normal 0.743101 -0.66918 0
-    outer loop
-      vertex 50.368 5.19496 -4.5
-      vertex 50.2 5.00844 -3.1
-      vertex 50.2 5.00844 -4.5
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 50.368 5.19496 -4.5
-      vertex 50.5711 5.34242 -3.1
-      vertex 50.368 5.19496 -3.1
-    endloop
-  endfacet
-  facet normal 0.587477 -0.809241 0
-    outer loop
-      vertex 50.5711 5.34242 -3.1
-      vertex 50.368 5.19496 -4.5
-      vertex 50.5711 5.34242 -4.5
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 50.5711 5.34242 -4.5
-      vertex 50.8006 5.44496 -3.1
-      vertex 50.5711 5.34242 -3.1
-    endloop
-  endfacet
-  facet normal 0.40794 -0.913009 0
-    outer loop
-      vertex 50.8006 5.44496 -3.1
-      vertex 50.5711 5.34242 -4.5
-      vertex 50.8006 5.44496 -4.5
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 50.8006 5.44496 -4.5
-      vertex 51.0457 5.49672 -3.1
-      vertex 50.8006 5.44496 -3.1
-    endloop
-  endfacet
-  facet normal 0.2066 -0.978426 0
-    outer loop
-      vertex 51.0457 5.49672 -3.1
-      vertex 50.8006 5.44496 -4.5
-      vertex 51.0457 5.49672 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 51.0457 5.49672 -4.5
-      vertex 51.2967 5.49672 -3.1
-      vertex 51.0457 5.49672 -3.1
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 51.2967 5.49672 -3.1
-      vertex 51.0457 5.49672 -4.5
-      vertex 51.2967 5.49672 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 0
-    outer loop
-      vertex 51.2967 5.49672 -4.5
-      vertex 51.5418 5.44496 -3.1
-      vertex 51.2967 5.49672 -3.1
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 -0
-    outer loop
-      vertex 51.5418 5.44496 -3.1
-      vertex 51.2967 5.49672 -4.5
-      vertex 51.5418 5.44496 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 0
-    outer loop
-      vertex 45.3797 5.63051 -4.5
-      vertex 45.6092 5.52797 -3.1
-      vertex 45.3797 5.63051 -3.1
-    endloop
-  endfacet
-  facet normal -0.40794 -0.913009 -0
-    outer loop
-      vertex 45.6092 5.52797 -3.1
-      vertex 45.3797 5.63051 -4.5
-      vertex 45.6092 5.52797 -4.5
-    endloop
-  endfacet
-  facet normal -0.587477 -0.809241 0
-    outer loop
-      vertex 45.6092 5.52797 -4.5
-      vertex 45.8123 5.38051 -3.1
-      vertex 45.6092 5.52797 -3.1
-    endloop
-  endfacet
-  facet normal -0.587477 -0.809241 -0
-    outer loop
-      vertex 45.8123 5.38051 -3.1
-      vertex 45.6092 5.52797 -4.5
-      vertex 45.8123 5.38051 -4.5
-    endloop
-  endfacet
-  facet normal -0.745037 -0.667023 0
-    outer loop
-      vertex 45.9793 5.19398 -4.5
-      vertex 45.8123 5.38051 -3.1
-      vertex 45.8123 5.38051 -4.5
-    endloop
-  endfacet
-  facet normal -0.745037 -0.667023 0
-    outer loop
-      vertex 45.8123 5.38051 -3.1
-      vertex 45.9793 5.19398 -4.5
-      vertex 45.9793 5.19398 -3.1
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 46.1053 4.97719 -4.5
-      vertex 45.9793 5.19398 -3.1
-      vertex 45.9793 5.19398 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 -0.502417 0
-    outer loop
-      vertex 45.9793 5.19398 -3.1
-      vertex 46.1053 4.97719 -4.5
-      vertex 46.1053 4.97719 -3.1
-    endloop
-  endfacet
-  facet normal -0.951745 -0.306889 0
-    outer loop
-      vertex 46.1825 4.73793 -4.5
-      vertex 46.1053 4.97719 -3.1
-      vertex 46.1053 4.97719 -4.5
-    endloop
-  endfacet
-  facet normal -0.951745 -0.306889 0
-    outer loop
-      vertex 46.1053 4.97719 -3.1
-      vertex 46.1825 4.73793 -4.5
-      vertex 46.1825 4.73793 -3.1
-    endloop
-  endfacet
-  facet normal -0.994441 -0.105294 0
-    outer loop
-      vertex 46.2088 4.48891 -4.5
-      vertex 46.1825 4.73793 -3.1
-      vertex 46.1825 4.73793 -4.5
-    endloop
-  endfacet
-  facet normal -0.994441 -0.105294 0
-    outer loop
-      vertex 46.1825 4.73793 -3.1
-      vertex 46.2088 4.48891 -4.5
-      vertex 46.2088 4.48891 -3.1
-    endloop
-  endfacet
-  facet normal -0.994484 0.104887 0
-    outer loop
-      vertex 46.1825 4.23891 -4.5
-      vertex 46.2088 4.48891 -3.1
-      vertex 46.2088 4.48891 -4.5
-    endloop
-  endfacet
-  facet normal -0.994484 0.104887 0
-    outer loop
-      vertex 46.2088 4.48891 -3.1
-      vertex 46.1825 4.23891 -4.5
-      vertex 46.1825 4.23891 -3.1
-    endloop
-  endfacet
-  facet normal -0.951377 0.308028 0
-    outer loop
-      vertex 46.1053 4.00062 -4.5
-      vertex 46.1825 4.23891 -3.1
-      vertex 46.1825 4.23891 -4.5
-    endloop
-  endfacet
-  facet normal -0.951377 0.308028 0
-    outer loop
-      vertex 46.1825 4.23891 -3.1
-      vertex 46.1053 4.00062 -4.5
-      vertex 46.1053 4.00062 -3.1
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 45.9793 3.78383 -4.5
-      vertex 46.1053 4.00062 -3.1
-      vertex 46.1053 4.00062 -4.5
-    endloop
-  endfacet
-  facet normal -0.864625 0.502417 0
-    outer loop
-      vertex 46.1053 4.00062 -3.1
-      vertex 45.9793 3.78383 -4.5
-      vertex 45.9793 3.78383 -3.1
-    endloop
-  endfacet
-  facet normal -0.745037 0.667023 0
-    outer loop
-      vertex 45.8123 3.5973 -4.5
-      vertex 45.9793 3.78383 -3.1
-      vertex 45.9793 3.78383 -4.5
-    endloop
-  endfacet
-  facet normal -0.745037 0.667023 0
-    outer loop
-      vertex 45.9793 3.78383 -3.1
-      vertex 45.8123 3.5973 -4.5
-      vertex 45.8123 3.5973 -3.1
-    endloop
-  endfacet
-  facet normal -0.587477 0.809241 0
-    outer loop
-      vertex 45.8123 3.5973 -4.5
-      vertex 45.6092 3.44984 -3.1
-      vertex 45.8123 3.5973 -3.1
-    endloop
-  endfacet
-  facet normal -0.587477 0.809241 0
-    outer loop
-      vertex 45.6092 3.44984 -3.1
-      vertex 45.8123 3.5973 -4.5
-      vertex 45.6092 3.44984 -4.5
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 45.6092 3.44984 -4.5
-      vertex 45.3797 3.3473 -3.1
-      vertex 45.6092 3.44984 -3.1
-    endloop
-  endfacet
-  facet normal -0.40794 0.913009 0
-    outer loop
-      vertex 45.3797 3.3473 -3.1
-      vertex 45.6092 3.44984 -4.5
-      vertex 45.3797 3.3473 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 45.3797 3.3473 -4.5
-      vertex 45.1346 3.29555 -3.1
-      vertex 45.3797 3.3473 -3.1
-    endloop
-  endfacet
-  facet normal -0.2066 0.978426 0
-    outer loop
-      vertex 45.1346 3.29555 -3.1
-      vertex 45.3797 3.3473 -4.5
-      vertex 45.1346 3.29555 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 45.1346 3.29555 -4.5
-      vertex 45 3.29555 -3.1
-      vertex 45.1346 3.29555 -3.1
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 45 3.29555 -3.1
-      vertex 45.1346 3.29555 -4.5
-      vertex 45 3.29555 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 45 5.68227 -4.5
-      vertex 45.1346 5.68227 -3.1
-      vertex 45 5.68227 -3.1
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 45.1346 5.68227 -3.1
-      vertex 45 5.68227 -4.5
-      vertex 45.1346 5.68227 -4.5
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 0
-    outer loop
-      vertex 45.1346 5.68227 -4.5
-      vertex 45.3797 5.63051 -3.1
-      vertex 45.1346 5.68227 -3.1
-    endloop
-  endfacet
-  facet normal -0.2066 -0.978426 -0
-    outer loop
-      vertex 45.3797 5.63051 -3.1
-      vertex 45.1346 5.68227 -4.5
-      vertex 45.3797 5.63051 -4.5
+      vertex 37.7843 24.7222 2.1
+      vertex 37.8464 24.6464 2.4
+      vertex 37.8464 24.6464 2.1
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 30 -21.5292 -2.5
-      vertex 30 -21.2733 -4.5
-      vertex 30 -21.2733 -2.5
+      vertex 37.7 25 2.4
+      vertex 37.7 29.5 2.1
+      vertex 37.7 29.5 2.4
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 30 -21.2733 -4.5
-      vertex 30 -21.5292 -2.5
-      vertex 30 -21.5292 -4.5
+      vertex 37.7 29.5 2.1
+      vertex 37.7 25 2.4
+      vertex 37.7 25 2.1
     endloop
   endfacet
-  facet normal -1 0 0
+  facet normal -0.633738 0.773548 0
     outer loop
-      vertex 41 -21.5747 -4.5
-      vertex 41 -21.2278 -2.5
-      vertex 41 -21.2278 -4.5
+      vertex 57.5536 24.6464 2.1
+      vertex 57.4778 24.5843 2.4
+      vertex 57.5536 24.6464 2.4
     endloop
   endfacet
-  facet normal -1 -0 0
+  facet normal -0.633738 0.773548 0
     outer loop
-      vertex 41 -21.2278 -2.5
-      vertex 41 -21.5747 -4.5
-      vertex 41 -21.5747 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 32.0487 -23.5 -4.5
-      vertex 31.2283 -23.5 -2.5
-      vertex 32.0487 -23.5 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 31.2283 -23.5 -2.5
-      vertex 32.0487 -23.5 -4.5
-      vertex 31.2283 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 34.5888 -23.5 -4.5
-      vertex 33.768 -23.5 -2.5
-      vertex 34.5888 -23.5 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 33.768 -23.5 -2.5
-      vertex 34.5888 -23.5 -4.5
-      vertex 33.768 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 37.1288 -23.5 -4.5
-      vertex 36.3081 -23.5 -2.5
-      vertex 37.1288 -23.5 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 36.3081 -23.5 -2.5
-      vertex 37.1288 -23.5 -4.5
-      vertex 36.3081 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 39.6688 -23.5 -4.5
-      vertex 38.8475 -23.5 -2.5
-      vertex 39.6688 -23.5 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 38.8475 -23.5 -2.5
-      vertex 39.6688 -23.5 -4.5
-      vertex 38.8475 -23.5 -4.5
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 48.5 -24.4414 -2.5
-      vertex 48.5 -23.7869 -4.5
-      vertex 48.5 -23.7869 -2.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 48.5 -23.7869 -4.5
-      vertex 48.5 -24.4414 -2.5
-      vertex 48.5 -24.4414 -4.5
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 48.5 -21.9013 -2.5
-      vertex 48.5 -21.2468 -4.5
-      vertex 48.5 -21.2468 -2.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 48.5 -21.2468 -4.5
-      vertex 48.5 -21.9013 -2.5
-      vertex 48.5 -21.9013 -4.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 52.5 -24.4374 -4.5
-      vertex 52.5 -23.7909 -2.5
-      vertex 52.5 -23.7909 -4.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 52.5 -23.7909 -2.5
-      vertex 52.5 -24.4374 -4.5
-      vertex 52.5 -24.4374 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 52.5 -21.8973 -4.5
-      vertex 52.5 -21.2508 -2.5
-      vertex 52.5 -21.2508 -4.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 52.5 -21.2508 -2.5
-      vertex 52.5 -21.8973 -4.5
-      vertex 52.5 -21.8973 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex -2.03031 -18.3 -4.5
-      vertex -3 -18.3 -2.5
-      vertex -2.03031 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -3 -18.3 -2.5
-      vertex -2.03031 -18.3 -4.5
-      vertex -3 -18.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 0.509724 -18.3 -4.5
-      vertex -0.296169 -18.3 -2.5
-      vertex 0.509724 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.296169 -18.3 -2.5
-      vertex 0.509724 -18.3 -4.5
-      vertex -0.296169 -18.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 3 -18.3 -4.5
-      vertex 2.24387 -18.3 -2.5
-      vertex 3 -18.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.24387 -18.3 -2.5
-      vertex 3 -18.3 -4.5
-      vertex 2.24387 -18.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -3 -14.3 -4.5
-      vertex -2.17187 -14.3 -2.5
-      vertex -3 -14.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex -2.17187 -14.3 -2.5
-      vertex -3 -14.3 -4.5
-      vertex -2.17187 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -0.154609 -14.3 -4.5
-      vertex 0.368165 -14.3 -2.5
-      vertex -0.154609 -14.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 0.368165 -14.3 -2.5
-      vertex -0.154609 -14.3 -4.5
-      vertex 0.368165 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 2.38543 -14.3 -4.5
-      vertex 2.9082 -14.3 -2.5
-      vertex 2.38543 -14.3 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 2.9082 -14.3 -2.5
-      vertex 2.38543 -14.3 -4.5
-      vertex 2.9082 -14.3 -4.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 1 -23.9011 -4.5
-      vertex 1 -23 -2.5
-      vertex 1 -23 -4.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 1 -23 -2.5
-      vertex 1 -23.9011 -4.5
-      vertex 1 -23.9011 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 1 -25.1143 -4.5
-      vertex 1 -25.8207 -2.5
-      vertex 1 -25.1143 -2.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 1 -26 -4.5
-      vertex 1 -25.8207 -2.5
-      vertex 1 -25.1143 -4.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 1 -25.8207 -2.5
-      vertex 1 -26 -4.5
-      vertex 1 -26 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex -3 -23 -4.5
-      vertex 1 -23 -2.5
-      vertex -3 -23 -2.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 1 -23 -2.5
-      vertex -3 -23 -4.5
-      vertex 1 -23 -4.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 46.1825 -0.621445 -3.1
-      vertex 46.2088 -0.870468 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 46.1053 -0.382187 -3.1
-      vertex 46.1825 -0.621445 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 45.9793 -0.16539 -3.1
-      vertex 46.1053 -0.382187 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 45.8123 0.0211325 -3.1
-      vertex 45.9793 -0.16539 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 45.6092 0.168593 -3.1
-      vertex 45.8123 0.0211325 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 45.3797 0.271132 -3.1
-      vertex 45.6092 0.168593 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 45.1346 0.32289 -3.1
-      vertex 45.3797 0.271132 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 44.8836 0.32289 -3.1
-      vertex 45.1346 0.32289 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 44.6385 0.271132 -3.1
-      vertex 44.8836 0.32289 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 44.409 0.168593 -3.1
-      vertex 44.6385 0.271132 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 44.2059 0.0211325 -3.1
-      vertex 44.409 0.168593 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 44.0379 -0.16539 -3.1
-      vertex 44.2059 0.0211325 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1952 -1 -3.1
-      vertex 43.9129 -0.382187 -3.1
-      vertex 44.0379 -0.16539 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.8226 -1 -3.1
-      vertex 43.9129 -0.382187 -3.1
-      vertex 46.1952 -1 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.9129 -0.382187 -3.1
-      vertex 43.8226 -1 -3.1
-      vertex 43.8348 -0.621445 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 43.8348 -0.621445 -3.1
-      vertex 43.8226 -1 -3.1
-      vertex 43.8094 -0.870468 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 52.3446 -0.526718 -3.1
-      vertex 52.3709 -0.776718 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 52.2674 -0.288437 -3.1
-      vertex 52.3446 -0.526718 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 52.1414 -0.07164 -3.1
-      vertex 52.2674 -0.288437 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 51.9735 0.114882 -3.1
-      vertex 52.1414 -0.07164 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 51.7713 0.262343 -3.1
-      vertex 51.9735 0.114882 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 51.5418 0.364882 -3.1
-      vertex 51.7713 0.262343 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 51.2967 0.41664 -3.1
-      vertex 51.5418 0.364882 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 51.0457 0.41664 -3.1
-      vertex 51.2967 0.41664 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 50.8006 0.364882 -3.1
-      vertex 51.0457 0.41664 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 50.5711 0.262343 -3.1
-      vertex 50.8006 0.364882 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 50.368 0.114882 -3.1
-      vertex 50.5711 0.262343 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 50.2 -0.07164 -3.1
-      vertex 50.368 0.114882 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 50.075 -0.288437 -3.1
-      vertex 50.2 -0.07164 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3473 -1 -3.1
-      vertex 49.9969 -0.526718 -3.1
-      vertex 50.075 -0.288437 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9942 -1 -3.1
-      vertex 49.9969 -0.526718 -3.1
-      vertex 52.3473 -1 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 -0.526718 -3.1
-      vertex 49.9942 -1 -3.1
-      vertex 49.9705 -0.776718 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3446 1.5143 -3.1
-      vertex 52.3446 2.01332 -3.1
-      vertex 52.3709 1.76332 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 1.27504 -3.1
-      vertex 52.3446 2.01332 -3.1
-      vertex 52.3446 1.5143 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 1.27504 -3.1
-      vertex 52.2674 2.2516 -3.1
-      vertex 52.3446 2.01332 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 1.05824 -3.1
-      vertex 52.2674 2.2516 -3.1
-      vertex 52.2674 1.27504 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 1.05824 -3.1
-      vertex 52.1414 2.4684 -3.1
-      vertex 52.2674 2.2516 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 0.871718 -3.1
-      vertex 52.1414 2.4684 -3.1
-      vertex 52.1414 1.05824 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 0.871718 -3.1
-      vertex 51.9735 2.65492 -3.1
-      vertex 52.1414 2.4684 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 0.724257 -3.1
-      vertex 51.9735 2.65492 -3.1
-      vertex 51.9735 0.871718 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 0.724257 -3.1
-      vertex 51.7713 2.80238 -3.1
-      vertex 51.9735 2.65492 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 0.621718 -3.1
-      vertex 51.7713 2.80238 -3.1
-      vertex 51.7713 0.724257 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 0.621718 -3.1
-      vertex 51.5418 2.90492 -3.1
-      vertex 51.7713 2.80238 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 0.569961 -3.1
-      vertex 51.5418 2.90492 -3.1
-      vertex 51.5418 0.621718 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 0.569961 -3.1
-      vertex 51.2967 2.95668 -3.1
-      vertex 51.5418 2.90492 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 0.569961 -3.1
-      vertex 51.2967 2.95668 -3.1
-      vertex 51.2967 0.569961 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 0.569961 -3.1
-      vertex 51.0457 2.95668 -3.1
-      vertex 51.2967 2.95668 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 0.621718 -3.1
-      vertex 51.0457 2.95668 -3.1
-      vertex 51.0457 0.569961 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 0.621718 -3.1
-      vertex 50.8006 2.90492 -3.1
-      vertex 51.0457 2.95668 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 0.724257 -3.1
-      vertex 50.8006 2.90492 -3.1
-      vertex 50.8006 0.621718 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 0.724257 -3.1
-      vertex 50.5711 2.80238 -3.1
-      vertex 50.8006 2.90492 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 0.871718 -3.1
-      vertex 50.5711 2.80238 -3.1
-      vertex 50.5711 0.724257 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 0.871718 -3.1
-      vertex 50.368 2.65492 -3.1
-      vertex 50.5711 2.80238 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 1.05824 -3.1
-      vertex 50.368 2.65492 -3.1
-      vertex 50.368 0.871718 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 1.05824 -3.1
-      vertex 50.2 2.4684 -3.1
-      vertex 50.368 2.65492 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 1.27504 -3.1
-      vertex 50.2 2.4684 -3.1
-      vertex 50.2 1.05824 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 1.27504 -3.1
-      vertex 50.075 2.2516 -3.1
-      vertex 50.2 2.4684 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 1.5143 -3.1
-      vertex 50.075 2.2516 -3.1
-      vertex 50.075 1.27504 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 1.5143 -3.1
-      vertex 49.9969 2.01332 -3.1
-      vertex 50.075 2.2516 -3.1
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 49.9969 2.01332 -3.1
-      vertex 49.9969 1.5143 -3.1
-      vertex 49.9705 1.76332 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1825 4.23891 -3.1
-      vertex 46.1825 4.73793 -3.1
-      vertex 46.2088 4.48891 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1053 4.00062 -3.1
-      vertex 46.1825 4.73793 -3.1
-      vertex 46.1825 4.23891 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 46.1053 4.00062 -3.1
-      vertex 46.1053 4.97719 -3.1
-      vertex 46.1825 4.73793 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.9793 3.78383 -3.1
-      vertex 46.1053 4.97719 -3.1
-      vertex 46.1053 4.00062 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.9793 3.78383 -3.1
-      vertex 45.9793 5.19398 -3.1
-      vertex 46.1053 4.97719 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.8123 3.5973 -3.1
-      vertex 45.9793 5.19398 -3.1
-      vertex 45.9793 3.78383 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.8123 3.5973 -3.1
-      vertex 45.8123 5.38051 -3.1
-      vertex 45.9793 5.19398 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 3.44984 -3.1
-      vertex 45.8123 5.38051 -3.1
-      vertex 45.8123 3.5973 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 3.44984 -3.1
-      vertex 45.6092 5.52797 -3.1
-      vertex 45.8123 5.38051 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 3.29555 -3.1
-      vertex 45.6092 3.44984 -3.1
-      vertex 45.3797 3.3473 -3.1
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 45.6092 3.44984 -3.1
-      vertex 45 3.29555 -3.1
-      vertex 45.6092 5.52797 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 3.29555 -3.1
-      vertex 45.3797 3.3473 -3.1
-      vertex 45.1346 3.29555 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45 5.68227 -3.1
-      vertex 45.6092 5.52797 -3.1
-      vertex 45 3.29555 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.6092 5.52797 -3.1
-      vertex 45 5.68227 -3.1
-      vertex 45.3797 5.63051 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 45.3797 5.63051 -3.1
-      vertex 45 5.68227 -3.1
-      vertex 45.1346 5.68227 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.3446 4.05434 -3.1
-      vertex 52.3446 4.55336 -3.1
-      vertex 52.3709 4.30336 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 3.81508 -3.1
-      vertex 52.3446 4.55336 -3.1
-      vertex 52.3446 4.05434 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.2674 3.81508 -3.1
-      vertex 52.2674 4.79164 -3.1
-      vertex 52.3446 4.55336 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 3.59828 -3.1
-      vertex 52.2674 4.79164 -3.1
-      vertex 52.2674 3.81508 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 52.1414 3.59828 -3.1
-      vertex 52.1414 5.00844 -3.1
-      vertex 52.2674 4.79164 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 3.41176 -3.1
-      vertex 52.1414 5.00844 -3.1
-      vertex 52.1414 3.59828 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.9735 3.41176 -3.1
-      vertex 51.9735 5.19496 -3.1
-      vertex 52.1414 5.00844 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 3.2643 -3.1
-      vertex 51.9735 5.19496 -3.1
-      vertex 51.9735 3.41176 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.7713 3.2643 -3.1
-      vertex 51.7713 5.34242 -3.1
-      vertex 51.9735 5.19496 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 3.16176 -3.1
-      vertex 51.7713 5.34242 -3.1
-      vertex 51.7713 3.2643 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.5418 3.16176 -3.1
-      vertex 51.5418 5.44496 -3.1
-      vertex 51.7713 5.34242 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 3.11 -3.1
-      vertex 51.5418 5.44496 -3.1
-      vertex 51.5418 3.16176 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.2967 3.11 -3.1
-      vertex 51.2967 5.49672 -3.1
-      vertex 51.5418 5.44496 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 3.11 -3.1
-      vertex 51.2967 5.49672 -3.1
-      vertex 51.2967 3.11 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 51.0457 3.11 -3.1
-      vertex 51.0457 5.49672 -3.1
-      vertex 51.2967 5.49672 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 3.16176 -3.1
-      vertex 51.0457 5.49672 -3.1
-      vertex 51.0457 3.11 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.8006 3.16176 -3.1
-      vertex 50.8006 5.44496 -3.1
-      vertex 51.0457 5.49672 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 3.2643 -3.1
-      vertex 50.8006 5.44496 -3.1
-      vertex 50.8006 3.16176 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.5711 3.2643 -3.1
-      vertex 50.5711 5.34242 -3.1
-      vertex 50.8006 5.44496 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 3.41176 -3.1
-      vertex 50.5711 5.34242 -3.1
-      vertex 50.5711 3.2643 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.368 3.41176 -3.1
-      vertex 50.368 5.19496 -3.1
-      vertex 50.5711 5.34242 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 3.59828 -3.1
-      vertex 50.368 5.19496 -3.1
-      vertex 50.368 3.41176 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.2 3.59828 -3.1
-      vertex 50.2 5.00844 -3.1
-      vertex 50.368 5.19496 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 3.81508 -3.1
-      vertex 50.2 5.00844 -3.1
-      vertex 50.2 3.59828 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 50.075 3.81508 -3.1
-      vertex 50.075 4.79164 -3.1
-      vertex 50.2 5.00844 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 4.05434 -3.1
-      vertex 50.075 4.79164 -3.1
-      vertex 50.075 3.81508 -3.1
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 49.9969 4.05434 -3.1
-      vertex 49.9969 4.55336 -3.1
-      vertex 50.075 4.79164 -3.1
-    endloop
-  endfacet
-  facet normal 0 -0 -1
-    outer loop
-      vertex 49.9969 4.55336 -3.1
-      vertex 49.9969 4.05434 -3.1
-      vertex 49.9705 4.30336 -3.1
+      vertex 57.4778 24.5843 2.4
+      vertex 57.5536 24.6464 2.1
+      vertex 57.4778 24.5843 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 45 3 -2.7
-      vertex 55 3 -2.7
-      vertex 55 6 -2.7
+      vertex 51.7 29.5 2.1
+      vertex 57.7 29.5 2.1
+      vertex 57.7 30.5 2.1
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 57.2 24.5 2.1
+      vertex 57.7 29.5 2.1
+      vertex 51.7 29.5 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 45 3 -2.7
-      vertex 55 -3.30655e-16 -2.7
+      vertex 57.6146 30.9 2.1
+      vertex 57.7 30.5 2.1
+      vertex 57.6808 30.6951 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 45 3 -2.7
-      vertex 55 6 -2.7
-      vertex 45 6 -2.7
+      vertex 57.7 29.5 2.1
+      vertex 57.2 24.5 2.1
+      vertex 57.7 25 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55 -3.30655e-16 -2.7
-      vertex 45 3 -2.7
-      vertex 55 -1 -2.7
+      vertex 57.6146 30.9 2.1
+      vertex 57.6808 30.6951 2.1
+      vertex 57.6239 30.8827 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 25 -1 -2.7
-      vertex 45 3 -2.7
-      vertex 25 3 -2.7
+      vertex 57.6904 24.9025 2.1
+      vertex 57.2 24.5 2.1
+      vertex 57.6619 24.8087 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 45 3 -2.7
-      vertex 25 -1 -2.7
-      vertex 55 -1 -2.7
+      vertex 51.7 30.5 2.1
+      vertex 57.7 30.5 2.1
+      vertex 57.6146 30.9 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 58 3 -2.7
-      vertex 57.6864 2.98357 -2.7
-      vertex 58 2.98357 -2.7
+      vertex 57.6619 24.8087 2.1
+      vertex 57.2 24.5 2.1
+      vertex 57.6157 24.7222 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.6157 24.7222 2.1
+      vertex 57.2 24.5 2.1
+      vertex 57.5536 24.6464 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.5536 24.6464 2.1
+      vertex 57.2 24.5 2.1
+      vertex 57.4778 24.5843 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.4778 24.5843 2.1
+      vertex 57.2 24.5 2.1
+      vertex 57.3913 24.5381 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.3913 24.5381 2.1
+      vertex 57.2 24.5 2.1
+      vertex 57.2975 24.5096 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.7 30.5 2.1
+      vertex 57.6146 30.9 2.1
+      vertex 51.7854 30.9 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.7192 30.6951 2.1
+      vertex 51.7854 30.9 2.1
+      vertex 51.7761 30.8827 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.7854 30.9 2.1
+      vertex 51.7192 30.6951 2.1
+      vertex 51.7 30.5 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.7 30.5 2.1
+      vertex 51.7 30.5 2.1
+      vertex 51.7 29.5 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 57.7 25 2.1
+      vertex 57.2 24.5 2.1
+      vertex 57.6904 24.9025 2.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 51.7 29.5 2.1
+      vertex 38.2 24.5 2.1
+      vertex 57.2 24.5 2.1
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 57.6864 2.98357 -2.7
-      vertex 58 3 -2.7
+      vertex 37.7 29.5 2.1
+      vertex 38.2 24.5 2.1
+      vertex 51.7 29.5 2.1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 37.7 25 2.1
+      vertex 38.2 24.5 2.1
+      vertex 37.7 29.5 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 57.0729 2.85317 -2.7
-      vertex 57.6864 2.98357 -2.7
+      vertex 38.2 24.5 2.1
+      vertex 37.7 25 2.1
+      vertex 38.1025 24.5096 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 56.5 2.59808 -2.7
-      vertex 57.0729 2.85317 -2.7
+      vertex 38.1025 24.5096 2.1
+      vertex 37.7 25 2.1
+      vertex 38.0087 24.5381 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 55.9926 2.22943 -2.7
-      vertex 56.5 2.59808 -2.7
+      vertex 38.0087 24.5381 2.1
+      vertex 37.7 25 2.1
+      vertex 37.9222 24.5843 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 55.5729 1.76336 -2.7
-      vertex 55.9926 2.22943 -2.7
+      vertex 37.8464 24.6464 2.1
+      vertex 37.7 25 2.1
+      vertex 37.7843 24.7222 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 55.2594 1.22021 -2.7
-      vertex 55.5729 1.76336 -2.7
+      vertex 37.7843 24.7222 2.1
+      vertex 37.7 25 2.1
+      vertex 37.7381 24.8087 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55 3 -2.7
-      vertex 55.0656 0.623734 -2.7
-      vertex 55.2594 1.22021 -2.7
+      vertex 37.9222 24.5843 2.1
+      vertex 37.7 25 2.1
+      vertex 37.8464 24.6464 2.1
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 55.0656 0.623734 -2.7
-      vertex 55 3 -2.7
-      vertex 55 -3.30655e-16 -2.7
+      vertex 37.7381 24.8087 2.1
+      vertex 37.7 25 2.1
+      vertex 37.7096 24.9025 2.1
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 57.7 29.5 2.1
+      vertex 57.7 30.5 0
+      vertex 57.7 30.5 2.1
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 57.7 30.5 0
+      vertex 57.7 29.5 2.1
+      vertex 57.7 29.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 57.7 25 2.1
+      vertex 57.7 29.5 2.4
+      vertex 57.7 29.5 2.1
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 57.7 29.5 2.4
+      vertex 57.7 25 2.1
+      vertex 57.7 25 2.4
+    endloop
+  endfacet
+  facet normal 0.995188 0.0979877 0
+    outer loop
+      vertex 37.7096 24.9025 2.4
+      vertex 37.7 25 2.1
+      vertex 37.7 25 2.4
+    endloop
+  endfacet
+  facet normal 0.995188 0.0979877 0
+    outer loop
+      vertex 37.7 25 2.1
+      vertex 37.7096 24.9025 2.4
+      vertex 37.7096 24.9025 2.1
+    endloop
+  endfacet
+  facet normal 0.290715 0.95681 -0
+    outer loop
+      vertex 38.1025 24.5096 2.1
+      vertex 38.0087 24.5381 2.4
+      vertex 38.1025 24.5096 2.4
+    endloop
+  endfacet
+  facet normal 0.290715 0.95681 0
+    outer loop
+      vertex 38.0087 24.5381 2.4
+      vertex 38.1025 24.5096 2.1
+      vertex 38.0087 24.5381 2.1
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 57.2 24.5 2.1
+      vertex 38.2 24.5 2.4
+      vertex 57.2 24.5 2.4
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 38.2 24.5 2.4
+      vertex 57.2 24.5 2.1
+      vertex 38.2 24.5 2.1
+    endloop
+  endfacet
+  facet normal 0.95681 0.290715 0
+    outer loop
+      vertex 37.7381 24.8087 2.4
+      vertex 37.7096 24.9025 2.1
+      vertex 37.7096 24.9025 2.4
+    endloop
+  endfacet
+  facet normal 0.95681 0.290715 0
+    outer loop
+      vertex 37.7096 24.9025 2.1
+      vertex 37.7381 24.8087 2.4
+      vertex 37.7381 24.8087 2.1
+    endloop
+  endfacet
+  facet normal 0.471117 0.882071 -0
+    outer loop
+      vertex 38.0087 24.5381 2.1
+      vertex 37.9222 24.5843 2.4
+      vertex 38.0087 24.5381 2.4
+    endloop
+  endfacet
+  facet normal 0.471117 0.882071 0
+    outer loop
+      vertex 37.9222 24.5843 2.4
+      vertex 38.0087 24.5381 2.1
+      vertex 37.9222 24.5843 2.1
+    endloop
+  endfacet
+  facet normal -0.882071 0.471117 0
+    outer loop
+      vertex 57.6157 24.7222 2.1
+      vertex 57.6619 24.8087 2.4
+      vertex 57.6619 24.8087 2.1
+    endloop
+  endfacet
+  facet normal -0.882071 0.471117 0
+    outer loop
+      vertex 57.6619 24.8087 2.4
+      vertex 57.6157 24.7222 2.1
+      vertex 57.6157 24.7222 2.4
+    endloop
+  endfacet
+  facet normal 0.882071 0.471117 0
+    outer loop
+      vertex 37.7843 24.7222 2.4
+      vertex 37.7381 24.8087 2.1
+      vertex 37.7381 24.8087 2.4
+    endloop
+  endfacet
+  facet normal 0.882071 0.471117 0
+    outer loop
+      vertex 37.7381 24.8087 2.1
+      vertex 37.7843 24.7222 2.4
+      vertex 37.7843 24.7222 2.1
+    endloop
+  endfacet
+  facet normal 0.0979877 0.995188 -0
+    outer loop
+      vertex 38.2 24.5 2.1
+      vertex 38.1025 24.5096 2.4
+      vertex 38.2 24.5 2.4
+    endloop
+  endfacet
+  facet normal 0.0979877 0.995188 0
+    outer loop
+      vertex 38.1025 24.5096 2.4
+      vertex 38.2 24.5 2.1
+      vertex 38.1025 24.5096 2.1
+    endloop
+  endfacet
+  facet normal -0.471117 0.882071 0
+    outer loop
+      vertex 57.4778 24.5843 2.1
+      vertex 57.3913 24.5381 2.4
+      vertex 57.4778 24.5843 2.4
+    endloop
+  endfacet
+  facet normal -0.471117 0.882071 0
+    outer loop
+      vertex 57.3913 24.5381 2.4
+      vertex 57.4778 24.5843 2.1
+      vertex 57.3913 24.5381 2.1
+    endloop
+  endfacet
+  facet normal 0.633738 0.773548 -0
+    outer loop
+      vertex 37.9222 24.5843 2.1
+      vertex 37.8464 24.6464 2.4
+      vertex 37.9222 24.5843 2.4
+    endloop
+  endfacet
+  facet normal 0.633738 0.773548 0
+    outer loop
+      vertex 37.8464 24.6464 2.4
+      vertex 37.9222 24.5843 2.1
+      vertex 37.8464 24.6464 2.1
+    endloop
+  endfacet
+  facet normal -0.0979877 0.995188 0
+    outer loop
+      vertex 57.2975 24.5096 2.1
+      vertex 57.2 24.5 2.4
+      vertex 57.2975 24.5096 2.4
+    endloop
+  endfacet
+  facet normal -0.0979877 0.995188 0
+    outer loop
+      vertex 57.2 24.5 2.4
+      vertex 57.2975 24.5096 2.1
+      vertex 57.2 24.5 2.1
+    endloop
+  endfacet
+  facet normal -0.95681 0.290715 0
+    outer loop
+      vertex 57.6619 24.8087 2.1
+      vertex 57.6904 24.9025 2.4
+      vertex 57.6904 24.9025 2.1
+    endloop
+  endfacet
+  facet normal -0.95681 0.290715 0
+    outer loop
+      vertex 57.6904 24.9025 2.4
+      vertex 57.6619 24.8087 2.1
+      vertex 57.6619 24.8087 2.4
+    endloop
+  endfacet
+  facet normal -0.995188 0.0979877 0
+    outer loop
+      vertex 57.6904 24.9025 2.1
+      vertex 57.7 25 2.4
+      vertex 57.7 25 2.1
+    endloop
+  endfacet
+  facet normal -0.995188 0.0979877 0
+    outer loop
+      vertex 57.7 25 2.4
+      vertex 57.6904 24.9025 2.1
+      vertex 57.6904 24.9025 2.4
+    endloop
+  endfacet
+  facet normal -0.773548 0.633738 0
+    outer loop
+      vertex 57.5536 24.6464 2.1
+      vertex 57.6157 24.7222 2.4
+      vertex 57.6157 24.7222 2.1
+    endloop
+  endfacet
+  facet normal -0.773548 0.633738 0
+    outer loop
+      vertex 57.6157 24.7222 2.4
+      vertex 57.5536 24.6464 2.1
+      vertex 57.5536 24.6464 2.4
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex 53.45 31.5 1.5
+      vertex 52.7 31.5 1.5
+      vertex 53.45 31.2 1.8
+    endloop
+  endfacet
+  facet normal -0.00112588 0.706737 0.707475
+    outer loop
+      vertex 57.4071 31.2071 1.79289
+      vertex 57.6146 30.9 2.1
+      vertex 57.5315 31.0556 1.94443
+    endloop
+  endfacet
+  facet normal 0.000461721 0.707274 0.706939
+    outer loop
+      vertex 57.2556 31.3315 1.66853
+      vertex 57.6146 30.9 2.1
+      vertex 57.4071 31.2071 1.79289
+    endloop
+  endfacet
+  facet normal -0.000120956 0.707032 0.707182
+    outer loop
+      vertex 57.0827 31.4239 1.57612
+      vertex 57.6146 30.9 2.1
+      vertex 57.2556 31.3315 1.66853
+    endloop
+  endfacet
+  facet normal -1.18307e-05 0.707087 0.707126
+    outer loop
+      vertex 56.8951 31.4808 1.51922
+      vertex 57.6146 30.9 2.1
+      vertex 57.0827 31.4239 1.57612
+    endloop
+  endfacet
+  facet normal -8.52873e-05 0.707042 0.707172
+    outer loop
+      vertex 56.7 31.5 1.5
+      vertex 57.6146 30.9 2.1
+      vertex 56.8951 31.4808 1.51922
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex 55.95 31.2 1.8
+      vertex 56.7 31.5 1.5
+      vertex 55.95 31.5 1.5
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex 56.7 31.5 1.5
+      vertex 55.95 31.2 1.8
+      vertex 57.6146 30.9 2.1
+    endloop
+  endfacet
+  facet normal -0 0.707107 0.707107
+    outer loop
+      vertex 53.45 31.2 1.8
+      vertex 57.6146 30.9 2.1
+      vertex 55.95 31.2 1.8
+    endloop
+  endfacet
+  facet normal 8.52873e-05 0.707042 0.707172
+    outer loop
+      vertex 51.7854 30.9 2.1
+      vertex 52.7 31.5 1.5
+      vertex 52.5049 31.4808 1.51922
+    endloop
+  endfacet
+  facet normal 1.18307e-05 0.707087 0.707126
+    outer loop
+      vertex 51.7854 30.9 2.1
+      vertex 52.5049 31.4808 1.51922
+      vertex 52.3173 31.4239 1.57612
+    endloop
+  endfacet
+  facet normal 0.000120956 0.707032 0.707182
+    outer loop
+      vertex 51.7854 30.9 2.1
+      vertex 52.3173 31.4239 1.57612
+      vertex 52.1444 31.3315 1.66853
+    endloop
+  endfacet
+  facet normal -0.000461721 0.707274 0.706939
+    outer loop
+      vertex 51.7854 30.9 2.1
+      vertex 52.1444 31.3315 1.66853
+      vertex 51.9929 31.2071 1.79289
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex 52.7 31.5 1.5
+      vertex 51.7854 30.9 2.1
+      vertex 53.45 31.2 1.8
+    endloop
+  endfacet
+  facet normal 0.00112588 0.706737 0.707475
+    outer loop
+      vertex 51.7854 30.9 2.1
+      vertex 51.9929 31.2071 1.79289
+      vertex 51.8685 31.0556 1.94443
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex 53.45 31.2 1.8
+      vertex 51.7854 30.9 2.1
+      vertex 57.6146 30.9 2.1
+    endloop
+  endfacet
+  facet normal -0.881913 0.471412 0
+    outer loop
+      vertex 2.25276 4.01662 4.5
+      vertex 2.37752 4.25002 5.9
+      vertex 2.37752 4.25002 4.5
+    endloop
+  endfacet
+  facet normal -0.881913 0.471412 0
+    outer loop
+      vertex 2.37752 4.25002 5.9
+      vertex 2.25276 4.01662 4.5
+      vertex 2.25276 4.01662 5.9
+    endloop
+  endfacet
+  facet normal 0.956943 0.290276 0
+    outer loop
+      vertex 4.82406 3.76337 5.9
+      vertex 4.74724 4.01662 4.5
+      vertex 4.74724 4.01662 5.9
+    endloop
+  endfacet
+  facet normal 0.956943 0.290276 0
+    outer loop
+      vertex 4.74724 4.01662 4.5
+      vertex 4.82406 3.76337 5.9
+      vertex 4.82406 3.76337 4.5
+    endloop
+  endfacet
+  facet normal 0.995185 0.0980183 0
+    outer loop
+      vertex 4.85 3.5 5.9
+      vertex 4.82406 3.76337 4.5
+      vertex 4.82406 3.76337 5.9
+    endloop
+  endfacet
+  facet normal 0.995185 0.0980183 0
+    outer loop
+      vertex 4.82406 3.76337 4.5
+      vertex 4.85 3.5 5.9
+      vertex 4.85 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0.290276 -0.956943 0
+    outer loop
+      vertex 3.76337 2.17594 4.5
+      vertex 4.01662 2.25276 5.9
+      vertex 3.76337 2.17594 5.9
+    endloop
+  endfacet
+  facet normal 0.290276 -0.956943 0
+    outer loop
+      vertex 4.01662 2.25276 5.9
+      vertex 3.76337 2.17594 4.5
+      vertex 4.01662 2.25276 4.5
+    endloop
+  endfacet
+  facet normal -0.956943 -0.290276 0
+    outer loop
+      vertex 2.25276 2.98338 4.5
+      vertex 2.17594 3.23663 5.9
+      vertex 2.17594 3.23663 4.5
+    endloop
+  endfacet
+  facet normal -0.956943 -0.290276 0
+    outer loop
+      vertex 2.17594 3.23663 5.9
+      vertex 2.25276 2.98338 4.5
+      vertex 2.25276 2.98338 5.9
+    endloop
+  endfacet
+  facet normal 0.773004 -0.634402 0
+    outer loop
+      vertex 4.45459 2.54541 5.9
+      vertex 4.62248 2.74998 4.5
+      vertex 4.62248 2.74998 5.9
+    endloop
+  endfacet
+  facet normal 0.773004 -0.634402 0
+    outer loop
+      vertex 4.62248 2.74998 4.5
+      vertex 4.45459 2.54541 5.9
+      vertex 4.45459 2.54541 4.5
+    endloop
+  endfacet
+  facet normal 0.881913 0.471412 0
+    outer loop
+      vertex 4.74724 4.01662 5.9
+      vertex 4.62248 4.25002 4.5
+      vertex 4.62248 4.25002 5.9
+    endloop
+  endfacet
+  facet normal 0.881913 0.471412 0
+    outer loop
+      vertex 4.62248 4.25002 4.5
+      vertex 4.74724 4.01662 5.9
+      vertex 4.74724 4.01662 4.5
+    endloop
+  endfacet
+  facet normal 0.634402 0.773004 -0
+    outer loop
+      vertex 4.45459 4.45459 4.5
+      vertex 4.25002 4.62248 5.9
+      vertex 4.45459 4.45459 5.9
+    endloop
+  endfacet
+  facet normal 0.634402 0.773004 0
+    outer loop
+      vertex 4.25002 4.62248 5.9
+      vertex 4.45459 4.45459 4.5
+      vertex 4.25002 4.62248 4.5
+    endloop
+  endfacet
+  facet normal 0.290276 0.956943 -0
+    outer loop
+      vertex 4.01662 4.74724 4.5
+      vertex 3.76337 4.82406 5.9
+      vertex 4.01662 4.74724 5.9
+    endloop
+  endfacet
+  facet normal 0.290276 0.956943 0
+    outer loop
+      vertex 3.76337 4.82406 5.9
+      vertex 4.01662 4.74724 4.5
+      vertex 3.76337 4.82406 4.5
+    endloop
+  endfacet
+  facet normal -0.881913 -0.471412 0
+    outer loop
+      vertex 2.37752 2.74998 4.5
+      vertex 2.25276 2.98338 5.9
+      vertex 2.25276 2.98338 4.5
+    endloop
+  endfacet
+  facet normal -0.881913 -0.471412 0
+    outer loop
+      vertex 2.25276 2.98338 5.9
+      vertex 2.37752 2.74998 4.5
+      vertex 2.37752 2.74998 5.9
+    endloop
+  endfacet
+  facet normal 0.773004 0.634402 0
+    outer loop
+      vertex 4.62248 4.25002 5.9
+      vertex 4.45459 4.45459 4.5
+      vertex 4.45459 4.45459 5.9
+    endloop
+  endfacet
+  facet normal 0.773004 0.634402 0
+    outer loop
+      vertex 4.45459 4.45459 4.5
+      vertex 4.62248 4.25002 5.9
+      vertex 4.62248 4.25002 4.5
+    endloop
+  endfacet
+  facet normal 0.0980183 0.995185 -0
+    outer loop
+      vertex 3.76337 4.82406 4.5
+      vertex 3.5 4.85 5.9
+      vertex 3.76337 4.82406 5.9
+    endloop
+  endfacet
+  facet normal 0.0980183 0.995185 0
+    outer loop
+      vertex 3.5 4.85 5.9
+      vertex 3.76337 4.82406 4.5
+      vertex 3.5 4.85 4.5
+    endloop
+  endfacet
+  facet normal -0.290276 0.956943 0
+    outer loop
+      vertex 3.23663 4.82406 4.5
+      vertex 2.98338 4.74724 5.9
+      vertex 3.23663 4.82406 5.9
+    endloop
+  endfacet
+  facet normal -0.290276 0.956943 0
+    outer loop
+      vertex 2.98338 4.74724 5.9
+      vertex 3.23663 4.82406 4.5
+      vertex 2.98338 4.74724 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.82406 3.76337 5.9
+      vertex 4.82406 3.23663 5.9
+      vertex 4.85 3.5 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.74724 4.01662 5.9
+      vertex 4.82406 3.23663 5.9
+      vertex 4.82406 3.76337 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.74724 4.01662 5.9
+      vertex 4.74724 2.98338 5.9
+      vertex 4.82406 3.23663 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.62248 4.25002 5.9
+      vertex 4.74724 2.98338 5.9
+      vertex 4.74724 4.01662 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.62248 4.25002 5.9
+      vertex 4.62248 2.74998 5.9
+      vertex 4.74724 2.98338 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45459 4.45459 5.9
+      vertex 4.62248 2.74998 5.9
+      vertex 4.62248 4.25002 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45459 4.45459 5.9
+      vertex 4.45459 2.54541 5.9
+      vertex 4.62248 2.74998 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.25002 4.62248 5.9
+      vertex 4.45459 2.54541 5.9
+      vertex 4.45459 4.45459 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.25002 4.62248 5.9
+      vertex 4.25002 2.37752 5.9
+      vertex 4.45459 2.54541 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01662 4.74724 5.9
+      vertex 4.25002 2.37752 5.9
+      vertex 4.25002 4.62248 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01662 4.74724 5.9
+      vertex 4.01662 2.25276 5.9
+      vertex 4.25002 2.37752 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.76337 4.82406 5.9
+      vertex 4.01662 2.25276 5.9
+      vertex 4.01662 4.74724 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.76337 4.82406 5.9
+      vertex 3.76337 2.17594 5.9
+      vertex 4.01662 2.25276 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 4.85 5.9
+      vertex 3.76337 2.17594 5.9
+      vertex 3.76337 4.82406 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 4.85 5.9
+      vertex 3.5 2.15 5.9
+      vertex 3.76337 2.17594 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.23663 4.82406 5.9
+      vertex 3.5 2.15 5.9
+      vertex 3.5 4.85 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23663 4.82406 5.9
+      vertex 3.23663 2.17594 5.9
+      vertex 3.5 2.15 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.98338 4.74724 5.9
+      vertex 3.23663 2.17594 5.9
+      vertex 3.23663 4.82406 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98338 4.74724 5.9
+      vertex 2.98338 2.25276 5.9
+      vertex 3.23663 2.17594 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.74998 4.62248 5.9
+      vertex 2.98338 2.25276 5.9
+      vertex 2.98338 4.74724 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.74998 4.62248 5.9
+      vertex 2.74998 2.37752 5.9
+      vertex 2.98338 2.25276 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.54541 4.45459 5.9
+      vertex 2.74998 2.37752 5.9
+      vertex 2.74998 4.62248 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54541 4.45459 5.9
+      vertex 2.54541 2.54541 5.9
+      vertex 2.74998 2.37752 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.37752 4.25002 5.9
+      vertex 2.54541 2.54541 5.9
+      vertex 2.54541 4.45459 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.37752 4.25002 5.9
+      vertex 2.37752 2.74998 5.9
+      vertex 2.54541 2.54541 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.25276 4.01662 5.9
+      vertex 2.37752 2.74998 5.9
+      vertex 2.37752 4.25002 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.25276 4.01662 5.9
+      vertex 2.25276 2.98338 5.9
+      vertex 2.37752 2.74998 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.17594 3.76337 5.9
+      vertex 2.25276 2.98338 5.9
+      vertex 2.25276 4.01662 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.17594 3.76337 5.9
+      vertex 2.17594 3.23663 5.9
+      vertex 2.25276 2.98338 5.9
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 2.17594 3.23663 5.9
+      vertex 2.17594 3.76337 5.9
+      vertex 2.15 3.5 5.9
+    endloop
+  endfacet
+  facet normal -0.634402 -0.773004 0
+    outer loop
+      vertex 2.54541 2.54541 4.5
+      vertex 2.74998 2.37752 5.9
+      vertex 2.54541 2.54541 5.9
+    endloop
+  endfacet
+  facet normal -0.634402 -0.773004 -0
+    outer loop
+      vertex 2.74998 2.37752 5.9
+      vertex 2.54541 2.54541 4.5
+      vertex 2.74998 2.37752 4.5
+    endloop
+  endfacet
+  facet normal 0.471412 0.881913 -0
+    outer loop
+      vertex 4.25002 4.62248 4.5
+      vertex 4.01662 4.74724 5.9
+      vertex 4.25002 4.62248 5.9
+    endloop
+  endfacet
+  facet normal 0.471412 0.881913 0
+    outer loop
+      vertex 4.01662 4.74724 5.9
+      vertex 4.25002 4.62248 4.5
+      vertex 4.01662 4.74724 4.5
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980183 0
+    outer loop
+      vertex 2.15 3.5 4.5
+      vertex 2.17594 3.76337 5.9
+      vertex 2.17594 3.76337 4.5
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980183 0
+    outer loop
+      vertex 2.17594 3.76337 5.9
+      vertex 2.15 3.5 4.5
+      vertex 2.15 3.5 5.9
+    endloop
+  endfacet
+  facet normal 0.881913 -0.471412 0
+    outer loop
+      vertex 4.62248 2.74998 5.9
+      vertex 4.74724 2.98338 4.5
+      vertex 4.74724 2.98338 5.9
+    endloop
+  endfacet
+  facet normal 0.881913 -0.471412 0
+    outer loop
+      vertex 4.74724 2.98338 4.5
+      vertex 4.62248 2.74998 5.9
+      vertex 4.62248 2.74998 4.5
+    endloop
+  endfacet
+  facet normal 0.471412 -0.881913 0
+    outer loop
+      vertex 4.01662 2.25276 4.5
+      vertex 4.25002 2.37752 5.9
+      vertex 4.01662 2.25276 5.9
+    endloop
+  endfacet
+  facet normal 0.471412 -0.881913 0
+    outer loop
+      vertex 4.25002 2.37752 5.9
+      vertex 4.01662 2.25276 4.5
+      vertex 4.25002 2.37752 4.5
+    endloop
+  endfacet
+  facet normal -0.634402 0.773004 0
+    outer loop
+      vertex 2.74998 4.62248 4.5
+      vertex 2.54541 4.45459 5.9
+      vertex 2.74998 4.62248 5.9
+    endloop
+  endfacet
+  facet normal -0.634402 0.773004 0
+    outer loop
+      vertex 2.54541 4.45459 5.9
+      vertex 2.74998 4.62248 4.5
+      vertex 2.54541 4.45459 4.5
+    endloop
+  endfacet
+  facet normal -0.471412 0.881913 0
+    outer loop
+      vertex 2.98338 4.74724 4.5
+      vertex 2.74998 4.62248 5.9
+      vertex 2.98338 4.74724 5.9
+    endloop
+  endfacet
+  facet normal -0.471412 0.881913 0
+    outer loop
+      vertex 2.74998 4.62248 5.9
+      vertex 2.98338 4.74724 4.5
+      vertex 2.74998 4.62248 4.5
+    endloop
+  endfacet
+  facet normal 0.0980183 -0.995185 0
+    outer loop
+      vertex 3.5 2.15 4.5
+      vertex 3.76337 2.17594 5.9
+      vertex 3.5 2.15 5.9
+    endloop
+  endfacet
+  facet normal 0.0980183 -0.995185 0
+    outer loop
+      vertex 3.76337 2.17594 5.9
+      vertex 3.5 2.15 4.5
+      vertex 3.76337 2.17594 4.5
+    endloop
+  endfacet
+  facet normal -0.471412 -0.881913 0
+    outer loop
+      vertex 2.74998 2.37752 4.5
+      vertex 2.98338 2.25276 5.9
+      vertex 2.74998 2.37752 5.9
+    endloop
+  endfacet
+  facet normal -0.471412 -0.881913 -0
+    outer loop
+      vertex 2.98338 2.25276 5.9
+      vertex 2.74998 2.37752 4.5
+      vertex 2.98338 2.25276 4.5
+    endloop
+  endfacet
+  facet normal -0.956943 0.290276 0
+    outer loop
+      vertex 2.17594 3.76337 4.5
+      vertex 2.25276 4.01662 5.9
+      vertex 2.25276 4.01662 4.5
+    endloop
+  endfacet
+  facet normal -0.956943 0.290276 0
+    outer loop
+      vertex 2.25276 4.01662 5.9
+      vertex 2.17594 3.76337 4.5
+      vertex 2.17594 3.76337 5.9
+    endloop
+  endfacet
+  facet normal 0.956943 -0.290276 0
+    outer loop
+      vertex 4.74724 2.98338 5.9
+      vertex 4.82406 3.23663 4.5
+      vertex 4.82406 3.23663 5.9
+    endloop
+  endfacet
+  facet normal 0.956943 -0.290276 0
+    outer loop
+      vertex 4.82406 3.23663 4.5
+      vertex 4.74724 2.98338 5.9
+      vertex 4.74724 2.98338 4.5
+    endloop
+  endfacet
+  facet normal -0.0980183 0.995185 0
+    outer loop
+      vertex 3.5 4.85 4.5
+      vertex 3.23663 4.82406 5.9
+      vertex 3.5 4.85 5.9
+    endloop
+  endfacet
+  facet normal -0.0980183 0.995185 0
+    outer loop
+      vertex 3.23663 4.82406 5.9
+      vertex 3.5 4.85 4.5
+      vertex 3.23663 4.82406 4.5
+    endloop
+  endfacet
+  facet normal -0.773004 0.634402 0
+    outer loop
+      vertex 2.37752 4.25002 4.5
+      vertex 2.54541 4.45459 5.9
+      vertex 2.54541 4.45459 4.5
+    endloop
+  endfacet
+  facet normal -0.773004 0.634402 0
+    outer loop
+      vertex 2.54541 4.45459 5.9
+      vertex 2.37752 4.25002 4.5
+      vertex 2.37752 4.25002 5.9
+    endloop
+  endfacet
+  facet normal 0.995185 -0.0980183 0
+    outer loop
+      vertex 4.82406 3.23663 5.9
+      vertex 4.85 3.5 4.5
+      vertex 4.85 3.5 5.9
+    endloop
+  endfacet
+  facet normal 0.995185 -0.0980183 0
+    outer loop
+      vertex 4.85 3.5 4.5
+      vertex 4.82406 3.23663 5.9
+      vertex 4.82406 3.23663 4.5
+    endloop
+  endfacet
+  facet normal -0.773004 -0.634402 0
+    outer loop
+      vertex 2.54541 2.54541 4.5
+      vertex 2.37752 2.74998 5.9
+      vertex 2.37752 2.74998 4.5
+    endloop
+  endfacet
+  facet normal -0.773004 -0.634402 0
+    outer loop
+      vertex 2.37752 2.74998 5.9
+      vertex 2.54541 2.54541 4.5
+      vertex 2.54541 2.54541 5.9
+    endloop
+  endfacet
+  facet normal 0.634402 -0.773004 0
+    outer loop
+      vertex 4.25002 2.37752 4.5
+      vertex 4.45459 2.54541 5.9
+      vertex 4.25002 2.37752 5.9
+    endloop
+  endfacet
+  facet normal 0.634402 -0.773004 0
+    outer loop
+      vertex 4.45459 2.54541 5.9
+      vertex 4.25002 2.37752 4.5
+      vertex 4.45459 2.54541 4.5
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980183 0
+    outer loop
+      vertex 2.17594 3.23663 4.5
+      vertex 2.15 3.5 5.9
+      vertex 2.15 3.5 4.5
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980183 0
+    outer loop
+      vertex 2.15 3.5 5.9
+      vertex 2.17594 3.23663 4.5
+      vertex 2.17594 3.23663 5.9
+    endloop
+  endfacet
+  facet normal -0.0980183 -0.995185 0
+    outer loop
+      vertex 3.23663 2.17594 4.5
+      vertex 3.5 2.15 5.9
+      vertex 3.23663 2.17594 5.9
+    endloop
+  endfacet
+  facet normal -0.0980183 -0.995185 -0
+    outer loop
+      vertex 3.5 2.15 5.9
+      vertex 3.23663 2.17594 4.5
+      vertex 3.5 2.15 4.5
+    endloop
+  endfacet
+  facet normal -0.290276 -0.956943 0
+    outer loop
+      vertex 2.98338 2.25276 4.5
+      vertex 3.23663 2.17594 5.9
+      vertex 2.98338 2.25276 5.9
+    endloop
+  endfacet
+  facet normal -0.290276 -0.956943 -0
+    outer loop
+      vertex 3.23663 2.17594 5.9
+      vertex 2.98338 2.25276 4.5
+      vertex 3.23663 2.17594 4.5
+    endloop
+  endfacet
+  facet normal -0.290553 0.956859 0
+    outer loop
+      vertex 3.23663 27.8241 4.5
+      vertex 2.98338 27.7472 5.9
+      vertex 3.23663 27.8241 5.9
+    endloop
+  endfacet
+  facet normal -0.290553 0.956859 0
+    outer loop
+      vertex 2.98338 27.7472 5.9
+      vertex 3.23663 27.8241 4.5
+      vertex 2.98338 27.7472 4.5
+    endloop
+  endfacet
+  facet normal 0.956927 0.290328 0
+    outer loop
+      vertex 4.82406 26.7634 5.9
+      vertex 4.74724 27.0166 4.5
+      vertex 4.74724 27.0166 5.9
+    endloop
+  endfacet
+  facet normal 0.956927 0.290328 0
+    outer loop
+      vertex 4.74724 27.0166 4.5
+      vertex 4.82406 26.7634 5.9
+      vertex 4.82406 26.7634 4.5
+    endloop
+  endfacet
+  facet normal 0.995186 0.0980073 0
+    outer loop
+      vertex 4.85 26.5 5.9
+      vertex 4.82406 26.7634 4.5
+      vertex 4.82406 26.7634 5.9
+    endloop
+  endfacet
+  facet normal 0.995186 0.0980073 0
+    outer loop
+      vertex 4.82406 26.7634 4.5
+      vertex 4.85 26.5 5.9
+      vertex 4.85 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0.881913 0.471412 0
+    outer loop
+      vertex 4.74724 27.0166 5.9
+      vertex 4.62248 27.25 4.5
+      vertex 4.62248 27.25 5.9
+    endloop
+  endfacet
+  facet normal 0.881913 0.471412 0
+    outer loop
+      vertex 4.62248 27.25 4.5
+      vertex 4.74724 27.0166 5.9
+      vertex 4.74724 27.0166 4.5
+    endloop
+  endfacet
+  facet normal 0.995186 -0.0980073 0
+    outer loop
+      vertex 4.82406 26.2366 5.9
+      vertex 4.85 26.5 4.5
+      vertex 4.85 26.5 5.9
+    endloop
+  endfacet
+  facet normal 0.995186 -0.0980073 0
+    outer loop
+      vertex 4.85 26.5 4.5
+      vertex 4.82406 26.2366 5.9
+      vertex 4.82406 26.2366 4.5
+    endloop
+  endfacet
+  facet normal 0.290553 -0.956859 0
+    outer loop
+      vertex 3.76337 25.1759 4.5
+      vertex 4.01662 25.2528 5.9
+      vertex 3.76337 25.1759 5.9
+    endloop
+  endfacet
+  facet normal 0.290553 -0.956859 0
+    outer loop
+      vertex 4.01662 25.2528 5.9
+      vertex 3.76337 25.1759 4.5
+      vertex 4.01662 25.2528 4.5
+    endloop
+  endfacet
+  facet normal 0.773049 0.634346 0
+    outer loop
+      vertex 4.62248 27.25 5.9
+      vertex 4.45459 27.4546 4.5
+      vertex 4.45459 27.4546 5.9
+    endloop
+  endfacet
+  facet normal 0.773049 0.634346 0
+    outer loop
+      vertex 4.45459 27.4546 4.5
+      vertex 4.62248 27.25 5.9
+      vertex 4.62248 27.25 4.5
+    endloop
+  endfacet
+  facet normal -0.773049 0.634346 0
+    outer loop
+      vertex 2.37752 27.25 4.5
+      vertex 2.54541 27.4546 5.9
+      vertex 2.54541 27.4546 4.5
+    endloop
+  endfacet
+  facet normal -0.773049 0.634346 0
+    outer loop
+      vertex 2.54541 27.4546 5.9
+      vertex 2.37752 27.25 4.5
+      vertex 2.37752 27.25 5.9
+    endloop
+  endfacet
+  facet normal -0.471235 -0.882007 0
+    outer loop
+      vertex 2.74998 25.3775 4.5
+      vertex 2.98338 25.2528 5.9
+      vertex 2.74998 25.3775 5.9
+    endloop
+  endfacet
+  facet normal -0.471235 -0.882007 -0
+    outer loop
+      vertex 2.98338 25.2528 5.9
+      vertex 2.74998 25.3775 4.5
+      vertex 2.98338 25.2528 4.5
+    endloop
+  endfacet
+  facet normal 0.956927 -0.290328 0
+    outer loop
+      vertex 4.74724 25.9834 5.9
+      vertex 4.82406 26.2366 4.5
+      vertex 4.82406 26.2366 5.9
+    endloop
+  endfacet
+  facet normal 0.956927 -0.290328 0
+    outer loop
+      vertex 4.82406 26.2366 4.5
+      vertex 4.74724 25.9834 5.9
+      vertex 4.74724 25.9834 4.5
+    endloop
+  endfacet
+  facet normal -0.634424 0.772985 0
+    outer loop
+      vertex 2.74998 27.6225 4.5
+      vertex 2.54541 27.4546 5.9
+      vertex 2.74998 27.6225 5.9
+    endloop
+  endfacet
+  facet normal -0.634424 0.772985 0
+    outer loop
+      vertex 2.54541 27.4546 5.9
+      vertex 2.74998 27.6225 4.5
+      vertex 2.54541 27.4546 4.5
+    endloop
+  endfacet
+  facet normal 0.881913 -0.471412 0
+    outer loop
+      vertex 4.62248 25.75 5.9
+      vertex 4.74724 25.9834 4.5
+      vertex 4.74724 25.9834 5.9
+    endloop
+  endfacet
+  facet normal 0.881913 -0.471412 0
+    outer loop
+      vertex 4.74724 25.9834 4.5
+      vertex 4.62248 25.75 5.9
+      vertex 4.62248 25.75 4.5
+    endloop
+  endfacet
+  facet normal -0.0978686 0.995199 0
+    outer loop
+      vertex 3.5 27.85 4.5
+      vertex 3.23663 27.8241 5.9
+      vertex 3.5 27.85 5.9
+    endloop
+  endfacet
+  facet normal -0.0978686 0.995199 0
+    outer loop
+      vertex 3.23663 27.8241 5.9
+      vertex 3.5 27.85 4.5
+      vertex 3.23663 27.8241 4.5
+    endloop
+  endfacet
+  facet normal 0.634424 -0.772985 0
+    outer loop
+      vertex 4.25002 25.3775 4.5
+      vertex 4.45459 25.5454 5.9
+      vertex 4.25002 25.3775 5.9
+    endloop
+  endfacet
+  facet normal 0.634424 -0.772985 0
+    outer loop
+      vertex 4.45459 25.5454 5.9
+      vertex 4.25002 25.3775 4.5
+      vertex 4.45459 25.5454 4.5
+    endloop
+  endfacet
+  facet normal -0.995186 0.0980073 0
+    outer loop
+      vertex 2.15 26.5 4.5
+      vertex 2.17594 26.7634 5.9
+      vertex 2.17594 26.7634 4.5
+    endloop
+  endfacet
+  facet normal -0.995186 0.0980073 0
+    outer loop
+      vertex 2.17594 26.7634 5.9
+      vertex 2.15 26.5 4.5
+      vertex 2.15 26.5 5.9
+    endloop
+  endfacet
+  facet normal -0.471235 0.882007 0
+    outer loop
+      vertex 2.98338 27.7472 4.5
+      vertex 2.74998 27.6225 5.9
+      vertex 2.98338 27.7472 5.9
+    endloop
+  endfacet
+  facet normal -0.471235 0.882007 0
+    outer loop
+      vertex 2.74998 27.6225 5.9
+      vertex 2.98338 27.7472 4.5
+      vertex 2.74998 27.6225 4.5
+    endloop
+  endfacet
+  facet normal -0.881913 -0.471412 0
+    outer loop
+      vertex 2.37752 25.75 4.5
+      vertex 2.25276 25.9834 5.9
+      vertex 2.25276 25.9834 4.5
+    endloop
+  endfacet
+  facet normal -0.881913 -0.471412 0
+    outer loop
+      vertex 2.25276 25.9834 5.9
+      vertex 2.37752 25.75 4.5
+      vertex 2.37752 25.75 5.9
+    endloop
+  endfacet
+  facet normal 0.773049 -0.634346 0
+    outer loop
+      vertex 4.45459 25.5454 5.9
+      vertex 4.62248 25.75 4.5
+      vertex 4.62248 25.75 5.9
+    endloop
+  endfacet
+  facet normal 0.773049 -0.634346 0
+    outer loop
+      vertex 4.62248 25.75 4.5
+      vertex 4.45459 25.5454 5.9
+      vertex 4.45459 25.5454 4.5
+    endloop
+  endfacet
+  facet normal -0.290553 -0.956859 0
+    outer loop
+      vertex 2.98338 25.2528 4.5
+      vertex 3.23663 25.1759 5.9
+      vertex 2.98338 25.2528 5.9
+    endloop
+  endfacet
+  facet normal -0.290553 -0.956859 -0
+    outer loop
+      vertex 3.23663 25.1759 5.9
+      vertex 2.98338 25.2528 4.5
+      vertex 3.23663 25.1759 4.5
+    endloop
+  endfacet
+  facet normal 0.290553 0.956859 -0
+    outer loop
+      vertex 4.01662 27.7472 4.5
+      vertex 3.76337 27.8241 5.9
+      vertex 4.01662 27.7472 5.9
+    endloop
+  endfacet
+  facet normal 0.290553 0.956859 0
+    outer loop
+      vertex 3.76337 27.8241 5.9
+      vertex 4.01662 27.7472 4.5
+      vertex 3.76337 27.8241 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.82406 26.7634 5.9
+      vertex 4.82406 26.2366 5.9
+      vertex 4.85 26.5 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.74724 27.0166 5.9
+      vertex 4.82406 26.2366 5.9
+      vertex 4.82406 26.7634 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.74724 27.0166 5.9
+      vertex 4.74724 25.9834 5.9
+      vertex 4.82406 26.2366 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.62248 27.25 5.9
+      vertex 4.74724 25.9834 5.9
+      vertex 4.74724 27.0166 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.62248 27.25 5.9
+      vertex 4.62248 25.75 5.9
+      vertex 4.74724 25.9834 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45459 27.4546 5.9
+      vertex 4.62248 25.75 5.9
+      vertex 4.62248 27.25 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45459 27.4546 5.9
+      vertex 4.45459 25.5454 5.9
+      vertex 4.62248 25.75 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.25002 27.6225 5.9
+      vertex 4.45459 25.5454 5.9
+      vertex 4.45459 27.4546 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.25002 27.6225 5.9
+      vertex 4.25002 25.3775 5.9
+      vertex 4.45459 25.5454 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01662 27.7472 5.9
+      vertex 4.25002 25.3775 5.9
+      vertex 4.25002 27.6225 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01662 27.7472 5.9
+      vertex 4.01662 25.2528 5.9
+      vertex 4.25002 25.3775 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.76337 27.8241 5.9
+      vertex 4.01662 25.2528 5.9
+      vertex 4.01662 27.7472 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.76337 27.8241 5.9
+      vertex 3.76337 25.1759 5.9
+      vertex 4.01662 25.2528 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 27.85 5.9
+      vertex 3.76337 25.1759 5.9
+      vertex 3.76337 27.8241 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 27.85 5.9
+      vertex 3.5 25.15 5.9
+      vertex 3.76337 25.1759 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.23663 27.8241 5.9
+      vertex 3.5 25.15 5.9
+      vertex 3.5 27.85 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23663 27.8241 5.9
+      vertex 3.23663 25.1759 5.9
+      vertex 3.5 25.15 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.98338 27.7472 5.9
+      vertex 3.23663 25.1759 5.9
+      vertex 3.23663 27.8241 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98338 27.7472 5.9
+      vertex 2.98338 25.2528 5.9
+      vertex 3.23663 25.1759 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.74998 27.6225 5.9
+      vertex 2.98338 25.2528 5.9
+      vertex 2.98338 27.7472 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.74998 27.6225 5.9
+      vertex 2.74998 25.3775 5.9
+      vertex 2.98338 25.2528 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.54541 27.4546 5.9
+      vertex 2.74998 25.3775 5.9
+      vertex 2.74998 27.6225 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54541 27.4546 5.9
+      vertex 2.54541 25.5454 5.9
+      vertex 2.74998 25.3775 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.37752 27.25 5.9
+      vertex 2.54541 25.5454 5.9
+      vertex 2.54541 27.4546 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.37752 27.25 5.9
+      vertex 2.37752 25.75 5.9
+      vertex 2.54541 25.5454 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.25276 27.0166 5.9
+      vertex 2.37752 25.75 5.9
+      vertex 2.37752 27.25 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.25276 27.0166 5.9
+      vertex 2.25276 25.9834 5.9
+      vertex 2.37752 25.75 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.17594 26.7634 5.9
+      vertex 2.25276 25.9834 5.9
+      vertex 2.25276 27.0166 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.17594 26.7634 5.9
+      vertex 2.17594 26.2366 5.9
+      vertex 2.25276 25.9834 5.9
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 2.17594 26.2366 5.9
+      vertex 2.17594 26.7634 5.9
+      vertex 2.15 26.5 5.9
+    endloop
+  endfacet
+  facet normal -0.773049 -0.634346 0
+    outer loop
+      vertex 2.54541 25.5454 4.5
+      vertex 2.37752 25.75 5.9
+      vertex 2.37752 25.75 4.5
+    endloop
+  endfacet
+  facet normal -0.773049 -0.634346 0
+    outer loop
+      vertex 2.37752 25.75 5.9
+      vertex 2.54541 25.5454 4.5
+      vertex 2.54541 25.5454 5.9
+    endloop
+  endfacet
+  facet normal 0.471235 -0.882007 0
+    outer loop
+      vertex 4.01662 25.2528 4.5
+      vertex 4.25002 25.3775 5.9
+      vertex 4.01662 25.2528 5.9
+    endloop
+  endfacet
+  facet normal 0.471235 -0.882007 0
+    outer loop
+      vertex 4.25002 25.3775 5.9
+      vertex 4.01662 25.2528 4.5
+      vertex 4.25002 25.3775 4.5
+    endloop
+  endfacet
+  facet normal -0.0978686 -0.995199 0
+    outer loop
+      vertex 3.23663 25.1759 4.5
+      vertex 3.5 25.15 5.9
+      vertex 3.23663 25.1759 5.9
+    endloop
+  endfacet
+  facet normal -0.0978686 -0.995199 -0
+    outer loop
+      vertex 3.5 25.15 5.9
+      vertex 3.23663 25.1759 4.5
+      vertex 3.5 25.15 4.5
+    endloop
+  endfacet
+  facet normal 0.634424 0.772985 -0
+    outer loop
+      vertex 4.45459 27.4546 4.5
+      vertex 4.25002 27.6225 5.9
+      vertex 4.45459 27.4546 5.9
+    endloop
+  endfacet
+  facet normal 0.634424 0.772985 0
+    outer loop
+      vertex 4.25002 27.6225 5.9
+      vertex 4.45459 27.4546 4.5
+      vertex 4.25002 27.6225 4.5
+    endloop
+  endfacet
+  facet normal 0.0978686 0.995199 -0
+    outer loop
+      vertex 3.76337 27.8241 4.5
+      vertex 3.5 27.85 5.9
+      vertex 3.76337 27.8241 5.9
+    endloop
+  endfacet
+  facet normal 0.0978686 0.995199 0
+    outer loop
+      vertex 3.5 27.85 5.9
+      vertex 3.76337 27.8241 4.5
+      vertex 3.5 27.85 4.5
+    endloop
+  endfacet
+  facet normal 0.471235 0.882007 -0
+    outer loop
+      vertex 4.25002 27.6225 4.5
+      vertex 4.01662 27.7472 5.9
+      vertex 4.25002 27.6225 5.9
+    endloop
+  endfacet
+  facet normal 0.471235 0.882007 0
+    outer loop
+      vertex 4.01662 27.7472 5.9
+      vertex 4.25002 27.6225 4.5
+      vertex 4.01662 27.7472 4.5
+    endloop
+  endfacet
+  facet normal -0.634424 -0.772985 0
+    outer loop
+      vertex 2.54541 25.5454 4.5
+      vertex 2.74998 25.3775 5.9
+      vertex 2.54541 25.5454 5.9
+    endloop
+  endfacet
+  facet normal -0.634424 -0.772985 -0
+    outer loop
+      vertex 2.74998 25.3775 5.9
+      vertex 2.54541 25.5454 4.5
+      vertex 2.74998 25.3775 4.5
+    endloop
+  endfacet
+  facet normal 0.0978686 -0.995199 0
+    outer loop
+      vertex 3.5 25.15 4.5
+      vertex 3.76337 25.1759 5.9
+      vertex 3.5 25.15 5.9
+    endloop
+  endfacet
+  facet normal 0.0978686 -0.995199 0
+    outer loop
+      vertex 3.76337 25.1759 5.9
+      vertex 3.5 25.15 4.5
+      vertex 3.76337 25.1759 4.5
+    endloop
+  endfacet
+  facet normal -0.956927 -0.290328 0
+    outer loop
+      vertex 2.25276 25.9834 4.5
+      vertex 2.17594 26.2366 5.9
+      vertex 2.17594 26.2366 4.5
+    endloop
+  endfacet
+  facet normal -0.956927 -0.290328 0
+    outer loop
+      vertex 2.17594 26.2366 5.9
+      vertex 2.25276 25.9834 4.5
+      vertex 2.25276 25.9834 5.9
+    endloop
+  endfacet
+  facet normal -0.956927 0.290328 0
+    outer loop
+      vertex 2.17594 26.7634 4.5
+      vertex 2.25276 27.0166 5.9
+      vertex 2.25276 27.0166 4.5
+    endloop
+  endfacet
+  facet normal -0.956927 0.290328 0
+    outer loop
+      vertex 2.25276 27.0166 5.9
+      vertex 2.17594 26.7634 4.5
+      vertex 2.17594 26.7634 5.9
+    endloop
+  endfacet
+  facet normal -0.995186 -0.0980073 0
+    outer loop
+      vertex 2.17594 26.2366 4.5
+      vertex 2.15 26.5 5.9
+      vertex 2.15 26.5 4.5
+    endloop
+  endfacet
+  facet normal -0.995186 -0.0980073 0
+    outer loop
+      vertex 2.15 26.5 5.9
+      vertex 2.17594 26.2366 4.5
+      vertex 2.17594 26.2366 5.9
+    endloop
+  endfacet
+  facet normal -0.881913 0.471412 0
+    outer loop
+      vertex 2.25276 27.0166 4.5
+      vertex 2.37752 27.25 5.9
+      vertex 2.37752 27.25 4.5
+    endloop
+  endfacet
+  facet normal -0.881913 0.471412 0
+    outer loop
+      vertex 2.37752 27.25 5.9
+      vertex 2.25276 27.0166 4.5
+      vertex 2.25276 27.0166 5.9
+    endloop
+  endfacet
+  facet normal 0.634405 -0.773001 0
+    outer loop
+      vertex 5.16671 24.0056 3
+      vertex 5.62132 24.3787 4.5
+      vertex 5.16671 24.0056 4.5
+    endloop
+  endfacet
+  facet normal 0.634405 -0.773001 0
+    outer loop
+      vertex 5.62132 24.3787 4.5
+      vertex 5.16671 24.0056 3
+      vertex 5.62132 24.3787 3
+    endloop
+  endfacet
+  facet normal 0.471358 -0.881942 0
+    outer loop
+      vertex 4.64805 23.7284 3
+      vertex 5.16671 24.0056 4.5
+      vertex 4.64805 23.7284 4.5
+    endloop
+  endfacet
+  facet normal 0.471358 -0.881942 0
+    outer loop
+      vertex 5.16671 24.0056 4.5
+      vertex 4.64805 23.7284 3
+      vertex 5.16671 24.0056 3
+    endloop
+  endfacet
+  facet normal 0.995186 -0.0980053 0
+    outer loop
+      vertex 6.44236 25.9147 4.5
+      vertex 6.5 26.5 3
+      vertex 6.5 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0.995186 -0.0980053 0
+    outer loop
+      vertex 6.5 26.5 3
+      vertex 6.44236 25.9147 4.5
+      vertex 6.44236 25.9147 3
+    endloop
+  endfacet
+  facet normal 0.881898 -0.47144 0
+    outer loop
+      vertex 5.99441 24.8333 4.5
+      vertex 6.27164 25.3519 3
+      vertex 6.27164 25.3519 4.5
+    endloop
+  endfacet
+  facet normal 0.881898 -0.47144 0
+    outer loop
+      vertex 6.27164 25.3519 3
+      vertex 5.99441 24.8333 4.5
+      vertex 5.99441 24.8333 3
+    endloop
+  endfacet
+  facet normal 0.290413 -0.956901 0
+    outer loop
+      vertex 4.08527 23.5576 3
+      vertex 4.64805 23.7284 4.5
+      vertex 4.08527 23.5576 4.5
+    endloop
+  endfacet
+  facet normal 0.290413 -0.956901 0
+    outer loop
+      vertex 4.64805 23.7284 4.5
+      vertex 4.08527 23.5576 3
+      vertex 4.64805 23.7284 3
+    endloop
+  endfacet
+  facet normal -0.956943 -0.290275 0
+    outer loop
+      vertex 0.728362 25.3519 3
+      vertex 0.557645 25.9147 4.5
+      vertex 0.557645 25.9147 3
+    endloop
+  endfacet
+  facet normal -0.956943 -0.290275 0
+    outer loop
+      vertex 0.557645 25.9147 4.5
+      vertex 0.728362 25.3519 3
+      vertex 0.728362 25.3519 4.5
+    endloop
+  endfacet
+  facet normal -0.8819 -0.471437 0
+    outer loop
+      vertex 1.00559 24.8333 3
+      vertex 0.728362 25.3519 4.5
+      vertex 0.728362 25.3519 3
+    endloop
+  endfacet
+  facet normal -0.8819 -0.471437 0
+    outer loop
+      vertex 0.728362 25.3519 4.5
+      vertex 1.00559 24.8333 3
+      vertex 1.00559 24.8333 4.5
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980137 0
+    outer loop
+      vertex 0.557645 25.9147 3
+      vertex 0.5 26.5 4.5
+      vertex 0.5 26.5 3
+    endloop
+  endfacet
+  facet normal -0.995185 -0.0980137 0
+    outer loop
+      vertex 0.5 26.5 4.5
+      vertex 0.557645 25.9147 3
+      vertex 0.557645 25.9147 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.85 26.5 4.5
+      vertex 6.5 26.5 4.5
+      vertex 6.44236 27.0853 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.82406 26.7634 4.5
+      vertex 6.44236 27.0853 4.5
+      vertex 6.27164 27.648 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.5 26.5 4.5
+      vertex 4.85 26.5 4.5
+      vertex 6.44236 25.9147 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.74724 27.0166 4.5
+      vertex 6.27164 27.648 4.5
+      vertex 5.99441 28.1667 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.82406 26.2366 4.5
+      vertex 6.44236 25.9147 4.5
+      vertex 4.85 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.62248 27.25 4.5
+      vertex 5.99441 28.1667 4.5
+      vertex 5.62132 28.6213 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.44236 25.9147 4.5
+      vertex 4.82406 26.2366 4.5
+      vertex 6.27164 25.3519 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.45459 27.4546 4.5
+      vertex 5.62132 28.6213 4.5
+      vertex 5.16671 28.9944 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.74724 25.9834 4.5
+      vertex 6.27164 25.3519 4.5
+      vertex 4.82406 26.2366 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.27164 25.3519 4.5
+      vertex 4.74724 25.9834 4.5
+      vertex 5.99441 24.8333 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.44236 27.0853 4.5
+      vertex 4.82406 26.7634 4.5
+      vertex 4.85 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.27164 27.648 4.5
+      vertex 4.74724 27.0166 4.5
+      vertex 4.82406 26.7634 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.25002 27.6225 4.5
+      vertex 5.16671 28.9944 4.5
+      vertex 4.64805 29.2716 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.99441 28.1667 4.5
+      vertex 4.62248 27.25 4.5
+      vertex 4.74724 27.0166 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.62132 28.6213 4.5
+      vertex 4.45459 27.4546 4.5
+      vertex 4.62248 27.25 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.16671 28.9944 4.5
+      vertex 4.25002 27.6225 4.5
+      vertex 4.45459 27.4546 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.01662 27.7472 4.5
+      vertex 4.64805 29.2716 4.5
+      vertex 4.08527 29.4424 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.64805 29.2716 4.5
+      vertex 4.01662 27.7472 4.5
+      vertex 4.25002 27.6225 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.08527 29.4424 4.5
+      vertex 3.76337 27.8241 4.5
+      vertex 4.01662 27.7472 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 29.5 4.5
+      vertex 3.76337 27.8241 4.5
+      vertex 4.08527 29.4424 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 29.5 4.5
+      vertex 3.5 27.85 4.5
+      vertex 3.76337 27.8241 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 29.5 4.5
+      vertex 3.23663 27.8241 4.5
+      vertex 3.5 27.85 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.91473 29.4424 4.5
+      vertex 3.23663 27.8241 4.5
+      vertex 3.5 29.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23663 27.8241 4.5
+      vertex 2.91473 29.4424 4.5
+      vertex 2.98338 27.7472 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.35195 29.2716 4.5
+      vertex 2.98338 27.7472 4.5
+      vertex 2.91473 29.4424 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98338 27.7472 4.5
+      vertex 2.35195 29.2716 4.5
+      vertex 2.74998 27.6225 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.83329 28.9944 4.5
+      vertex 2.74998 27.6225 4.5
+      vertex 2.35195 29.2716 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.74998 27.6225 4.5
+      vertex 1.83329 28.9944 4.5
+      vertex 2.54541 27.4546 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.37868 28.6213 4.5
+      vertex 2.54541 27.4546 4.5
+      vertex 1.83329 28.9944 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54541 27.4546 4.5
+      vertex 1.37868 28.6213 4.5
+      vertex 2.37752 27.25 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.00559 28.1667 4.5
+      vertex 2.37752 27.25 4.5
+      vertex 1.37868 28.6213 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.37752 27.25 4.5
+      vertex 1.00559 28.1667 4.5
+      vertex 2.25276 27.0166 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.62248 25.75 4.5
+      vertex 5.99441 24.8333 4.5
+      vertex 4.74724 25.9834 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.99441 24.8333 4.5
+      vertex 4.62248 25.75 4.5
+      vertex 5.62132 24.3787 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.45459 25.5454 4.5
+      vertex 5.62132 24.3787 4.5
+      vertex 4.62248 25.75 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.62132 24.3787 4.5
+      vertex 4.45459 25.5454 4.5
+      vertex 5.16671 24.0056 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.25002 25.3775 4.5
+      vertex 5.16671 24.0056 4.5
+      vertex 4.45459 25.5454 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.16671 24.0056 4.5
+      vertex 4.25002 25.3775 4.5
+      vertex 4.64805 23.7284 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.01662 25.2528 4.5
+      vertex 4.64805 23.7284 4.5
+      vertex 4.25002 25.3775 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.64805 23.7284 4.5
+      vertex 4.01662 25.2528 4.5
+      vertex 4.08527 23.5576 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.76337 25.1759 4.5
+      vertex 4.08527 23.5576 4.5
+      vertex 4.01662 25.2528 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.5 25.15 4.5
+      vertex 4.08527 23.5576 4.5
+      vertex 3.76337 25.1759 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 25.15 4.5
+      vertex 3.5 23.5 4.5
+      vertex 4.08527 23.5576 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23663 25.1759 4.5
+      vertex 3.5 23.5 4.5
+      vertex 3.5 25.15 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.91473 23.5576 4.5
+      vertex 3.23663 25.1759 4.5
+      vertex 2.98338 25.2528 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.23663 25.1759 4.5
+      vertex 2.91473 23.5576 4.5
+      vertex 3.5 23.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.35195 23.7284 4.5
+      vertex 2.98338 25.2528 4.5
+      vertex 2.74998 25.3775 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.83329 24.0056 4.5
+      vertex 2.74998 25.3775 4.5
+      vertex 2.54541 25.5454 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.37868 24.3787 4.5
+      vertex 2.54541 25.5454 4.5
+      vertex 2.37752 25.75 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98338 25.2528 4.5
+      vertex 2.35195 23.7284 4.5
+      vertex 2.91473 23.5576 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.00559 24.8333 4.5
+      vertex 2.37752 25.75 4.5
+      vertex 2.25276 25.9834 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.728362 25.3519 4.5
+      vertex 2.25276 25.9834 4.5
+      vertex 2.17594 26.2366 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.557645 25.9147 4.5
+      vertex 2.17594 26.2366 4.5
+      vertex 2.15 26.5 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.728362 27.648 4.5
+      vertex 2.25276 27.0166 4.5
+      vertex 1.00559 28.1667 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.74998 25.3775 4.5
+      vertex 1.83329 24.0056 4.5
+      vertex 2.35195 23.7284 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.25276 27.0166 4.5
+      vertex 0.728362 27.648 4.5
+      vertex 2.17594 26.7634 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.54541 25.5454 4.5
+      vertex 1.37868 24.3787 4.5
+      vertex 1.83329 24.0056 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.557645 27.0853 4.5
+      vertex 2.17594 26.7634 4.5
+      vertex 0.728362 27.648 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.37752 25.75 4.5
+      vertex 1.00559 24.8333 4.5
+      vertex 1.37868 24.3787 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.17594 26.7634 4.5
+      vertex 0.557645 27.0853 4.5
+      vertex 2.15 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.25276 25.9834 4.5
+      vertex 0.728362 25.3519 4.5
+      vertex 1.00559 24.8333 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 26.5 4.5
+      vertex 2.15 26.5 4.5
+      vertex 0.557645 27.0853 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.17594 26.2366 4.5
+      vertex 0.557645 25.9147 4.5
+      vertex 0.728362 25.3519 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.15 26.5 4.5
+      vertex 0.5 26.5 4.5
+      vertex 0.557645 25.9147 4.5
+    endloop
+  endfacet
+  facet normal -0.0979429 -0.995192 0
+    outer loop
+      vertex 2.91473 23.5576 3
+      vertex 3.5 23.5 4.5
+      vertex 2.91473 23.5576 4.5
+    endloop
+  endfacet
+  facet normal -0.0979429 -0.995192 -0
+    outer loop
+      vertex 3.5 23.5 4.5
+      vertex 2.91473 23.5576 3
+      vertex 3.5 23.5 3
+    endloop
+  endfacet
+  facet normal -0.471358 -0.881942 0
+    outer loop
+      vertex 1.83329 24.0056 3
+      vertex 2.35195 23.7284 4.5
+      vertex 1.83329 24.0056 4.5
+    endloop
+  endfacet
+  facet normal -0.471358 -0.881942 -0
+    outer loop
+      vertex 2.35195 23.7284 4.5
+      vertex 1.83329 24.0056 3
+      vertex 2.35195 23.7284 3
+    endloop
+  endfacet
+  facet normal 0.956942 -0.290279 0
+    outer loop
+      vertex 6.27164 25.3519 4.5
+      vertex 6.44236 25.9147 3
+      vertex 6.44236 25.9147 4.5
+    endloop
+  endfacet
+  facet normal 0.956942 -0.290279 0
+    outer loop
+      vertex 6.44236 25.9147 3
+      vertex 6.27164 25.3519 4.5
+      vertex 6.27164 25.3519 3
+    endloop
+  endfacet
+  facet normal 0.773003 -0.634403 0
+    outer loop
+      vertex 5.62132 24.3787 4.5
+      vertex 5.99441 24.8333 3
+      vertex 5.99441 24.8333 4.5
+    endloop
+  endfacet
+  facet normal 0.773003 -0.634403 0
+    outer loop
+      vertex 5.99441 24.8333 3
+      vertex 5.62132 24.3787 4.5
+      vertex 5.62132 24.3787 3
+    endloop
+  endfacet
+  facet normal -0.290413 -0.956901 0
+    outer loop
+      vertex 2.35195 23.7284 3
+      vertex 2.91473 23.5576 4.5
+      vertex 2.35195 23.7284 4.5
+    endloop
+  endfacet
+  facet normal -0.290413 -0.956901 -0
+    outer loop
+      vertex 2.91473 23.5576 4.5
+      vertex 2.35195 23.7284 3
+      vertex 2.91473 23.5576 3
+    endloop
+  endfacet
+  facet normal -0.773003 -0.634403 0
+    outer loop
+      vertex 1.37868 24.3787 3
+      vertex 1.00559 24.8333 4.5
+      vertex 1.00559 24.8333 3
+    endloop
+  endfacet
+  facet normal -0.773003 -0.634403 0
+    outer loop
+      vertex 1.00559 24.8333 4.5
+      vertex 1.37868 24.3787 3
+      vertex 1.37868 24.3787 4.5
+    endloop
+  endfacet
+  facet normal -0.634405 -0.773001 0
+    outer loop
+      vertex 1.37868 24.3787 3
+      vertex 1.83329 24.0056 4.5
+      vertex 1.37868 24.3787 4.5
+    endloop
+  endfacet
+  facet normal -0.634405 -0.773001 -0
+    outer loop
+      vertex 1.83329 24.0056 4.5
+      vertex 1.37868 24.3787 3
+      vertex 1.83329 24.0056 3
+    endloop
+  endfacet
+  facet normal 0.0979429 -0.995192 0
+    outer loop
+      vertex 3.5 23.5 3
+      vertex 4.08527 23.5576 4.5
+      vertex 3.5 23.5 4.5
+    endloop
+  endfacet
+  facet normal 0.0979429 -0.995192 0
+    outer loop
+      vertex 4.08527 23.5576 4.5
+      vertex 3.5 23.5 3
+      vertex 4.08527 23.5576 3
+    endloop
+  endfacet
+  facet normal -0.882007 0.471235 0
+    outer loop
+      vertex 60.2528 4.01662 4.5
+      vertex 60.3775 4.25002 5.9
+      vertex 60.3775 4.25002 4.5
+    endloop
+  endfacet
+  facet normal -0.882007 0.471235 0
+    outer loop
+      vertex 60.3775 4.25002 5.9
+      vertex 60.2528 4.01662 4.5
+      vertex 60.2528 4.01662 5.9
+    endloop
+  endfacet
+  facet normal 0.0980073 -0.995186 0
+    outer loop
+      vertex 61.5 2.15 4.5
+      vertex 61.7634 2.17594 5.9
+      vertex 61.5 2.15 5.9
+    endloop
+  endfacet
+  facet normal 0.0980073 -0.995186 0
+    outer loop
+      vertex 61.7634 2.17594 5.9
+      vertex 61.5 2.15 4.5
+      vertex 61.7634 2.17594 4.5
+    endloop
+  endfacet
+  facet normal 0.956859 0.290553 0
+    outer loop
+      vertex 62.8241 3.76337 5.9
+      vertex 62.7472 4.01662 4.5
+      vertex 62.7472 4.01662 5.9
+    endloop
+  endfacet
+  facet normal 0.956859 0.290553 0
+    outer loop
+      vertex 62.7472 4.01662 4.5
+      vertex 62.8241 3.76337 5.9
+      vertex 62.8241 3.76337 4.5
+    endloop
+  endfacet
+  facet normal 0.995199 0.0978686 0
+    outer loop
+      vertex 62.85 3.5 5.9
+      vertex 62.8241 3.76337 4.5
+      vertex 62.8241 3.76337 5.9
+    endloop
+  endfacet
+  facet normal 0.995199 0.0978686 0
+    outer loop
+      vertex 62.8241 3.76337 4.5
+      vertex 62.85 3.5 5.9
+      vertex 62.85 3.5 4.5
+    endloop
+  endfacet
+  facet normal 0.290328 -0.956927 0
+    outer loop
+      vertex 61.7634 2.17594 4.5
+      vertex 62.0166 2.25276 5.9
+      vertex 61.7634 2.17594 5.9
+    endloop
+  endfacet
+  facet normal 0.290328 -0.956927 0
+    outer loop
+      vertex 62.0166 2.25276 5.9
+      vertex 61.7634 2.17594 4.5
+      vertex 62.0166 2.25276 4.5
+    endloop
+  endfacet
+  facet normal -0.956859 -0.290553 0
+    outer loop
+      vertex 60.2528 2.98338 4.5
+      vertex 60.1759 3.23663 5.9
+      vertex 60.1759 3.23663 4.5
+    endloop
+  endfacet
+  facet normal -0.956859 -0.290553 0
+    outer loop
+      vertex 60.1759 3.23663 5.9
+      vertex 60.2528 2.98338 4.5
+      vertex 60.2528 2.98338 5.9
+    endloop
+  endfacet
+  facet normal 0.772985 -0.634424 0
+    outer loop
+      vertex 62.4546 2.54541 5.9
+      vertex 62.6225 2.74998 4.5
+      vertex 62.6225 2.74998 5.9
+    endloop
+  endfacet
+  facet normal 0.772985 -0.634424 0
+    outer loop
+      vertex 62.6225 2.74998 4.5
+      vertex 62.4546 2.54541 5.9
+      vertex 62.4546 2.54541 4.5
+    endloop
+  endfacet
+  facet normal 0.882007 0.471235 0
+    outer loop
+      vertex 62.7472 4.01662 5.9
+      vertex 62.6225 4.25002 4.5
+      vertex 62.6225 4.25002 5.9
+    endloop
+  endfacet
+  facet normal 0.882007 0.471235 0
+    outer loop
+      vertex 62.6225 4.25002 4.5
+      vertex 62.7472 4.01662 5.9
+      vertex 62.7472 4.01662 4.5
+    endloop
+  endfacet
+  facet normal 0.634346 0.773049 -0
+    outer loop
+      vertex 62.4546 4.45459 4.5
+      vertex 62.25 4.62248 5.9
+      vertex 62.4546 4.45459 5.9
+    endloop
+  endfacet
+  facet normal 0.634346 0.773049 0
+    outer loop
+      vertex 62.25 4.62248 5.9
+      vertex 62.4546 4.45459 4.5
+      vertex 62.25 4.62248 4.5
+    endloop
+  endfacet
+  facet normal 0.290328 0.956927 -0
+    outer loop
+      vertex 62.0166 4.74724 4.5
+      vertex 61.7634 4.82406 5.9
+      vertex 62.0166 4.74724 5.9
+    endloop
+  endfacet
+  facet normal 0.290328 0.956927 0
+    outer loop
+      vertex 61.7634 4.82406 5.9
+      vertex 62.0166 4.74724 4.5
+      vertex 61.7634 4.82406 4.5
+    endloop
+  endfacet
+  facet normal -0.882007 -0.471235 0
+    outer loop
+      vertex 60.3775 2.74998 4.5
+      vertex 60.2528 2.98338 5.9
+      vertex 60.2528 2.98338 4.5
+    endloop
+  endfacet
+  facet normal -0.882007 -0.471235 0
+    outer loop
+      vertex 60.2528 2.98338 5.9
+      vertex 60.3775 2.74998 4.5
+      vertex 60.3775 2.74998 5.9
+    endloop
+  endfacet
+  facet normal 0.772985 0.634424 0
+    outer loop
+      vertex 62.6225 4.25002 5.9
+      vertex 62.4546 4.45459 4.5
+      vertex 62.4546 4.45459 5.9
+    endloop
+  endfacet
+  facet normal 0.772985 0.634424 0
+    outer loop
+      vertex 62.4546 4.45459 4.5
+      vertex 62.6225 4.25002 5.9
+      vertex 62.6225 4.25002 4.5
+    endloop
+  endfacet
+  facet normal 0.0980073 0.995186 -0
+    outer loop
+      vertex 61.7634 4.82406 4.5
+      vertex 61.5 4.85 5.9
+      vertex 61.7634 4.82406 5.9
+    endloop
+  endfacet
+  facet normal 0.0980073 0.995186 0
+    outer loop
+      vertex 61.5 4.85 5.9
+      vertex 61.7634 4.82406 4.5
+      vertex 61.5 4.85 4.5
+    endloop
+  endfacet
+  facet normal -0.290328 0.956927 0
+    outer loop
+      vertex 61.2366 4.82406 4.5
+      vertex 60.9834 4.74724 5.9
+      vertex 61.2366 4.82406 5.9
+    endloop
+  endfacet
+  facet normal -0.290328 0.956927 0
+    outer loop
+      vertex 60.9834 4.74724 5.9
+      vertex 61.2366 4.82406 4.5
+      vertex 60.9834 4.74724 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8241 3.76337 5.9
+      vertex 62.8241 3.23663 5.9
+      vertex 62.85 3.5 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7472 4.01662 5.9
+      vertex 62.8241 3.23663 5.9
+      vertex 62.8241 3.76337 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7472 4.01662 5.9
+      vertex 62.7472 2.98338 5.9
+      vertex 62.8241 3.23663 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6225 4.25002 5.9
+      vertex 62.7472 2.98338 5.9
+      vertex 62.7472 4.01662 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6225 4.25002 5.9
+      vertex 62.6225 2.74998 5.9
+      vertex 62.7472 2.98338 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4546 4.45459 5.9
+      vertex 62.6225 2.74998 5.9
+      vertex 62.6225 4.25002 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4546 4.45459 5.9
+      vertex 62.4546 2.54541 5.9
+      vertex 62.6225 2.74998 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.25 4.62248 5.9
+      vertex 62.4546 2.54541 5.9
+      vertex 62.4546 4.45459 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.25 4.62248 5.9
+      vertex 62.25 2.37752 5.9
+      vertex 62.4546 2.54541 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0166 4.74724 5.9
+      vertex 62.25 2.37752 5.9
+      vertex 62.25 4.62248 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0166 4.74724 5.9
+      vertex 62.0166 2.25276 5.9
+      vertex 62.25 2.37752 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7634 4.82406 5.9
+      vertex 62.0166 2.25276 5.9
+      vertex 62.0166 4.74724 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7634 4.82406 5.9
+      vertex 61.7634 2.17594 5.9
+      vertex 62.0166 2.25276 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 4.85 5.9
+      vertex 61.7634 2.17594 5.9
+      vertex 61.7634 4.82406 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 4.85 5.9
+      vertex 61.5 2.15 5.9
+      vertex 61.7634 2.17594 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.2366 4.82406 5.9
+      vertex 61.5 2.15 5.9
+      vertex 61.5 4.85 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2366 4.82406 5.9
+      vertex 61.2366 2.17594 5.9
+      vertex 61.5 2.15 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.9834 4.74724 5.9
+      vertex 61.2366 2.17594 5.9
+      vertex 61.2366 4.82406 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9834 4.74724 5.9
+      vertex 60.9834 2.25276 5.9
+      vertex 61.2366 2.17594 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.75 4.62248 5.9
+      vertex 60.9834 2.25276 5.9
+      vertex 60.9834 4.74724 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.75 4.62248 5.9
+      vertex 60.75 2.37752 5.9
+      vertex 60.9834 2.25276 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.5454 4.45459 5.9
+      vertex 60.75 2.37752 5.9
+      vertex 60.75 4.62248 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5454 4.45459 5.9
+      vertex 60.5454 2.54541 5.9
+      vertex 60.75 2.37752 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.3775 4.25002 5.9
+      vertex 60.5454 2.54541 5.9
+      vertex 60.5454 4.45459 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3775 4.25002 5.9
+      vertex 60.3775 2.74998 5.9
+      vertex 60.5454 2.54541 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.2528 4.01662 5.9
+      vertex 60.3775 2.74998 5.9
+      vertex 60.3775 4.25002 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.2528 4.01662 5.9
+      vertex 60.2528 2.98338 5.9
+      vertex 60.3775 2.74998 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.1759 3.76337 5.9
+      vertex 60.2528 2.98338 5.9
+      vertex 60.2528 4.01662 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.1759 3.76337 5.9
+      vertex 60.1759 3.23663 5.9
+      vertex 60.2528 2.98338 5.9
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 60.1759 3.23663 5.9
+      vertex 60.1759 3.76337 5.9
+      vertex 60.15 3.5 5.9
+    endloop
+  endfacet
+  facet normal -0.634346 -0.773049 0
+    outer loop
+      vertex 60.5454 2.54541 4.5
+      vertex 60.75 2.37752 5.9
+      vertex 60.5454 2.54541 5.9
+    endloop
+  endfacet
+  facet normal -0.634346 -0.773049 -0
+    outer loop
+      vertex 60.75 2.37752 5.9
+      vertex 60.5454 2.54541 4.5
+      vertex 60.75 2.37752 4.5
+    endloop
+  endfacet
+  facet normal 0.471412 0.881913 -0
+    outer loop
+      vertex 62.25 4.62248 4.5
+      vertex 62.0166 4.74724 5.9
+      vertex 62.25 4.62248 5.9
+    endloop
+  endfacet
+  facet normal 0.471412 0.881913 0
+    outer loop
+      vertex 62.0166 4.74724 5.9
+      vertex 62.25 4.62248 4.5
+      vertex 62.0166 4.74724 4.5
+    endloop
+  endfacet
+  facet normal -0.995199 0.0978686 0
+    outer loop
+      vertex 60.15 3.5 4.5
+      vertex 60.1759 3.76337 5.9
+      vertex 60.1759 3.76337 4.5
+    endloop
+  endfacet
+  facet normal -0.995199 0.0978686 0
+    outer loop
+      vertex 60.1759 3.76337 5.9
+      vertex 60.15 3.5 4.5
+      vertex 60.15 3.5 5.9
+    endloop
+  endfacet
+  facet normal 0.882007 -0.471235 0
+    outer loop
+      vertex 62.6225 2.74998 5.9
+      vertex 62.7472 2.98338 4.5
+      vertex 62.7472 2.98338 5.9
+    endloop
+  endfacet
+  facet normal 0.882007 -0.471235 0
+    outer loop
+      vertex 62.7472 2.98338 4.5
+      vertex 62.6225 2.74998 5.9
+      vertex 62.6225 2.74998 4.5
+    endloop
+  endfacet
+  facet normal 0.471412 -0.881913 0
+    outer loop
+      vertex 62.0166 2.25276 4.5
+      vertex 62.25 2.37752 5.9
+      vertex 62.0166 2.25276 5.9
+    endloop
+  endfacet
+  facet normal 0.471412 -0.881913 0
+    outer loop
+      vertex 62.25 2.37752 5.9
+      vertex 62.0166 2.25276 4.5
+      vertex 62.25 2.37752 4.5
+    endloop
+  endfacet
+  facet normal -0.634346 0.773049 0
+    outer loop
+      vertex 60.75 4.62248 4.5
+      vertex 60.5454 4.45459 5.9
+      vertex 60.75 4.62248 5.9
+    endloop
+  endfacet
+  facet normal -0.634346 0.773049 0
+    outer loop
+      vertex 60.5454 4.45459 5.9
+      vertex 60.75 4.62248 4.5
+      vertex 60.5454 4.45459 4.5
+    endloop
+  endfacet
+  facet normal -0.471412 0.881913 0
+    outer loop
+      vertex 60.9834 4.74724 4.5
+      vertex 60.75 4.62248 5.9
+      vertex 60.9834 4.74724 5.9
+    endloop
+  endfacet
+  facet normal -0.471412 0.881913 0
+    outer loop
+      vertex 60.75 4.62248 5.9
+      vertex 60.9834 4.74724 4.5
+      vertex 60.75 4.62248 4.5
+    endloop
+  endfacet
+  facet normal -0.471412 -0.881913 0
+    outer loop
+      vertex 60.75 2.37752 4.5
+      vertex 60.9834 2.25276 5.9
+      vertex 60.75 2.37752 5.9
+    endloop
+  endfacet
+  facet normal -0.471412 -0.881913 -0
+    outer loop
+      vertex 60.9834 2.25276 5.9
+      vertex 60.75 2.37752 4.5
+      vertex 60.9834 2.25276 4.5
+    endloop
+  endfacet
+  facet normal -0.956859 0.290553 0
+    outer loop
+      vertex 60.1759 3.76337 4.5
+      vertex 60.2528 4.01662 5.9
+      vertex 60.2528 4.01662 4.5
+    endloop
+  endfacet
+  facet normal -0.956859 0.290553 0
+    outer loop
+      vertex 60.2528 4.01662 5.9
+      vertex 60.1759 3.76337 4.5
+      vertex 60.1759 3.76337 5.9
+    endloop
+  endfacet
+  facet normal 0.956859 -0.290553 0
+    outer loop
+      vertex 62.7472 2.98338 5.9
+      vertex 62.8241 3.23663 4.5
+      vertex 62.8241 3.23663 5.9
+    endloop
+  endfacet
+  facet normal 0.956859 -0.290553 0
+    outer loop
+      vertex 62.8241 3.23663 4.5
+      vertex 62.7472 2.98338 5.9
+      vertex 62.7472 2.98338 4.5
+    endloop
+  endfacet
+  facet normal -0.0980073 0.995186 0
+    outer loop
+      vertex 61.5 4.85 4.5
+      vertex 61.2366 4.82406 5.9
+      vertex 61.5 4.85 5.9
+    endloop
+  endfacet
+  facet normal -0.0980073 0.995186 0
+    outer loop
+      vertex 61.2366 4.82406 5.9
+      vertex 61.5 4.85 4.5
+      vertex 61.2366 4.82406 4.5
+    endloop
+  endfacet
+  facet normal -0.772985 0.634424 0
+    outer loop
+      vertex 60.3775 4.25002 4.5
+      vertex 60.5454 4.45459 5.9
+      vertex 60.5454 4.45459 4.5
+    endloop
+  endfacet
+  facet normal -0.772985 0.634424 0
+    outer loop
+      vertex 60.5454 4.45459 5.9
+      vertex 60.3775 4.25002 4.5
+      vertex 60.3775 4.25002 5.9
+    endloop
+  endfacet
+  facet normal 0.995199 -0.0978686 0
+    outer loop
+      vertex 62.8241 3.23663 5.9
+      vertex 62.85 3.5 4.5
+      vertex 62.85 3.5 5.9
+    endloop
+  endfacet
+  facet normal 0.995199 -0.0978686 0
+    outer loop
+      vertex 62.85 3.5 4.5
+      vertex 62.8241 3.23663 5.9
+      vertex 62.8241 3.23663 4.5
+    endloop
+  endfacet
+  facet normal -0.772985 -0.634424 0
+    outer loop
+      vertex 60.5454 2.54541 4.5
+      vertex 60.3775 2.74998 5.9
+      vertex 60.3775 2.74998 4.5
+    endloop
+  endfacet
+  facet normal -0.772985 -0.634424 0
+    outer loop
+      vertex 60.3775 2.74998 5.9
+      vertex 60.5454 2.54541 4.5
+      vertex 60.5454 2.54541 5.9
+    endloop
+  endfacet
+  facet normal 0.634346 -0.773049 0
+    outer loop
+      vertex 62.25 2.37752 4.5
+      vertex 62.4546 2.54541 5.9
+      vertex 62.25 2.37752 5.9
+    endloop
+  endfacet
+  facet normal 0.634346 -0.773049 0
+    outer loop
+      vertex 62.4546 2.54541 5.9
+      vertex 62.25 2.37752 4.5
+      vertex 62.4546 2.54541 4.5
+    endloop
+  endfacet
+  facet normal -0.995199 -0.0978686 0
+    outer loop
+      vertex 60.1759 3.23663 4.5
+      vertex 60.15 3.5 5.9
+      vertex 60.15 3.5 4.5
+    endloop
+  endfacet
+  facet normal -0.995199 -0.0978686 0
+    outer loop
+      vertex 60.15 3.5 5.9
+      vertex 60.1759 3.23663 4.5
+      vertex 60.1759 3.23663 5.9
+    endloop
+  endfacet
+  facet normal -0.0980073 -0.995186 0
+    outer loop
+      vertex 61.2366 2.17594 4.5
+      vertex 61.5 2.15 5.9
+      vertex 61.2366 2.17594 5.9
+    endloop
+  endfacet
+  facet normal -0.0980073 -0.995186 -0
+    outer loop
+      vertex 61.5 2.15 5.9
+      vertex 61.2366 2.17594 4.5
+      vertex 61.5 2.15 4.5
+    endloop
+  endfacet
+  facet normal -0.290328 -0.956927 0
+    outer loop
+      vertex 60.9834 2.25276 4.5
+      vertex 61.2366 2.17594 5.9
+      vertex 60.9834 2.25276 5.9
+    endloop
+  endfacet
+  facet normal -0.290328 -0.956927 -0
+    outer loop
+      vertex 61.2366 2.17594 5.9
+      vertex 60.9834 2.25276 4.5
+      vertex 61.2366 2.17594 4.5
+    endloop
+  endfacet
+  facet normal -0.290605 0.956843 0
+    outer loop
+      vertex 61.2366 27.8241 4.5
+      vertex 60.9834 27.7472 5.9
+      vertex 61.2366 27.8241 5.9
+    endloop
+  endfacet
+  facet normal -0.290605 0.956843 0
+    outer loop
+      vertex 60.9834 27.7472 5.9
+      vertex 61.2366 27.8241 4.5
+      vertex 60.9834 27.7472 4.5
+    endloop
+  endfacet
+  facet normal 0.956843 0.290605 0
+    outer loop
+      vertex 62.8241 26.7634 5.9
+      vertex 62.7472 27.0166 4.5
+      vertex 62.7472 27.0166 5.9
+    endloop
+  endfacet
+  facet normal 0.956843 0.290605 0
+    outer loop
+      vertex 62.7472 27.0166 4.5
+      vertex 62.8241 26.7634 5.9
+      vertex 62.8241 26.7634 4.5
+    endloop
+  endfacet
+  facet normal 0.9952 0.0978576 0
+    outer loop
+      vertex 62.85 26.5 5.9
+      vertex 62.8241 26.7634 4.5
+      vertex 62.8241 26.7634 5.9
+    endloop
+  endfacet
+  facet normal 0.9952 0.0978576 0
+    outer loop
+      vertex 62.8241 26.7634 4.5
+      vertex 62.85 26.5 5.9
+      vertex 62.85 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0.882007 0.471235 0
+    outer loop
+      vertex 62.7472 27.0166 5.9
+      vertex 62.6225 27.25 4.5
+      vertex 62.6225 27.25 5.9
+    endloop
+  endfacet
+  facet normal 0.882007 0.471235 0
+    outer loop
+      vertex 62.6225 27.25 4.5
+      vertex 62.7472 27.0166 5.9
+      vertex 62.7472 27.0166 4.5
+    endloop
+  endfacet
+  facet normal 0.9952 -0.0978576 0
+    outer loop
+      vertex 62.8241 26.2366 5.9
+      vertex 62.85 26.5 4.5
+      vertex 62.85 26.5 5.9
+    endloop
+  endfacet
+  facet normal 0.9952 -0.0978576 0
+    outer loop
+      vertex 62.85 26.5 4.5
+      vertex 62.8241 26.2366 5.9
+      vertex 62.8241 26.2366 4.5
+    endloop
+  endfacet
+  facet normal 0.290605 -0.956843 0
+    outer loop
+      vertex 61.7634 25.1759 4.5
+      vertex 62.0166 25.2528 5.9
+      vertex 61.7634 25.1759 5.9
+    endloop
+  endfacet
+  facet normal 0.290605 -0.956843 0
+    outer loop
+      vertex 62.0166 25.2528 5.9
+      vertex 61.7634 25.1759 4.5
+      vertex 62.0166 25.2528 4.5
+    endloop
+  endfacet
+  facet normal 0.773031 0.634369 0
+    outer loop
+      vertex 62.6225 27.25 5.9
+      vertex 62.4546 27.4546 4.5
+      vertex 62.4546 27.4546 5.9
+    endloop
+  endfacet
+  facet normal 0.773031 0.634369 0
+    outer loop
+      vertex 62.4546 27.4546 4.5
+      vertex 62.6225 27.25 5.9
+      vertex 62.6225 27.25 4.5
+    endloop
+  endfacet
+  facet normal -0.773031 0.634369 0
+    outer loop
+      vertex 60.3775 27.25 4.5
+      vertex 60.5454 27.4546 5.9
+      vertex 60.5454 27.4546 4.5
+    endloop
+  endfacet
+  facet normal -0.773031 0.634369 0
+    outer loop
+      vertex 60.5454 27.4546 5.9
+      vertex 60.3775 27.25 4.5
+      vertex 60.3775 27.25 5.9
+    endloop
+  endfacet
+  facet normal -0.471235 -0.882007 0
+    outer loop
+      vertex 60.75 25.3775 4.5
+      vertex 60.9834 25.2528 5.9
+      vertex 60.75 25.3775 5.9
+    endloop
+  endfacet
+  facet normal -0.471235 -0.882007 -0
+    outer loop
+      vertex 60.9834 25.2528 5.9
+      vertex 60.75 25.3775 4.5
+      vertex 60.9834 25.2528 4.5
+    endloop
+  endfacet
+  facet normal 0.956843 -0.290605 0
+    outer loop
+      vertex 62.7472 25.9834 5.9
+      vertex 62.8241 26.2366 4.5
+      vertex 62.8241 26.2366 5.9
+    endloop
+  endfacet
+  facet normal 0.956843 -0.290605 0
+    outer loop
+      vertex 62.8241 26.2366 4.5
+      vertex 62.7472 25.9834 5.9
+      vertex 62.7472 25.9834 4.5
+    endloop
+  endfacet
+  facet normal -0.634369 0.773031 0
+    outer loop
+      vertex 60.75 27.6225 4.5
+      vertex 60.5454 27.4546 5.9
+      vertex 60.75 27.6225 5.9
+    endloop
+  endfacet
+  facet normal -0.634369 0.773031 0
+    outer loop
+      vertex 60.5454 27.4546 5.9
+      vertex 60.75 27.6225 4.5
+      vertex 60.5454 27.4546 4.5
+    endloop
+  endfacet
+  facet normal 0.882007 -0.471235 0
+    outer loop
+      vertex 62.6225 25.75 5.9
+      vertex 62.7472 25.9834 4.5
+      vertex 62.7472 25.9834 5.9
+    endloop
+  endfacet
+  facet normal 0.882007 -0.471235 0
+    outer loop
+      vertex 62.7472 25.9834 4.5
+      vertex 62.6225 25.75 5.9
+      vertex 62.6225 25.75 4.5
+    endloop
+  endfacet
+  facet normal -0.0978576 0.9952 0
+    outer loop
+      vertex 61.5 27.85 4.5
+      vertex 61.2366 27.8241 5.9
+      vertex 61.5 27.85 5.9
+    endloop
+  endfacet
+  facet normal -0.0978576 0.9952 0
+    outer loop
+      vertex 61.2366 27.8241 5.9
+      vertex 61.5 27.85 4.5
+      vertex 61.2366 27.8241 4.5
+    endloop
+  endfacet
+  facet normal 0.634369 -0.773031 0
+    outer loop
+      vertex 62.25 25.3775 4.5
+      vertex 62.4546 25.5454 5.9
+      vertex 62.25 25.3775 5.9
+    endloop
+  endfacet
+  facet normal 0.634369 -0.773031 0
+    outer loop
+      vertex 62.4546 25.5454 5.9
+      vertex 62.25 25.3775 4.5
+      vertex 62.4546 25.5454 4.5
+    endloop
+  endfacet
+  facet normal -0.9952 0.0978576 0
+    outer loop
+      vertex 60.15 26.5 4.5
+      vertex 60.1759 26.7634 5.9
+      vertex 60.1759 26.7634 4.5
+    endloop
+  endfacet
+  facet normal -0.9952 0.0978576 0
+    outer loop
+      vertex 60.1759 26.7634 5.9
+      vertex 60.15 26.5 4.5
+      vertex 60.15 26.5 5.9
+    endloop
+  endfacet
+  facet normal -0.471235 0.882007 0
+    outer loop
+      vertex 60.9834 27.7472 4.5
+      vertex 60.75 27.6225 5.9
+      vertex 60.9834 27.7472 5.9
+    endloop
+  endfacet
+  facet normal -0.471235 0.882007 0
+    outer loop
+      vertex 60.75 27.6225 5.9
+      vertex 60.9834 27.7472 4.5
+      vertex 60.75 27.6225 4.5
+    endloop
+  endfacet
+  facet normal -0.882007 -0.471235 0
+    outer loop
+      vertex 60.3775 25.75 4.5
+      vertex 60.2528 25.9834 5.9
+      vertex 60.2528 25.9834 4.5
+    endloop
+  endfacet
+  facet normal -0.882007 -0.471235 0
+    outer loop
+      vertex 60.2528 25.9834 5.9
+      vertex 60.3775 25.75 4.5
+      vertex 60.3775 25.75 5.9
+    endloop
+  endfacet
+  facet normal 0.773031 -0.634369 0
+    outer loop
+      vertex 62.4546 25.5454 5.9
+      vertex 62.6225 25.75 4.5
+      vertex 62.6225 25.75 5.9
+    endloop
+  endfacet
+  facet normal 0.773031 -0.634369 0
+    outer loop
+      vertex 62.6225 25.75 4.5
+      vertex 62.4546 25.5454 5.9
+      vertex 62.4546 25.5454 4.5
+    endloop
+  endfacet
+  facet normal -0.290605 -0.956843 0
+    outer loop
+      vertex 60.9834 25.2528 4.5
+      vertex 61.2366 25.1759 5.9
+      vertex 60.9834 25.2528 5.9
+    endloop
+  endfacet
+  facet normal -0.290605 -0.956843 -0
+    outer loop
+      vertex 61.2366 25.1759 5.9
+      vertex 60.9834 25.2528 4.5
+      vertex 61.2366 25.1759 4.5
+    endloop
+  endfacet
+  facet normal 0.290605 0.956843 -0
+    outer loop
+      vertex 62.0166 27.7472 4.5
+      vertex 61.7634 27.8241 5.9
+      vertex 62.0166 27.7472 5.9
+    endloop
+  endfacet
+  facet normal 0.290605 0.956843 0
+    outer loop
+      vertex 61.7634 27.8241 5.9
+      vertex 62.0166 27.7472 4.5
+      vertex 61.7634 27.8241 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8241 26.7634 5.9
+      vertex 62.8241 26.2366 5.9
+      vertex 62.85 26.5 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7472 27.0166 5.9
+      vertex 62.8241 26.2366 5.9
+      vertex 62.8241 26.7634 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7472 27.0166 5.9
+      vertex 62.7472 25.9834 5.9
+      vertex 62.8241 26.2366 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6225 27.25 5.9
+      vertex 62.7472 25.9834 5.9
+      vertex 62.7472 27.0166 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6225 27.25 5.9
+      vertex 62.6225 25.75 5.9
+      vertex 62.7472 25.9834 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4546 27.4546 5.9
+      vertex 62.6225 25.75 5.9
+      vertex 62.6225 27.25 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4546 27.4546 5.9
+      vertex 62.4546 25.5454 5.9
+      vertex 62.6225 25.75 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.25 27.6225 5.9
+      vertex 62.4546 25.5454 5.9
+      vertex 62.4546 27.4546 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.25 27.6225 5.9
+      vertex 62.25 25.3775 5.9
+      vertex 62.4546 25.5454 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0166 27.7472 5.9
+      vertex 62.25 25.3775 5.9
+      vertex 62.25 27.6225 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0166 27.7472 5.9
+      vertex 62.0166 25.2528 5.9
+      vertex 62.25 25.3775 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7634 27.8241 5.9
+      vertex 62.0166 25.2528 5.9
+      vertex 62.0166 27.7472 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.7634 27.8241 5.9
+      vertex 61.7634 25.1759 5.9
+      vertex 62.0166 25.2528 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 27.85 5.9
+      vertex 61.7634 25.1759 5.9
+      vertex 61.7634 27.8241 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 27.85 5.9
+      vertex 61.5 25.15 5.9
+      vertex 61.7634 25.1759 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.2366 27.8241 5.9
+      vertex 61.5 25.15 5.9
+      vertex 61.5 27.85 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2366 27.8241 5.9
+      vertex 61.2366 25.1759 5.9
+      vertex 61.5 25.15 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.9834 27.7472 5.9
+      vertex 61.2366 25.1759 5.9
+      vertex 61.2366 27.8241 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9834 27.7472 5.9
+      vertex 60.9834 25.2528 5.9
+      vertex 61.2366 25.1759 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.75 27.6225 5.9
+      vertex 60.9834 25.2528 5.9
+      vertex 60.9834 27.7472 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.75 27.6225 5.9
+      vertex 60.75 25.3775 5.9
+      vertex 60.9834 25.2528 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.5454 27.4546 5.9
+      vertex 60.75 25.3775 5.9
+      vertex 60.75 27.6225 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5454 27.4546 5.9
+      vertex 60.5454 25.5454 5.9
+      vertex 60.75 25.3775 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.3775 27.25 5.9
+      vertex 60.5454 25.5454 5.9
+      vertex 60.5454 27.4546 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3775 27.25 5.9
+      vertex 60.3775 25.75 5.9
+      vertex 60.5454 25.5454 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.2528 27.0166 5.9
+      vertex 60.3775 25.75 5.9
+      vertex 60.3775 27.25 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.2528 27.0166 5.9
+      vertex 60.2528 25.9834 5.9
+      vertex 60.3775 25.75 5.9
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.1759 26.7634 5.9
+      vertex 60.2528 25.9834 5.9
+      vertex 60.2528 27.0166 5.9
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.1759 26.7634 5.9
+      vertex 60.1759 26.2366 5.9
+      vertex 60.2528 25.9834 5.9
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 60.1759 26.2366 5.9
+      vertex 60.1759 26.7634 5.9
+      vertex 60.15 26.5 5.9
+    endloop
+  endfacet
+  facet normal -0.773031 -0.634369 0
+    outer loop
+      vertex 60.5454 25.5454 4.5
+      vertex 60.3775 25.75 5.9
+      vertex 60.3775 25.75 4.5
+    endloop
+  endfacet
+  facet normal -0.773031 -0.634369 0
+    outer loop
+      vertex 60.3775 25.75 5.9
+      vertex 60.5454 25.5454 4.5
+      vertex 60.5454 25.5454 5.9
+    endloop
+  endfacet
+  facet normal 0.471235 -0.882007 0
+    outer loop
+      vertex 62.0166 25.2528 4.5
+      vertex 62.25 25.3775 5.9
+      vertex 62.0166 25.2528 5.9
+    endloop
+  endfacet
+  facet normal 0.471235 -0.882007 0
+    outer loop
+      vertex 62.25 25.3775 5.9
+      vertex 62.0166 25.2528 4.5
+      vertex 62.25 25.3775 4.5
+    endloop
+  endfacet
+  facet normal -0.0978576 -0.9952 0
+    outer loop
+      vertex 61.2366 25.1759 4.5
+      vertex 61.5 25.15 5.9
+      vertex 61.2366 25.1759 5.9
+    endloop
+  endfacet
+  facet normal -0.0978576 -0.9952 -0
+    outer loop
+      vertex 61.5 25.15 5.9
+      vertex 61.2366 25.1759 4.5
+      vertex 61.5 25.15 4.5
+    endloop
+  endfacet
+  facet normal 0.634369 0.773031 -0
+    outer loop
+      vertex 62.4546 27.4546 4.5
+      vertex 62.25 27.6225 5.9
+      vertex 62.4546 27.4546 5.9
+    endloop
+  endfacet
+  facet normal 0.634369 0.773031 0
+    outer loop
+      vertex 62.25 27.6225 5.9
+      vertex 62.4546 27.4546 4.5
+      vertex 62.25 27.6225 4.5
+    endloop
+  endfacet
+  facet normal 0.0978576 0.9952 -0
+    outer loop
+      vertex 61.7634 27.8241 4.5
+      vertex 61.5 27.85 5.9
+      vertex 61.7634 27.8241 5.9
+    endloop
+  endfacet
+  facet normal 0.0978576 0.9952 0
+    outer loop
+      vertex 61.5 27.85 5.9
+      vertex 61.7634 27.8241 4.5
+      vertex 61.5 27.85 4.5
+    endloop
+  endfacet
+  facet normal 0.471235 0.882007 -0
+    outer loop
+      vertex 62.25 27.6225 4.5
+      vertex 62.0166 27.7472 5.9
+      vertex 62.25 27.6225 5.9
+    endloop
+  endfacet
+  facet normal 0.471235 0.882007 0
+    outer loop
+      vertex 62.0166 27.7472 5.9
+      vertex 62.25 27.6225 4.5
+      vertex 62.0166 27.7472 4.5
+    endloop
+  endfacet
+  facet normal 0.0978576 -0.9952 0
+    outer loop
+      vertex 61.5 25.15 4.5
+      vertex 61.7634 25.1759 5.9
+      vertex 61.5 25.15 5.9
+    endloop
+  endfacet
+  facet normal 0.0978576 -0.9952 0
+    outer loop
+      vertex 61.7634 25.1759 5.9
+      vertex 61.5 25.15 4.5
+      vertex 61.7634 25.1759 4.5
+    endloop
+  endfacet
+  facet normal -0.956843 -0.290605 0
+    outer loop
+      vertex 60.2528 25.9834 4.5
+      vertex 60.1759 26.2366 5.9
+      vertex 60.1759 26.2366 4.5
+    endloop
+  endfacet
+  facet normal -0.956843 -0.290605 0
+    outer loop
+      vertex 60.1759 26.2366 5.9
+      vertex 60.2528 25.9834 4.5
+      vertex 60.2528 25.9834 5.9
+    endloop
+  endfacet
+  facet normal -0.634369 -0.773031 0
+    outer loop
+      vertex 60.5454 25.5454 4.5
+      vertex 60.75 25.3775 5.9
+      vertex 60.5454 25.5454 5.9
+    endloop
+  endfacet
+  facet normal -0.634369 -0.773031 -0
+    outer loop
+      vertex 60.75 25.3775 5.9
+      vertex 60.5454 25.5454 4.5
+      vertex 60.75 25.3775 4.5
+    endloop
+  endfacet
+  facet normal -0.956843 0.290605 0
+    outer loop
+      vertex 60.1759 26.7634 4.5
+      vertex 60.2528 27.0166 5.9
+      vertex 60.2528 27.0166 4.5
+    endloop
+  endfacet
+  facet normal -0.956843 0.290605 0
+    outer loop
+      vertex 60.2528 27.0166 5.9
+      vertex 60.1759 26.7634 4.5
+      vertex 60.1759 26.7634 5.9
+    endloop
+  endfacet
+  facet normal -0.9952 -0.0978576 0
+    outer loop
+      vertex 60.1759 26.2366 4.5
+      vertex 60.15 26.5 5.9
+      vertex 60.15 26.5 4.5
+    endloop
+  endfacet
+  facet normal -0.9952 -0.0978576 0
+    outer loop
+      vertex 60.15 26.5 5.9
+      vertex 60.1759 26.2366 4.5
+      vertex 60.1759 26.2366 5.9
+    endloop
+  endfacet
+  facet normal -0.882007 0.471235 0
+    outer loop
+      vertex 60.2528 27.0166 4.5
+      vertex 60.3775 27.25 5.9
+      vertex 60.3775 27.25 4.5
+    endloop
+  endfacet
+  facet normal -0.882007 0.471235 0
+    outer loop
+      vertex 60.3775 27.25 5.9
+      vertex 60.2528 27.0166 4.5
+      vertex 60.2528 27.0166 5.9
+    endloop
+  endfacet
+  facet normal -0.881919 -0.4714 0
+    outer loop
+      vertex 59.0056 24.8333 3.3
+      vertex 58.7284 25.3519 4.5
+      vertex 58.7284 25.3519 3.3
+    endloop
+  endfacet
+  facet normal -0.881919 -0.4714 0
+    outer loop
+      vertex 58.7284 25.3519 4.5
+      vertex 59.0056 24.8333 3.3
+      vertex 59.0056 24.8333 4.5
+    endloop
+  endfacet
+  facet normal -0.097938 0.995193 0
+    outer loop
+      vertex 61.5 29.5 2.4
+      vertex 60.9147 29.4424 4.5
+      vertex 61.5 29.5 4.5
+    endloop
+  endfacet
+  facet normal -0.097938 0.995193 0
+    outer loop
+      vertex 60.9147 29.4424 4.5
+      vertex 61.5 29.5 2.4
+      vertex 60.9147 29.4424 2.4
+    endloop
+  endfacet
+  facet normal -0.471329 -0.881957 0
+    outer loop
+      vertex 59.8333 24.0056 3.3
+      vertex 60.352 23.7284 4.5
+      vertex 59.8333 24.0056 4.5
+    endloop
+  endfacet
+  facet normal -0.471329 -0.881957 -0
+    outer loop
+      vertex 60.352 23.7284 4.5
+      vertex 59.8333 24.0056 3.3
+      vertex 60.352 23.7284 3.3
+    endloop
+  endfacet
+  facet normal -0.471329 0.881957 0
+    outer loop
+      vertex 60.352 29.2716 2.4
+      vertex 59.8333 28.9944 4.5
+      vertex 60.352 29.2716 4.5
+    endloop
+  endfacet
+  facet normal -0.471329 0.881957 0
+    outer loop
+      vertex 59.8333 28.9944 4.5
+      vertex 60.352 29.2716 2.4
+      vertex 59.8333 28.9944 2.4
+    endloop
+  endfacet
+  facet normal -0.772994 0.634413 0
+    outer loop
+      vertex 59.0056 28.1667 2.4
+      vertex 59.3787 28.6213 4.5
+      vertex 59.3787 28.6213 2.4
+    endloop
+  endfacet
+  facet normal -0.772994 0.634413 0
+    outer loop
+      vertex 59.3787 28.6213 4.5
+      vertex 59.0056 28.1667 2.4
+      vertex 59.0056 28.1667 4.5
+    endloop
+  endfacet
+  facet normal -0.097938 -0.995193 0
+    outer loop
+      vertex 60.9147 23.5576 3.3
+      vertex 61.5 23.5 4.5
+      vertex 60.9147 23.5576 4.5
+    endloop
+  endfacet
+  facet normal -0.097938 -0.995193 -0
+    outer loop
+      vertex 61.5 23.5 4.5
+      vertex 60.9147 23.5576 3.3
+      vertex 61.5 23.5 3.3
+    endloop
+  endfacet
+  facet normal -0.290451 0.95689 0
+    outer loop
+      vertex 60.9147 29.4424 2.4
+      vertex 60.352 29.2716 4.5
+      vertex 60.9147 29.4424 4.5
+    endloop
+  endfacet
+  facet normal -0.290451 0.95689 0
+    outer loop
+      vertex 60.352 29.2716 4.5
+      vertex 60.9147 29.4424 2.4
+      vertex 60.352 29.2716 2.4
+    endloop
+  endfacet
+  facet normal -0.290451 -0.95689 0
+    outer loop
+      vertex 60.352 23.7284 3.3
+      vertex 60.9147 23.5576 4.5
+      vertex 60.352 23.7284 4.5
+    endloop
+  endfacet
+  facet normal -0.290451 -0.95689 -0
+    outer loop
+      vertex 60.9147 23.5576 4.5
+      vertex 60.352 23.7284 3.3
+      vertex 60.9147 23.5576 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.85 26.5 4.5
+      vertex 64.5 26.5 4.5
+      vertex 64.4424 27.0853 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.8241 26.7634 4.5
+      vertex 64.4424 27.0853 4.5
+      vertex 64.2716 27.648 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.5 26.5 4.5
+      vertex 62.85 26.5 4.5
+      vertex 64.4424 25.9147 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.7472 27.0166 4.5
+      vertex 64.2716 27.648 4.5
+      vertex 63.9944 28.1667 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.8241 26.2366 4.5
+      vertex 64.4424 25.9147 4.5
+      vertex 62.85 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.6225 27.25 4.5
+      vertex 63.9944 28.1667 4.5
+      vertex 63.6213 28.6213 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4424 25.9147 4.5
+      vertex 62.8241 26.2366 4.5
+      vertex 64.2716 25.3519 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.4546 27.4546 4.5
+      vertex 63.6213 28.6213 4.5
+      vertex 63.1667 28.9944 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.7472 25.9834 4.5
+      vertex 64.2716 25.3519 4.5
+      vertex 62.8241 26.2366 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2716 25.3519 4.5
+      vertex 62.7472 25.9834 4.5
+      vertex 63.9944 24.8333 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4424 27.0853 4.5
+      vertex 62.8241 26.7634 4.5
+      vertex 62.85 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2716 27.648 4.5
+      vertex 62.7472 27.0166 4.5
+      vertex 62.8241 26.7634 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.25 27.6225 4.5
+      vertex 63.1667 28.9944 4.5
+      vertex 62.648 29.2716 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9944 28.1667 4.5
+      vertex 62.6225 27.25 4.5
+      vertex 62.7472 27.0166 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6213 28.6213 4.5
+      vertex 62.4546 27.4546 4.5
+      vertex 62.6225 27.25 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1667 28.9944 4.5
+      vertex 62.25 27.6225 4.5
+      vertex 62.4546 27.4546 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0166 27.7472 4.5
+      vertex 62.648 29.2716 4.5
+      vertex 62.0853 29.4424 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.648 29.2716 4.5
+      vertex 62.0166 27.7472 4.5
+      vertex 62.25 27.6225 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.0853 29.4424 4.5
+      vertex 61.7634 27.8241 4.5
+      vertex 62.0166 27.7472 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 29.5 4.5
+      vertex 61.7634 27.8241 4.5
+      vertex 62.0853 29.4424 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 29.5 4.5
+      vertex 61.5 27.85 4.5
+      vertex 61.7634 27.8241 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 29.5 4.5
+      vertex 61.2366 27.8241 4.5
+      vertex 61.5 27.85 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.9147 29.4424 4.5
+      vertex 61.2366 27.8241 4.5
+      vertex 61.5 29.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2366 27.8241 4.5
+      vertex 60.9147 29.4424 4.5
+      vertex 60.9834 27.7472 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.352 29.2716 4.5
+      vertex 60.9834 27.7472 4.5
+      vertex 60.9147 29.4424 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9834 27.7472 4.5
+      vertex 60.352 29.2716 4.5
+      vertex 60.75 27.6225 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.8333 28.9944 4.5
+      vertex 60.75 27.6225 4.5
+      vertex 60.352 29.2716 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.75 27.6225 4.5
+      vertex 59.8333 28.9944 4.5
+      vertex 60.5454 27.4546 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.3787 28.6213 4.5
+      vertex 60.5454 27.4546 4.5
+      vertex 59.8333 28.9944 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5454 27.4546 4.5
+      vertex 59.3787 28.6213 4.5
+      vertex 60.3775 27.25 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.0056 28.1667 4.5
+      vertex 60.3775 27.25 4.5
+      vertex 59.3787 28.6213 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3775 27.25 4.5
+      vertex 59.0056 28.1667 4.5
+      vertex 60.2528 27.0166 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.6225 25.75 4.5
+      vertex 63.9944 24.8333 4.5
+      vertex 62.7472 25.9834 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9944 24.8333 4.5
+      vertex 62.6225 25.75 4.5
+      vertex 63.6213 24.3787 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.4546 25.5454 4.5
+      vertex 63.6213 24.3787 4.5
+      vertex 62.6225 25.75 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6213 24.3787 4.5
+      vertex 62.4546 25.5454 4.5
+      vertex 63.1667 24.0056 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.25 25.3775 4.5
+      vertex 63.1667 24.0056 4.5
+      vertex 62.4546 25.5454 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1667 24.0056 4.5
+      vertex 62.25 25.3775 4.5
+      vertex 62.648 23.7284 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 62.0166 25.2528 4.5
+      vertex 62.648 23.7284 4.5
+      vertex 62.25 25.3775 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.648 23.7284 4.5
+      vertex 62.0166 25.2528 4.5
+      vertex 62.0853 23.5576 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.7634 25.1759 4.5
+      vertex 62.0853 23.5576 4.5
+      vertex 62.0166 25.2528 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 61.5 25.15 4.5
+      vertex 62.0853 23.5576 4.5
+      vertex 61.7634 25.1759 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 25.15 4.5
+      vertex 61.5 23.5 4.5
+      vertex 62.0853 23.5576 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2366 25.1759 4.5
+      vertex 61.5 23.5 4.5
+      vertex 61.5 25.15 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9147 23.5576 4.5
+      vertex 61.2366 25.1759 4.5
+      vertex 60.9834 25.2528 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.2366 25.1759 4.5
+      vertex 60.9147 23.5576 4.5
+      vertex 61.5 23.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.352 23.7284 4.5
+      vertex 60.9834 25.2528 4.5
+      vertex 60.75 25.3775 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.8333 24.0056 4.5
+      vertex 60.75 25.3775 4.5
+      vertex 60.5454 25.5454 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.3787 24.3787 4.5
+      vertex 60.5454 25.5454 4.5
+      vertex 60.3775 25.75 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9834 25.2528 4.5
+      vertex 60.352 23.7284 4.5
+      vertex 60.9147 23.5576 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.0056 24.8333 4.5
+      vertex 60.3775 25.75 4.5
+      vertex 60.2528 25.9834 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.7284 25.3519 4.5
+      vertex 60.2528 25.9834 4.5
+      vertex 60.1759 26.2366 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5576 25.9147 4.5
+      vertex 60.1759 26.2366 4.5
+      vertex 60.15 26.5 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.7284 27.648 4.5
+      vertex 60.2528 27.0166 4.5
+      vertex 59.0056 28.1667 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.75 25.3775 4.5
+      vertex 59.8333 24.0056 4.5
+      vertex 60.352 23.7284 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.2528 27.0166 4.5
+      vertex 58.7284 27.648 4.5
+      vertex 60.1759 26.7634 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5454 25.5454 4.5
+      vertex 59.3787 24.3787 4.5
+      vertex 59.8333 24.0056 4.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 58.5576 27.0853 4.5
+      vertex 60.1759 26.7634 4.5
+      vertex 58.7284 27.648 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3775 25.75 4.5
+      vertex 59.0056 24.8333 4.5
+      vertex 59.3787 24.3787 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.1759 26.7634 4.5
+      vertex 58.5576 27.0853 4.5
+      vertex 60.15 26.5 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.2528 25.9834 4.5
+      vertex 58.7284 25.3519 4.5
+      vertex 59.0056 24.8333 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 26.5 4.5
+      vertex 60.15 26.5 4.5
+      vertex 58.5576 27.0853 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.1759 26.2366 4.5
+      vertex 58.5576 25.9147 4.5
+      vertex 58.7284 25.3519 4.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.15 26.5 4.5
+      vertex 58.5 26.5 4.5
+      vertex 58.5576 25.9147 4.5
+    endloop
+  endfacet
+  facet normal -0.956904 -0.290404 0
+    outer loop
+      vertex 58.7284 25.3519 3.3
+      vertex 58.5576 25.9147 4.5
+      vertex 58.5576 25.9147 3.3
+    endloop
+  endfacet
+  facet normal -0.956904 -0.290404 0
+    outer loop
+      vertex 58.5576 25.9147 4.5
+      vertex 58.7284 25.3519 3.3
+      vertex 58.7284 25.3519 4.5
+    endloop
+  endfacet
+  facet normal -0.995193 0.097938 0
+    outer loop
+      vertex 58.5 26.5 3.3
+      vertex 58.5576 27.0853 2.4
+      vertex 58.5 26.5 2.4
+    endloop
+  endfacet
+  facet normal -0.995193 0.097938 0
+    outer loop
+      vertex 58.5576 27.0853 2.4
+      vertex 58.5 26.5 3.3
+      vertex 58.5576 27.0853 4.5
+    endloop
+  endfacet
+  facet normal -0.995193 0.097938 0
+    outer loop
+      vertex 58.5576 27.0853 4.5
+      vertex 58.5 26.5 3.3
+      vertex 58.5 26.5 4.5
+    endloop
+  endfacet
+  facet normal -0.634413 0.772994 0
+    outer loop
+      vertex 59.8333 28.9944 2.4
+      vertex 59.3787 28.6213 4.5
+      vertex 59.8333 28.9944 4.5
+    endloop
+  endfacet
+  facet normal -0.634413 0.772994 0
+    outer loop
+      vertex 59.3787 28.6213 4.5
+      vertex 59.8333 28.9944 2.4
+      vertex 59.3787 28.6213 2.4
+    endloop
+  endfacet
+  facet normal -0.772994 -0.634413 0
+    outer loop
+      vertex 59.3787 24.3787 3.3
+      vertex 59.0056 24.8333 4.5
+      vertex 59.0056 24.8333 3.3
+    endloop
+  endfacet
+  facet normal -0.772994 -0.634413 0
+    outer loop
+      vertex 59.0056 24.8333 4.5
+      vertex 59.3787 24.3787 3.3
+      vertex 59.3787 24.3787 4.5
+    endloop
+  endfacet
+  facet normal -0.634413 -0.772994 0
+    outer loop
+      vertex 59.3787 24.3787 3.3
+      vertex 59.8333 24.0056 4.5
+      vertex 59.3787 24.3787 4.5
+    endloop
+  endfacet
+  facet normal -0.634413 -0.772994 -0
+    outer loop
+      vertex 59.8333 24.0056 4.5
+      vertex 59.3787 24.3787 3.3
+      vertex 59.8333 24.0056 3.3
+    endloop
+  endfacet
+  facet normal -0.95689 0.290451 0
+    outer loop
+      vertex 58.5576 27.0853 2.4
+      vertex 58.7284 27.648 4.5
+      vertex 58.7284 27.648 2.4
+    endloop
+  endfacet
+  facet normal -0.95689 0.290451 0
+    outer loop
+      vertex 58.7284 27.648 4.5
+      vertex 58.5576 27.0853 2.4
+      vertex 58.5576 27.0853 4.5
+    endloop
+  endfacet
+  facet normal -0.881957 0.471329 0
+    outer loop
+      vertex 58.7284 27.648 2.4
+      vertex 59.0056 28.1667 4.5
+      vertex 59.0056 28.1667 2.4
+    endloop
+  endfacet
+  facet normal -0.881957 0.471329 0
+    outer loop
+      vertex 59.0056 28.1667 4.5
+      vertex 58.7284 27.648 2.4
+      vertex 58.7284 27.648 4.5
+    endloop
+  endfacet
+  facet normal -0.995193 -0.097938 0
+    outer loop
+      vertex 58.5576 25.9147 3.3
+      vertex 58.5 26.5 4.5
+      vertex 58.5 26.5 3.3
+    endloop
+  endfacet
+  facet normal -0.995193 -0.097938 0
+    outer loop
+      vertex 58.5 26.5 4.5
+      vertex 58.5576 25.9147 3.3
+      vertex 58.5576 25.9147 4.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 64.5 3.5 3.3
+      vertex 64.5 26.5 0
+      vertex 64.5 26.5 3.3
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 64.5 26.5 0
+      vertex 64.5 3.5 3.3
+      vertex 64.5 3.5 0
+    endloop
+  endfacet
+  facet normal -0.956929 0.290322 0
+    outer loop
+      vertex 0.557644 27.0853 0
+      vertex 0.728361 27.648 1.1
+      vertex 0.728361 27.648 0
+    endloop
+  endfacet
+  facet normal -0.956929 0.290322 0
+    outer loop
+      vertex 0.728361 27.648 1.1
+      vertex 0.557644 27.0853 0
+      vertex 0.557644 27.0853 1.1
+    endloop
+  endfacet
+  facet normal 0.0980121 -0.995185 0
+    outer loop
+      vertex 61.5 0.5 0
+      vertex 62.0853 0.557644 2
+      vertex 61.5 0.5 2
+    endloop
+  endfacet
+  facet normal 0.0980121 -0.995185 0
+    outer loop
+      vertex 62.0853 0.557644 2
+      vertex 61.5 0.5 0
+      vertex 62.0853 0.557644 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 7.75 0
+      vertex 0.5 3.5 0
+      vertex 0.5 7.75 1.8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 20.4567 0
+      vertex 0.5 12.79 0
+      vertex 0.5 20.4567 1.8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 25.2833 0
+      vertex 0.5 26.5 1.1
+      vertex 0.5 26.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 0.5 26.5 1.1
+      vertex 0.5 25.2833 0
+      vertex 0.5 25.2833 1.8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 26.5 1.1
+      vertex 0.5 25.2833 1.8
+      vertex 0.5 26.5 3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 20.4567 1.8
+      vertex 0.5 26.5 3
+      vertex 0.5 25.2833 1.8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 12.79 1.8
+      vertex 0.5 20.4567 1.8
+      vertex 0.5 12.79 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 12.79 1.8
+      vertex 0.5 26.5 3
+      vertex 0.5 20.4567 1.8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 3.5 3
+      vertex 0.5 12.79 1.8
+      vertex 0.5 7.75 1.8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 12.79 1.8
+      vertex 0.5 3.5 3
+      vertex 0.5 26.5 3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 3.5 3
+      vertex 0.5 7.75 1.8
+      vertex 0.5 3.5 0
+    endloop
+  endfacet
+  facet normal -0.773003 0.634403 0
+    outer loop
+      vertex 1.00559 28.1667 0
+      vertex 1.37868 28.6213 1.1
+      vertex 1.37868 28.6213 0
+    endloop
+  endfacet
+  facet normal -0.773003 0.634403 0
+    outer loop
+      vertex 1.37868 28.6213 1.1
+      vertex 1.00559 28.1667 0
+      vertex 1.00559 28.1667 1.1
+    endloop
+  endfacet
+  facet normal -0.0979429 0.995192 0
+    outer loop
+      vertex 3.5 29.5 0
+      vertex 2.91473 29.4424 1.1
+      vertex 3.5 29.5 1.1
+    endloop
+  endfacet
+  facet normal -0.0979429 0.995192 0
+    outer loop
+      vertex 2.91473 29.4424 1.1
+      vertex 3.5 29.5 0
+      vertex 2.91473 29.4424 0
+    endloop
+  endfacet
+  facet normal -0.881937 0.471368 0
+    outer loop
+      vertex 0.728361 27.648 0
+      vertex 1.00559 28.1667 1.1
+      vertex 1.00559 28.1667 0
+    endloop
+  endfacet
+  facet normal -0.881937 0.471368 0
+    outer loop
+      vertex 1.00559 28.1667 1.1
+      vertex 0.728361 27.648 0
+      vertex 0.728361 27.648 1.1
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980121 0
+    outer loop
+      vertex 0.5 26.5 0
+      vertex 0.557644 27.0853 1.1
+      vertex 0.557644 27.0853 0
+    endloop
+  endfacet
+  facet normal -0.995185 0.0980121 0
+    outer loop
+      vertex 0.557644 27.0853 1.1
+      vertex 0.5 26.5 0
+      vertex 0.5 26.5 1.1
+    endloop
+  endfacet
+  facet normal -0.471358 0.881942 0
+    outer loop
+      vertex 2.35195 29.2716 0
+      vertex 1.83329 28.9944 1.1
+      vertex 2.35195 29.2716 1.1
+    endloop
+  endfacet
+  facet normal -0.471358 0.881942 0
+    outer loop
+      vertex 1.83329 28.9944 1.1
+      vertex 2.35195 29.2716 0
+      vertex 1.83329 28.9944 0
+    endloop
+  endfacet
+  facet normal -0.290413 0.956901 0
+    outer loop
+      vertex 2.91473 29.4424 0
+      vertex 2.35195 29.2716 1.1
+      vertex 2.91473 29.4424 1.1
+    endloop
+  endfacet
+  facet normal -0.290413 0.956901 0
+    outer loop
+      vertex 2.35195 29.2716 1.1
+      vertex 2.91473 29.4424 0
+      vertex 2.35195 29.2716 0
+    endloop
+  endfacet
+  facet normal -0.634405 0.773001 0
+    outer loop
+      vertex 1.83329 28.9944 0
+      vertex 1.37868 28.6213 1.1
+      vertex 1.83329 28.9944 1.1
+    endloop
+  endfacet
+  facet normal -0.634405 0.773001 0
+    outer loop
+      vertex 1.37868 28.6213 1.1
+      vertex 1.83329 28.9944 0
+      vertex 1.37868 28.6213 0
+    endloop
+  endfacet
+  facet normal 0.290322 -0.956929 0
+    outer loop
+      vertex 62.0853 0.557644 0
+      vertex 62.648 0.728361 2
+      vertex 62.0853 0.557644 2
+    endloop
+  endfacet
+  facet normal 0.290322 -0.956929 0
+    outer loop
+      vertex 62.648 0.728361 2
+      vertex 62.0853 0.557644 0
+      vertex 62.648 0.728361 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.44236 25.9147 3
+      vertex 6.5 6.5 3
+      vertex 6.5 26.5 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.27164 25.3519 3
+      vertex 6.5 6.5 3
+      vertex 6.44236 25.9147 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.99441 24.8333 3
+      vertex 6.5 6.5 3
+      vertex 6.27164 25.3519 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.62132 24.3787 3
+      vertex 6.5 6.5 3
+      vertex 5.99441 24.8333 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 5.16671 24.0056 3
+      vertex 6.5 6.5 3
+      vertex 5.62132 24.3787 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.64805 23.7284 3
+      vertex 6.5 6.5 3
+      vertex 5.16671 24.0056 3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 4.08527 23.5576 3
+      vertex 6.5 6.5 3
+      vertex 4.64805 23.7284 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 6.5 3
+      vertex 4.08527 23.5576 3
+      vertex 3.5 23.5 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.08527 23.5576 3
+      vertex 3.5 6.5 3
+      vertex 6.5 6.5 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.91473 23.5576 3
+      vertex 3.5 6.5 3
+      vertex 3.5 23.5 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.91473 23.5576 3
+      vertex 2.91473 6.44236 3
+      vertex 3.5 6.5 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.35195 23.7284 3
+      vertex 2.91473 6.44236 3
+      vertex 2.91473 23.5576 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.35195 23.7284 3
+      vertex 2.35195 6.27164 3
+      vertex 2.91473 6.44236 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.83329 24.0056 3
+      vertex 2.35195 6.27164 3
+      vertex 2.35195 23.7284 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.83329 24.0056 3
+      vertex 1.83329 5.99441 3
+      vertex 2.35195 6.27164 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.37868 24.3787 3
+      vertex 1.83329 5.99441 3
+      vertex 1.83329 24.0056 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.37868 24.3787 3
+      vertex 1.37868 5.62132 3
+      vertex 1.83329 5.99441 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.00559 24.8333 3
+      vertex 1.37868 5.62132 3
+      vertex 1.37868 24.3787 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.00559 24.8333 3
+      vertex 1.00559 5.16671 3
+      vertex 1.37868 5.62132 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.728362 25.3519 3
+      vertex 1.00559 5.16671 3
+      vertex 1.00559 24.8333 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.728362 25.3519 3
+      vertex 0.728361 4.64805 3
+      vertex 1.00559 5.16671 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.557645 25.9147 3
+      vertex 0.728361 4.64805 3
+      vertex 0.728362 25.3519 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.557645 25.9147 3
+      vertex 0.557644 4.08527 3
+      vertex 0.728361 4.64805 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.5 26.5 3
+      vertex 0.557644 4.08527 3
+      vertex 0.557645 25.9147 3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.557644 4.08527 3
+      vertex 0.5 26.5 3
+      vertex 0.5 3.5 3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 58.5 23.5 2.4
+      vertex 58.5 26.5 3.3
+      vertex 58.5 26.5 2.4
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 58.5 26.5 3.3
+      vertex 58.5 23.5 2.4
+      vertex 58.5 23.5 3.3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 58.5 15.5 2.7
+      vertex 58.5 23.5 2.4
+      vertex 58.5 23.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 58.5 23.5 2.4
+      vertex 58.5 15.5 2.7
+      vertex 58.5 23.5 3.3
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 58.5 6.5 0
+      vertex 58.5 15.5 2.7
+      vertex 58.5 23.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 58.5 15.5 2.7
+      vertex 58.5 6.5 0
+      vertex 58.5 10.5 2.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 58.5 6.5 3.3
+      vertex 58.5 10.5 2.7
+      vertex 58.5 6.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 58.5 10.5 2.7
+      vertex 58.5 6.5 3.3
+      vertex 58.5 10.5 3.3
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 58.5 23.5 3.3
+      vertex 58.5 15.5 2.7
+      vertex 58.5 15.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6213 24.3787 3.3
+      vertex 60.4808 14.6951 3.3
+      vertex 60.5 14.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 23.5 3.3
+      vertex 60.4239 14.8827 3.3
+      vertex 60.4808 14.6951 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 23.5 3.3
+      vertex 60.9147 23.5576 3.3
+      vertex 60.352 23.7284 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 23.5 3.3
+      vertex 60.3315 15.0556 3.3
+      vertex 60.4239 14.8827 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 23.5 3.3
+      vertex 60.2071 15.2071 3.3
+      vertex 60.3315 15.0556 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 23.5 3.3
+      vertex 60.0556 15.3315 3.3
+      vertex 60.2071 15.2071 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 23.5 3.3
+      vertex 59.8827 15.4239 3.3
+      vertex 60.0556 15.3315 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 23.5 3.3
+      vertex 60.352 23.7284 3.3
+      vertex 59.8333 24.0056 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 61.5 23.5 3.3
+      vertex 59.6951 15.4808 3.3
+      vertex 59.8827 15.4239 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9147 23.5576 3.3
+      vertex 58.5 23.5 3.3
+      vertex 59.5 15.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 23.5 3.3
+      vertex 59.8333 24.0056 3.3
+      vertex 59.3787 24.3787 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 23.5 3.3
+      vertex 59.3787 24.3787 3.3
+      vertex 59.0056 24.8333 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 23.5 3.3
+      vertex 59.0056 24.8333 3.3
+      vertex 58.7284 25.3519 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 23.5 3.3
+      vertex 58.7284 25.3519 3.3
+      vertex 58.5576 25.9147 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 23.5 3.3
+      vertex 58.5576 25.9147 3.3
+      vertex 58.5 26.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.9147 23.5576 3.3
+      vertex 59.5 15.5 3.3
+      vertex 59.6951 15.4808 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5 15.5 3.3
+      vertex 58.5 23.5 3.3
+      vertex 58.5 15.5 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.4424 25.9147 3.3
+      vertex 64.5 3.5 3.3
+      vertex 64.5 26.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.4424 25.9147 3.3
+      vertex 64.4424 4.08527 3.3
+      vertex 64.5 3.5 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 64.2716 25.3519 3.3
+      vertex 64.4424 4.08527 3.3
+      vertex 64.4424 25.9147 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 64.2716 25.3519 3.3
+      vertex 64.2716 4.64805 3.3
+      vertex 64.4424 4.08527 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 63.9944 24.8333 3.3
+      vertex 64.2716 4.64805 3.3
+      vertex 64.2716 25.3519 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9944 24.8333 3.3
+      vertex 63.9944 5.16671 3.3
+      vertex 64.2716 4.64805 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5 14.5 3.3
+      vertex 63.9944 24.8333 3.3
+      vertex 63.6213 24.3787 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9944 24.8333 3.3
+      vertex 60.5 14.5 3.3
+      vertex 63.9944 5.16671 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4808 14.6951 3.3
+      vertex 63.6213 24.3787 3.3
+      vertex 63.1667 24.0056 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.9944 5.16671 3.3
+      vertex 60.5 14.5 3.3
+      vertex 63.6213 5.62132 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4808 14.6951 3.3
+      vertex 63.1667 24.0056 3.3
+      vertex 62.648 23.7284 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.5 11.5 3.3
+      vertex 63.6213 5.62132 3.3
+      vertex 60.5 14.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4808 14.6951 3.3
+      vertex 62.648 23.7284 3.3
+      vertex 62.0853 23.5576 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.6213 5.62132 3.3
+      vertex 60.5 11.5 3.3
+      vertex 63.1667 5.99441 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4808 14.6951 3.3
+      vertex 62.0853 23.5576 3.3
+      vertex 61.5 23.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.6951 15.4808 3.3
+      vertex 61.5 23.5 3.3
+      vertex 60.9147 23.5576 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.4808 11.3049 3.3
+      vertex 63.1667 5.99441 3.3
+      vertex 60.5 11.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 63.1667 5.99441 3.3
+      vertex 60.4808 11.3049 3.3
+      vertex 62.648 6.27164 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.4239 11.1173 3.3
+      vertex 62.648 6.27164 3.3
+      vertex 60.4808 11.3049 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 62.648 6.27164 3.3
+      vertex 60.4239 11.1173 3.3
+      vertex 62 6.5 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.3315 10.9444 3.3
+      vertex 62 6.5 3.3
+      vertex 60.4239 11.1173 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.2071 10.7929 3.3
+      vertex 62 6.5 3.3
+      vertex 60.3315 10.9444 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 60.0556 10.6685 3.3
+      vertex 62 6.5 3.3
+      vertex 60.2071 10.7929 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.8827 10.5761 3.3
+      vertex 62 6.5 3.3
+      vertex 60.0556 10.6685 3.3
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 59.6951 10.5192 3.3
+      vertex 62 6.5 3.3
+      vertex 59.8827 10.5761 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 6.5 3.3
+      vertex 59.6951 10.5192 3.3
+      vertex 59.5 10.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 6.5 3.3
+      vertex 59.5 10.5 3.3
+      vertex 58.5 10.5 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.6951 10.5192 3.3
+      vertex 58.5 6.5 3.3
+      vertex 62 6.5 3.3
+    endloop
+  endfacet
+  facet normal 0.995193 0.097938 0
+    outer loop
+      vertex 57.7 30.5 2.1
+      vertex 57.6808 30.6951 0
+      vertex 57.6808 30.6951 2.1
+    endloop
+  endfacet
+  facet normal 0.995193 0.097938 0
+    outer loop
+      vertex 57.6808 30.6951 0
+      vertex 57.7 30.5 2.1
+      vertex 57.7 30.5 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 51.7 29.5 0
+      vertex 51.7 30.5 2.1
+      vertex 51.7 30.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 51.7 30.5 2.1
+      vertex 51.7 29.5 0
+      vertex 51.7 29.5 2.1
+    endloop
+  endfacet
+  facet normal -0.995193 0.097938 0
+    outer loop
+      vertex 51.7 30.5 0
+      vertex 51.7192 30.6951 2.1
+      vertex 51.7192 30.6951 0
+    endloop
+  endfacet
+  facet normal -0.995193 0.097938 0
+    outer loop
+      vertex 51.7192 30.6951 2.1
+      vertex 51.7 30.5 0
+      vertex 51.7 30.5 2.1
+    endloop
+  endfacet
+  facet normal -0.097938 0.995193 0
+    outer loop
+      vertex 52.5049 31.4808 0
+      vertex 52.7 31.5 1.5
+      vertex 52.7 31.5 0
+    endloop
+  endfacet
+  facet normal -0.097938 0.995193 0
+    outer loop
+      vertex 52.7 31.5 1.5
+      vertex 52.5049 31.4808 0
+      vertex 52.5049 31.4808 1.51922
+    endloop
+  endfacet
+  facet normal -0.772842 0.634598 0
+    outer loop
+      vertex 51.8685 31.0556 0
+      vertex 51.9929 31.2071 1.79289
+      vertex 51.9929 31.2071 0
+    endloop
+  endfacet
+  facet normal -0.772842 0.634598 0
+    outer loop
+      vertex 51.9929 31.2071 1.79289
+      vertex 51.8685 31.0556 0
+      vertex 51.8685 31.0556 1.94443
+    endloop
+  endfacet
+  facet normal -0.290248 0.956951 0
+    outer loop
+      vertex 52.3173 31.4239 0
+      vertex 52.5049 31.4808 1.51922
+      vertex 52.5049 31.4808 0
+    endloop
+  endfacet
+  facet normal -0.290248 0.956951 0
+    outer loop
+      vertex 52.5049 31.4808 1.51922
+      vertex 52.3173 31.4239 0
+      vertex 52.3173 31.4239 1.57612
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 53.45 31.5 0
+      vertex 52.7 31.5 1.5
+      vertex 53.45 31.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 52.7 31.5 1.5
+      vertex 53.45 31.5 0
+      vertex 52.7 31.5 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 56.7 31.5 0
+      vertex 55.95 31.5 1.5
+      vertex 56.7 31.5 1.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 55.95 31.5 1.5
+      vertex 56.7 31.5 0
+      vertex 55.95 31.5 0
+    endloop
+  endfacet
+  facet normal -0.471329 0.881957 0
+    outer loop
+      vertex 52.1444 31.3315 0
+      vertex 52.3173 31.4239 1.57612
+      vertex 52.3173 31.4239 0
+    endloop
+  endfacet
+  facet normal -0.471329 0.881957 0
+    outer loop
+      vertex 52.3173 31.4239 1.57612
+      vertex 52.1444 31.3315 0
+      vertex 52.1444 31.3315 1.66853
+    endloop
+  endfacet
+  facet normal 0.880794 0.47349 0.00309267
+    outer loop
+      vertex 57.6239 30.8827 2.1
+      vertex 57.5315 31.0556 1.94443
+      vertex 57.6146 30.9 2.1
+    endloop
+  endfacet
+  facet normal 0.881957 0.471329 0
+    outer loop
+      vertex 57.5315 31.0556 1.94443
+      vertex 57.6239 30.8827 2.1
+      vertex 57.6239 30.8827 0
+    endloop
+  endfacet
+  facet normal 0.881957 0.471329 0
+    outer loop
+      vertex 57.5315 31.0556 1.94443
+      vertex 57.6239 30.8827 0
+      vertex 57.5315 31.0556 0
+    endloop
+  endfacet
+  facet normal 0.956951 0.290248 0
+    outer loop
+      vertex 57.6808 30.6951 2.1
+      vertex 57.6239 30.8827 0
+      vertex 57.6239 30.8827 2.1
+    endloop
+  endfacet
+  facet normal 0.956951 0.290248 0
+    outer loop
+      vertex 57.6239 30.8827 0
+      vertex 57.6808 30.6951 2.1
+      vertex 57.6808 30.6951 0
+    endloop
+  endfacet
+  facet normal 0.772842 0.634598 -0
+    outer loop
+      vertex 57.5315 31.0556 0
+      vertex 57.4071 31.2071 1.79289
+      vertex 57.5315 31.0556 1.94443
+    endloop
+  endfacet
+  facet normal 0.772842 0.634598 0
+    outer loop
+      vertex 57.4071 31.2071 1.79289
+      vertex 57.5315 31.0556 0
+      vertex 57.4071 31.2071 0
+    endloop
+  endfacet
+  facet normal 0.634598 0.772842 -0
+    outer loop
+      vertex 57.4071 31.2071 0
+      vertex 57.2556 31.3315 1.66853
+      vertex 57.4071 31.2071 1.79289
+    endloop
+  endfacet
+  facet normal 0.634598 0.772842 0
+    outer loop
+      vertex 57.2556 31.3315 1.66853
+      vertex 57.4071 31.2071 0
+      vertex 57.2556 31.3315 0
+    endloop
+  endfacet
+  facet normal 0.097938 0.995193 -0
+    outer loop
+      vertex 56.8951 31.4808 0
+      vertex 56.7 31.5 1.5
+      vertex 56.8951 31.4808 1.51922
+    endloop
+  endfacet
+  facet normal 0.097938 0.995193 0
+    outer loop
+      vertex 56.7 31.5 1.5
+      vertex 56.8951 31.4808 0
+      vertex 56.7 31.5 0
+    endloop
+  endfacet
+  facet normal 0.290248 0.956951 -0
+    outer loop
+      vertex 57.0827 31.4239 0
+      vertex 56.8951 31.4808 1.51922
+      vertex 57.0827 31.4239 1.57612
+    endloop
+  endfacet
+  facet normal 0.290248 0.956951 0
+    outer loop
+      vertex 56.8951 31.4808 1.51922
+      vertex 57.0827 31.4239 0
+      vertex 56.8951 31.4808 0
+    endloop
+  endfacet
+  facet normal -0.634598 0.772842 0
+    outer loop
+      vertex 51.9929 31.2071 0
+      vertex 52.1444 31.3315 1.66853
+      vertex 52.1444 31.3315 0
+    endloop
+  endfacet
+  facet normal -0.634598 0.772842 0
+    outer loop
+      vertex 52.1444 31.3315 1.66853
+      vertex 51.9929 31.2071 0
+      vertex 51.9929 31.2071 1.79289
+    endloop
+  endfacet
+  facet normal -0.881957 0.471329 0
+    outer loop
+      vertex 51.7761 30.8827 0
+      vertex 51.8685 31.0556 1.94443
+      vertex 51.8685 31.0556 0
+    endloop
+  endfacet
+  facet normal -0.881957 0.471329 0
+    outer loop
+      vertex 51.7761 30.8827 2.1
+      vertex 51.8685 31.0556 1.94443
+      vertex 51.7761 30.8827 0
+    endloop
+  endfacet
+  facet normal -0.880794 0.47349 0.00309267
+    outer loop
+      vertex 51.8685 31.0556 1.94443
+      vertex 51.7761 30.8827 2.1
+      vertex 51.7854 30.9 2.1
+    endloop
+  endfacet
+  facet normal -0.956951 0.290248 0
+    outer loop
+      vertex 51.7192 30.6951 0
+      vertex 51.7761 30.8827 2.1
+      vertex 51.7761 30.8827 0
+    endloop
+  endfacet
+  facet normal -0.956951 0.290248 0
+    outer loop
+      vertex 51.7761 30.8827 2.1
+      vertex 51.7192 30.6951 0
+      vertex 51.7192 30.6951 2.1
+    endloop
+  endfacet
+  facet normal 0.471329 0.881957 -0
+    outer loop
+      vertex 57.2556 31.3315 0
+      vertex 57.0827 31.4239 1.57612
+      vertex 57.2556 31.3315 1.66853
+    endloop
+  endfacet
+  facet normal 0.471329 0.881957 0
+    outer loop
+      vertex 57.0827 31.4239 1.57612
+      vertex 57.2556 31.3315 0
+      vertex 57.0827 31.4239 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 53.45 31.2 1.8
+      vertex 53.45 31.5 0
+      vertex 53.45 31.5 1.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 53.45 25.7 0
+      vertex 53.45 31.2 1.8
+      vertex 53.45 25.7 1.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 53.45 31.2 1.8
+      vertex 53.45 25.7 0
+      vertex 53.45 31.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 55.95 25.7 1.8
+      vertex 55.926 25.4561 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 55.926 25.4561 1.8
+      vertex 55.8549 25.2216 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 55.8549 25.2216 1.8
+      vertex 55.7393 25.0055 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 55.7393 25.0055 1.8
+      vertex 55.5839 24.8161 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 55.5839 24.8161 1.8
+      vertex 55.3945 24.6607 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 55.3945 24.6607 1.8
+      vertex 55.1784 24.5452 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 55.1784 24.5452 1.8
+      vertex 54.9439 24.474 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 54.9439 24.474 1.8
+      vertex 54.7 24.45 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 54.7 24.45 1.8
+      vertex 54.4561 24.474 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 54.4561 24.474 1.8
+      vertex 54.2216 24.5452 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 54.2216 24.5452 1.8
+      vertex 54.0055 24.6607 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 54.0055 24.6607 1.8
+      vertex 53.8161 24.8161 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 53.8161 24.8161 1.8
+      vertex 53.6607 25.0055 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 53.6607 25.0055 1.8
+      vertex 53.5452 25.2216 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 53.45 25.7 1.8
+      vertex 53.5452 25.2216 1.8
+      vertex 53.474 25.4561 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 55.95 25.7 1.8
+      vertex 53.45 25.7 1.8
+      vertex 55.95 31.2 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 55.95 31.2 1.8
+      vertex 53.45 25.7 1.8
+      vertex 53.45 31.2 1.8
+    endloop
+  endfacet
+  facet normal 0.956866 0.290528 0
+    outer loop
+      vertex 53.5452 25.2216 1.8
+      vertex 53.474 25.4561 0
+      vertex 53.474 25.4561 1.8
+    endloop
+  endfacet
+  facet normal 0.956866 0.290528 0
+    outer loop
+      vertex 53.474 25.4561 0
+      vertex 53.5452 25.2216 1.8
+      vertex 53.5452 25.2216 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 55.95 31.5 0
+      vertex 55.95 31.2 1.8
+      vertex 55.95 31.5 1.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 55.95 25.7 0
+      vertex 55.95 31.2 1.8
+      vertex 55.95 31.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 55.95 31.2 1.8
+      vertex 55.95 25.7 0
+      vertex 55.95 25.7 1.8
+    endloop
+  endfacet
+  facet normal 0.881935 0.471372 0
+    outer loop
+      vertex 53.6607 25.0055 1.8
+      vertex 53.5452 25.2216 0
+      vertex 53.5452 25.2216 1.8
+    endloop
+  endfacet
+  facet normal 0.881935 0.471372 0
+    outer loop
+      vertex 53.5452 25.2216 0
+      vertex 53.6607 25.0055 1.8
+      vertex 53.6607 25.0055 0
+    endloop
+  endfacet
+  facet normal 0.995194 0.097928 0
+    outer loop
+      vertex 53.474 25.4561 1.8
+      vertex 53.45 25.7 0
+      vertex 53.45 25.7 1.8
+    endloop
+  endfacet
+  facet normal 0.995194 0.097928 0
+    outer loop
+      vertex 53.45 25.7 0
+      vertex 53.474 25.4561 1.8
+      vertex 53.474 25.4561 0
+    endloop
+  endfacet
+  facet normal 0.290528 0.956866 -0
+    outer loop
+      vertex 54.4561 24.474 0
+      vertex 54.2216 24.5452 1.8
+      vertex 54.4561 24.474 1.8
+    endloop
+  endfacet
+  facet normal 0.290528 0.956866 0
+    outer loop
+      vertex 54.2216 24.5452 1.8
+      vertex 54.4561 24.474 0
+      vertex 54.2216 24.5452 0
+    endloop
+  endfacet
+  facet normal -0.995194 0.097928 0
+    outer loop
+      vertex 55.926 25.4561 0
+      vertex 55.95 25.7 1.8
+      vertex 55.95 25.7 0
+    endloop
+  endfacet
+  facet normal -0.995194 0.097928 0
+    outer loop
+      vertex 55.95 25.7 1.8
+      vertex 55.926 25.4561 0
+      vertex 55.926 25.4561 1.8
+    endloop
+  endfacet
+  facet normal 0.097928 0.995194 -0
+    outer loop
+      vertex 54.7 24.45 0
+      vertex 54.4561 24.474 1.8
+      vertex 54.7 24.45 1.8
+    endloop
+  endfacet
+  facet normal 0.097928 0.995194 0
+    outer loop
+      vertex 54.4561 24.474 1.8
+      vertex 54.7 24.45 0
+      vertex 54.4561 24.474 0
+    endloop
+  endfacet
+  facet normal -0.773084 0.634304 0
+    outer loop
+      vertex 55.5839 24.8161 0
+      vertex 55.7393 25.0055 1.8
+      vertex 55.7393 25.0055 0
+    endloop
+  endfacet
+  facet normal -0.773084 0.634304 0
+    outer loop
+      vertex 55.7393 25.0055 1.8
+      vertex 55.5839 24.8161 0
+      vertex 55.5839 24.8161 1.8
+    endloop
+  endfacet
+  facet normal 0.471372 0.881935 -0
+    outer loop
+      vertex 54.2216 24.5452 0
+      vertex 54.0055 24.6607 1.8
+      vertex 54.2216 24.5452 1.8
+    endloop
+  endfacet
+  facet normal 0.471372 0.881935 0
+    outer loop
+      vertex 54.0055 24.6607 1.8
+      vertex 54.2216 24.5452 0
+      vertex 54.0055 24.6607 0
+    endloop
+  endfacet
+  facet normal -0.471372 0.881935 0
+    outer loop
+      vertex 55.3945 24.6607 0
+      vertex 55.1784 24.5452 1.8
+      vertex 55.3945 24.6607 1.8
+    endloop
+  endfacet
+  facet normal -0.471372 0.881935 0
+    outer loop
+      vertex 55.1784 24.5452 1.8
+      vertex 55.3945 24.6607 0
+      vertex 55.1784 24.5452 0
+    endloop
+  endfacet
+  facet normal -0.290528 0.956866 0
+    outer loop
+      vertex 55.1784 24.5452 0
+      vertex 54.9439 24.474 1.8
+      vertex 55.1784 24.5452 1.8
+    endloop
+  endfacet
+  facet normal -0.290528 0.956866 0
+    outer loop
+      vertex 54.9439 24.474 1.8
+      vertex 55.1784 24.5452 0
+      vertex 54.9439 24.474 0
+    endloop
+  endfacet
+  facet normal -0.634304 0.773084 0
+    outer loop
+      vertex 55.5839 24.8161 0
+      vertex 55.3945 24.6607 1.8
+      vertex 55.5839 24.8161 1.8
+    endloop
+  endfacet
+  facet normal -0.634304 0.773084 0
+    outer loop
+      vertex 55.3945 24.6607 1.8
+      vertex 55.5839 24.8161 0
+      vertex 55.3945 24.6607 0
+    endloop
+  endfacet
+  facet normal -0.95698 0.290155 0
+    outer loop
+      vertex 55.8549 25.2216 0
+      vertex 55.926 25.4561 1.8
+      vertex 55.926 25.4561 0
+    endloop
+  endfacet
+  facet normal -0.95698 0.290155 0
+    outer loop
+      vertex 55.926 25.4561 1.8
+      vertex 55.8549 25.2216 0
+      vertex 55.8549 25.2216 1.8
+    endloop
+  endfacet
+  facet normal 0.634304 0.773084 -0
+    outer loop
+      vertex 54.0055 24.6607 0
+      vertex 53.8161 24.8161 1.8
+      vertex 54.0055 24.6607 1.8
+    endloop
+  endfacet
+  facet normal 0.634304 0.773084 0
+    outer loop
+      vertex 53.8161 24.8161 1.8
+      vertex 54.0055 24.6607 0
+      vertex 53.8161 24.8161 0
+    endloop
+  endfacet
+  facet normal -0.881765 0.471689 0
+    outer loop
+      vertex 55.7393 25.0055 0
+      vertex 55.8549 25.2216 1.8
+      vertex 55.8549 25.2216 0
+    endloop
+  endfacet
+  facet normal -0.881765 0.471689 0
+    outer loop
+      vertex 55.8549 25.2216 1.8
+      vertex 55.7393 25.0055 0
+      vertex 55.7393 25.0055 1.8
+    endloop
+  endfacet
+  facet normal 0.773084 0.634304 0
+    outer loop
+      vertex 53.8161 24.8161 1.8
+      vertex 53.6607 25.0055 0
+      vertex 53.6607 25.0055 1.8
+    endloop
+  endfacet
+  facet normal 0.773084 0.634304 0
+    outer loop
+      vertex 53.6607 25.0055 0
+      vertex 53.8161 24.8161 1.8
+      vertex 53.8161 24.8161 0
+    endloop
+  endfacet
+  facet normal -0.097928 0.995194 0
+    outer loop
+      vertex 54.9439 24.474 0
+      vertex 54.7 24.45 1.8
+      vertex 54.9439 24.474 1.8
+    endloop
+  endfacet
+  facet normal -0.097928 0.995194 0
+    outer loop
+      vertex 54.7 24.45 1.8
+      vertex 54.9439 24.474 0
+      vertex 54.7 24.45 0
+    endloop
+  endfacet
+  facet normal -0.881935 -0.471372 0
+    outer loop
+      vertex 49.5048 26.1784 0
+      vertex 49.3893 26.3945 1.8
+      vertex 49.3893 26.3945 0
+    endloop
+  endfacet
+  facet normal -0.881935 -0.471372 0
+    outer loop
+      vertex 49.3893 26.3945 1.8
+      vertex 49.5048 26.1784 0
+      vertex 49.5048 26.1784 1.8
+    endloop
+  endfacet
+  facet normal -0.097928 -0.995194 0
+    outer loop
+      vertex 48.35 26.95 0
+      vertex 48.5939 26.926 1.8
+      vertex 48.35 26.95 1.8
+    endloop
+  endfacet
+  facet normal -0.097928 -0.995194 -0
+    outer loop
+      vertex 48.5939 26.926 1.8
+      vertex 48.35 26.95 0
+      vertex 48.5939 26.926 0
+    endloop
+  endfacet
+  facet normal 0.881935 -0.471372 0
+    outer loop
+      vertex 47.1952 26.1784 1.8
+      vertex 47.3107 26.3945 0
+      vertex 47.3107 26.3945 1.8
+    endloop
+  endfacet
+  facet normal 0.881935 -0.471372 0
+    outer loop
+      vertex 47.3107 26.3945 0
+      vertex 47.1952 26.1784 1.8
+      vertex 47.1952 26.1784 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.1 25.7 1.8
+      vertex 49.6 25.7 1.8
+      vertex 49.6 23.5 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 49.6 25.7 1.8
+      vertex 47.1 25.7 1.8
+      vertex 49.576 25.9439 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 49.576 25.9439 1.8
+      vertex 47.1 25.7 1.8
+      vertex 49.5048 26.1784 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 49.5048 26.1784 1.8
+      vertex 47.1 25.7 1.8
+      vertex 49.3893 26.3945 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 49.3893 26.3945 1.8
+      vertex 47.1 25.7 1.8
+      vertex 49.2339 26.5839 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 49.2339 26.5839 1.8
+      vertex 47.1 25.7 1.8
+      vertex 49.0445 26.7393 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 49.0445 26.7393 1.8
+      vertex 47.1 25.7 1.8
+      vertex 48.8284 26.8549 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 48.8284 26.8549 1.8
+      vertex 47.1 25.7 1.8
+      vertex 48.5939 26.926 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 48.5939 26.926 1.8
+      vertex 47.1 25.7 1.8
+      vertex 48.35 26.95 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.35 26.95 1.8
+      vertex 47.1 25.7 1.8
+      vertex 48.1061 26.926 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 48.1061 26.926 1.8
+      vertex 47.1 25.7 1.8
+      vertex 47.8716 26.8549 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.8716 26.8549 1.8
+      vertex 47.1 25.7 1.8
+      vertex 47.6555 26.7393 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.6555 26.7393 1.8
+      vertex 47.1 25.7 1.8
+      vertex 47.4661 26.5839 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.4661 26.5839 1.8
+      vertex 47.1 25.7 1.8
+      vertex 47.3107 26.3945 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.3107 26.3945 1.8
+      vertex 47.1 25.7 1.8
+      vertex 47.1952 26.1784 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.1 25.7 1.8
+      vertex 49.6 23.5 1.8
+      vertex 47.1 23.5 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 47.1952 26.1784 1.8
+      vertex 47.1 25.7 1.8
+      vertex 47.124 25.9439 1.8
+    endloop
+  endfacet
+  facet normal 0.290155 -0.95698 0
+    outer loop
+      vertex 47.8716 26.8549 0
+      vertex 48.1061 26.926 1.8
+      vertex 47.8716 26.8549 1.8
+    endloop
+  endfacet
+  facet normal 0.290155 -0.95698 0
+    outer loop
+      vertex 48.1061 26.926 1.8
+      vertex 47.8716 26.8549 0
+      vertex 48.1061 26.926 0
+    endloop
+  endfacet
+  facet normal -0.290155 -0.95698 0
+    outer loop
+      vertex 48.5939 26.926 0
+      vertex 48.8284 26.8549 1.8
+      vertex 48.5939 26.926 1.8
+    endloop
+  endfacet
+  facet normal -0.290155 -0.95698 -0
+    outer loop
+      vertex 48.8284 26.8549 1.8
+      vertex 48.5939 26.926 0
+      vertex 48.8284 26.8549 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 47.1 23.5 1.8
+      vertex 47.1 25.7 0
+      vertex 47.1 25.7 1.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 47.1 25.7 0
+      vertex 47.1 23.5 1.8
+      vertex 47.1 23.5 0
+    endloop
+  endfacet
+  facet normal 0.471689 -0.881765 0
+    outer loop
+      vertex 47.6555 26.7393 0
+      vertex 47.8716 26.8549 1.8
+      vertex 47.6555 26.7393 1.8
+    endloop
+  endfacet
+  facet normal 0.471689 -0.881765 0
+    outer loop
+      vertex 47.8716 26.8549 1.8
+      vertex 47.6555 26.7393 0
+      vertex 47.8716 26.8549 0
+    endloop
+  endfacet
+  facet normal 0.097928 -0.995194 0
+    outer loop
+      vertex 48.1061 26.926 0
+      vertex 48.35 26.95 1.8
+      vertex 48.1061 26.926 1.8
+    endloop
+  endfacet
+  facet normal 0.097928 -0.995194 0
+    outer loop
+      vertex 48.35 26.95 1.8
+      vertex 48.1061 26.926 0
+      vertex 48.35 26.95 0
+    endloop
+  endfacet
+  facet normal -0.471689 -0.881765 0
+    outer loop
+      vertex 48.8284 26.8549 0
+      vertex 49.0445 26.7393 1.8
+      vertex 48.8284 26.8549 1.8
+    endloop
+  endfacet
+  facet normal -0.471689 -0.881765 -0
+    outer loop
+      vertex 49.0445 26.7393 1.8
+      vertex 48.8284 26.8549 0
+      vertex 49.0445 26.7393 0
+    endloop
+  endfacet
+  facet normal 0.995194 -0.097928 0
+    outer loop
+      vertex 47.1 25.7 1.8
+      vertex 47.124 25.9439 0
+      vertex 47.124 25.9439 1.8
+    endloop
+  endfacet
+  facet normal 0.995194 -0.097928 0
+    outer loop
+      vertex 47.124 25.9439 0
+      vertex 47.1 25.7 1.8
+      vertex 47.1 25.7 0
+    endloop
+  endfacet
+  facet normal -0.773084 -0.634304 0
+    outer loop
+      vertex 49.3893 26.3945 0
+      vertex 49.2339 26.5839 1.8
+      vertex 49.2339 26.5839 0
+    endloop
+  endfacet
+  facet normal -0.773084 -0.634304 0
+    outer loop
+      vertex 49.2339 26.5839 1.8
+      vertex 49.3893 26.3945 0
+      vertex 49.3893 26.3945 1.8
+    endloop
+  endfacet
+  facet normal 0.773084 -0.634304 0
+    outer loop
+      vertex 47.3107 26.3945 1.8
+      vertex 47.4661 26.5839 0
+      vertex 47.4661 26.5839 1.8
+    endloop
+  endfacet
+  facet normal 0.773084 -0.634304 0
+    outer loop
+      vertex 47.4661 26.5839 0
+      vertex 47.3107 26.3945 1.8
+      vertex 47.3107 26.3945 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 49.6 23.5 0
+      vertex 49.6 25.7 1.8
+      vertex 49.6 25.7 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 49.6 25.7 1.8
+      vertex 49.6 23.5 0
+      vertex 49.6 23.5 1.8
+    endloop
+  endfacet
+  facet normal 0.634304 -0.773084 0
+    outer loop
+      vertex 47.4661 26.5839 0
+      vertex 47.6555 26.7393 1.8
+      vertex 47.4661 26.5839 1.8
+    endloop
+  endfacet
+  facet normal 0.634304 -0.773084 0
+    outer loop
+      vertex 47.6555 26.7393 1.8
+      vertex 47.4661 26.5839 0
+      vertex 47.6555 26.7393 0
+    endloop
+  endfacet
+  facet normal -0.956866 -0.290528 0
+    outer loop
+      vertex 49.576 25.9439 0
+      vertex 49.5048 26.1784 1.8
+      vertex 49.5048 26.1784 0
+    endloop
+  endfacet
+  facet normal -0.956866 -0.290528 0
+    outer loop
+      vertex 49.5048 26.1784 1.8
+      vertex 49.576 25.9439 0
+      vertex 49.576 25.9439 1.8
+    endloop
+  endfacet
+  facet normal -0.995194 -0.097928 0
+    outer loop
+      vertex 49.6 25.7 0
+      vertex 49.576 25.9439 1.8
+      vertex 49.576 25.9439 0
+    endloop
+  endfacet
+  facet normal -0.995194 -0.097928 0
+    outer loop
+      vertex 49.576 25.9439 1.8
+      vertex 49.6 25.7 0
+      vertex 49.6 25.7 1.8
+    endloop
+  endfacet
+  facet normal -0.634304 -0.773084 0
+    outer loop
+      vertex 49.0445 26.7393 0
+      vertex 49.2339 26.5839 1.8
+      vertex 49.0445 26.7393 1.8
+    endloop
+  endfacet
+  facet normal -0.634304 -0.773084 -0
+    outer loop
+      vertex 49.2339 26.5839 1.8
+      vertex 49.0445 26.7393 0
+      vertex 49.2339 26.5839 0
+    endloop
+  endfacet
+  facet normal 0.956866 -0.290528 0
+    outer loop
+      vertex 47.124 25.9439 1.8
+      vertex 47.1952 26.1784 0
+      vertex 47.1952 26.1784 1.8
+    endloop
+  endfacet
+  facet normal 0.956866 -0.290528 0
+    outer loop
+      vertex 47.1952 26.1784 0
+      vertex 47.124 25.9439 1.8
+      vertex 47.124 25.9439 0
+    endloop
+  endfacet
+  facet normal 0.290267 0.956946 -0
+    outer loop
+      vertex 33.7561 2.77402 0
+      vertex 33.5216 2.84515 1.8
+      vertex 33.7561 2.77402 1.8
+    endloop
+  endfacet
+  facet normal 0.290267 0.956946 0
+    outer loop
+      vertex 33.5216 2.84515 1.8
+      vertex 33.7561 2.77402 0
+      vertex 33.5216 2.84515 0
+    endloop
+  endfacet
+  facet normal 0.995192 0.0979439 0
+    outer loop
+      vertex 32.774 3.75614 1.8
+      vertex 32.75 4 0
+      vertex 32.75 4 1.8
+    endloop
+  endfacet
+  facet normal 0.995192 0.0979439 0
+    outer loop
+      vertex 32.75 4 0
+      vertex 32.774 3.75614 1.8
+      vertex 32.774 3.75614 0
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 44.16 2.75 0
+      vertex 34 2.75 1.8
+      vertex 44.16 2.75 1.8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 34 2.75 1.8
+      vertex 44.16 2.75 0
+      vertex 34 2.75 0
+    endloop
+  endfacet
+  facet normal -0.0980088 0.995186 0
+    outer loop
+      vertex 44.4039 2.77402 0
+      vertex 44.16 2.75 1.8
+      vertex 44.4039 2.77402 1.8
+    endloop
+  endfacet
+  facet normal -0.0980088 0.995186 0
+    outer loop
+      vertex 44.16 2.75 1.8
+      vertex 44.4039 2.77402 0
+      vertex 44.16 2.75 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 45.41 4 0
+      vertex 45.41 6.5 1.8
+      vertex 45.41 6.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 45.41 6.5 1.8
+      vertex 45.41 4 0
+      vertex 45.41 4 1.8
+    endloop
+  endfacet
+  facet normal 0.881774 0.471672 0
+    outer loop
+      vertex 32.9607 3.30554 1.8
+      vertex 32.8451 3.52165 0
+      vertex 32.8451 3.52165 1.8
+    endloop
+  endfacet
+  facet normal 0.881774 0.471672 0
+    outer loop
+      vertex 32.8451 3.52165 0
+      vertex 32.9607 3.30554 1.8
+      vertex 32.9607 3.30554 0
+    endloop
+  endfacet
+  facet normal -0.995192 0.0979439 0
+    outer loop
+      vertex 45.386 3.75614 0
+      vertex 45.41 4 1.8
+      vertex 45.41 4 0
+    endloop
+  endfacet
+  facet normal -0.995192 0.0979439 0
+    outer loop
+      vertex 45.41 4 1.8
+      vertex 45.386 3.75614 0
+      vertex 45.386 3.75614 1.8
+    endloop
+  endfacet
+  facet normal -0.773116 0.634264 0
+    outer loop
+      vertex 45.0439 3.11612 0
+      vertex 45.1993 3.30554 1.8
+      vertex 45.1993 3.30554 0
+    endloop
+  endfacet
+  facet normal -0.773116 0.634264 0
+    outer loop
+      vertex 45.1993 3.30554 1.8
+      vertex 45.0439 3.11612 0
+      vertex 45.0439 3.11612 1.8
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 32.75 4 1.8
+      vertex 32.75 6.5 0
+      vertex 32.75 6.5 1.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 32.75 6.5 0
+      vertex 32.75 4 1.8
+      vertex 32.75 4 0
+    endloop
+  endfacet
+  facet normal 0.0980088 0.995186 -0
+    outer loop
+      vertex 34 2.75 0
+      vertex 33.7561 2.77402 1.8
+      vertex 34 2.75 1.8
+    endloop
+  endfacet
+  facet normal 0.0980088 0.995186 0
+    outer loop
+      vertex 33.7561 2.77402 1.8
+      vertex 34 2.75 0
+      vertex 33.7561 2.77402 0
+    endloop
+  endfacet
+  facet normal 0.63445 0.772964 -0
+    outer loop
+      vertex 33.3055 2.96066 0
+      vertex 33.1161 3.11612 1.8
+      vertex 33.3055 2.96066 1.8
+    endloop
+  endfacet
+  facet normal 0.63445 0.772964 0
+    outer loop
+      vertex 33.1161 3.11612 1.8
+      vertex 33.3055 2.96066 0
+      vertex 33.1161 3.11612 0
+    endloop
+  endfacet
+  facet normal -0.956863 0.29054 0
+    outer loop
+      vertex 45.3148 3.52165 0
+      vertex 45.386 3.75614 1.8
+      vertex 45.386 3.75614 0
+    endloop
+  endfacet
+  facet normal -0.956863 0.29054 0
+    outer loop
+      vertex 45.386 3.75614 1.8
+      vertex 45.3148 3.52165 0
+      vertex 45.3148 3.52165 1.8
+    endloop
+  endfacet
+  facet normal -0.290267 0.956946 0
+    outer loop
+      vertex 44.6384 2.84515 0
+      vertex 44.4039 2.77402 1.8
+      vertex 44.6384 2.84515 1.8
+    endloop
+  endfacet
+  facet normal -0.290267 0.956946 0
+    outer loop
+      vertex 44.4039 2.77402 1.8
+      vertex 44.6384 2.84515 0
+      vertex 44.4039 2.77402 0
+    endloop
+  endfacet
+  facet normal 0.956976 0.290166 0
+    outer loop
+      vertex 32.8451 3.52165 1.8
+      vertex 32.774 3.75614 0
+      vertex 32.774 3.75614 1.8
+    endloop
+  endfacet
+  facet normal 0.956976 0.290166 0
+    outer loop
+      vertex 32.774 3.75614 0
+      vertex 32.8451 3.52165 1.8
+      vertex 32.8451 3.52165 0
+    endloop
+  endfacet
+  facet normal -0.63445 0.772964 0
+    outer loop
+      vertex 45.0439 3.11612 0
+      vertex 44.8545 2.96066 1.8
+      vertex 45.0439 3.11612 1.8
+    endloop
+  endfacet
+  facet normal -0.63445 0.772964 0
+    outer loop
+      vertex 44.8545 2.96066 1.8
+      vertex 45.0439 3.11612 0
+      vertex 44.8545 2.96066 0
+    endloop
+  endfacet
+  facet normal -0.881944 0.471355 0
+    outer loop
+      vertex 45.1993 3.30554 0
+      vertex 45.3148 3.52165 1.8
+      vertex 45.3148 3.52165 0
+    endloop
+  endfacet
+  facet normal -0.881944 0.471355 0
+    outer loop
+      vertex 45.3148 3.52165 1.8
+      vertex 45.1993 3.30554 0
+      vertex 45.1993 3.30554 1.8
+    endloop
+  endfacet
+  facet normal 0.773116 0.634264 0
+    outer loop
+      vertex 33.1161 3.11612 1.8
+      vertex 32.9607 3.30554 0
+      vertex 32.9607 3.30554 1.8
+    endloop
+  endfacet
+  facet normal 0.773116 0.634264 0
+    outer loop
+      vertex 32.9607 3.30554 0
+      vertex 33.1161 3.11612 1.8
+      vertex 33.1161 3.11612 0
+    endloop
+  endfacet
+  facet normal -0.471404 0.881918 0
+    outer loop
+      vertex 44.8545 2.96066 0
+      vertex 44.6384 2.84515 1.8
+      vertex 44.8545 2.96066 1.8
+    endloop
+  endfacet
+  facet normal -0.471404 0.881918 0
+    outer loop
+      vertex 44.6384 2.84515 1.8
+      vertex 44.8545 2.96066 0
+      vertex 44.6384 2.84515 0
+    endloop
+  endfacet
+  facet normal 0.471404 0.881918 -0
+    outer loop
+      vertex 33.5216 2.84515 0
+      vertex 33.3055 2.96066 1.8
+      vertex 33.5216 2.84515 1.8
+    endloop
+  endfacet
+  facet normal 0.471404 0.881918 0
+    outer loop
+      vertex 33.3055 2.96066 1.8
+      vertex 33.5216 2.84515 0
+      vertex 33.3055 2.96066 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.16 2.75 1.8
+      vertex 45.41 4 1.8
+      vertex 45.386 3.75614 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.16 2.75 1.8
+      vertex 45.386 3.75614 1.8
+      vertex 45.3148 3.52165 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.16 2.75 1.8
+      vertex 45.3148 3.52165 1.8
+      vertex 45.1993 3.30554 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.16 2.75 1.8
+      vertex 45.1993 3.30554 1.8
+      vertex 45.0439 3.11612 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.16 2.75 1.8
+      vertex 45.0439 3.11612 1.8
+      vertex 44.8545 2.96066 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.16 2.75 1.8
+      vertex 44.8545 2.96066 1.8
+      vertex 44.6384 2.84515 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 44.16 2.75 1.8
+      vertex 44.6384 2.84515 1.8
+      vertex 44.4039 2.77402 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 45.41 4 1.8
+      vertex 44.16 2.75 1.8
+      vertex 45.41 6.5 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34 2.75 1.8
+      vertex 45.41 6.5 1.8
+      vertex 44.16 2.75 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.75 4 1.8
+      vertex 34 2.75 1.8
+      vertex 33.7561 2.77402 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.75 4 1.8
+      vertex 33.7561 2.77402 1.8
+      vertex 33.5216 2.84515 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.75 4 1.8
+      vertex 33.5216 2.84515 1.8
+      vertex 33.3055 2.96066 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.75 4 1.8
+      vertex 33.3055 2.96066 1.8
+      vertex 33.1161 3.11612 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.75 4 1.8
+      vertex 33.1161 3.11612 1.8
+      vertex 32.9607 3.30554 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.75 4 1.8
+      vertex 32.9607 3.30554 1.8
+      vertex 32.8451 3.52165 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 32.75 4 1.8
+      vertex 32.8451 3.52165 1.8
+      vertex 32.774 3.75614 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34 2.75 1.8
+      vertex 32.75 4 1.8
+      vertex 32.75 6.5 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 34 2.75 1.8
+      vertex 32.75 6.5 1.8
+      vertex 45.41 6.5 1.8
+    endloop
+  endfacet
+  facet normal -0.77297 0.634443 0
+    outer loop
+      vertex 0.883883 20.7161 0
+      vertex 1.03934 20.9055 1.8
+      vertex 1.03934 20.9055 0
+    endloop
+  endfacet
+  facet normal -0.77297 0.634443 0
+    outer loop
+      vertex 1.03934 20.9055 1.8
+      vertex 0.883883 20.7161 0
+      vertex 0.883883 20.7161 1.8
+    endloop
+  endfacet
+  facet normal -0.634264 -0.773116 0
+    outer loop
+      vertex 0.694463 25.1793 0
+      vertex 0.883883 25.0239 1.8
+      vertex 0.694463 25.1793 1.8
+    endloop
+  endfacet
+  facet normal -0.634264 -0.773116 -0
+    outer loop
+      vertex 0.883883 25.0239 1.8
+      vertex 0.694463 25.1793 0
+      vertex 0.883883 25.0239 0
+    endloop
+  endfacet
+  facet normal -0.471599 -0.881813 0
+    outer loop
+      vertex 0.5 25.2833 0
+      vertex 0.694463 25.1793 1.8
+      vertex 0.5 25.2833 1.8
+    endloop
+  endfacet
+  facet normal -0.471599 -0.881813 -0
+    outer loop
+      vertex 0.694463 25.1793 1.8
+      vertex 0.5 25.2833 0
+      vertex 0.694463 25.1793 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 20.4567 1.8
+      vertex 1.25 21.6 1.8
+      vertex 1.22598 21.3561 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 1.25 21.6 1.8
+      vertex 0.5 20.4567 1.8
+      vertex 1.25 24.14 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 20.4567 1.8
+      vertex 1.22598 21.3561 1.8
+      vertex 1.15485 21.1216 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 25.2833 1.8
+      vertex 1.25 24.14 1.8
+      vertex 0.5 20.4567 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 20.4567 1.8
+      vertex 1.15485 21.1216 1.8
+      vertex 1.03934 20.9055 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.25 24.14 1.8
+      vertex 0.5 25.2833 1.8
+      vertex 1.22598 24.3839 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 20.4567 1.8
+      vertex 1.03934 20.9055 1.8
+      vertex 0.883883 20.7161 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.22598 24.3839 1.8
+      vertex 0.5 25.2833 1.8
+      vertex 1.15485 24.6184 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 20.4567 1.8
+      vertex 0.883883 20.7161 1.8
+      vertex 0.694463 20.5607 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.15485 24.6184 1.8
+      vertex 0.5 25.2833 1.8
+      vertex 1.03934 24.8345 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.03934 24.8345 1.8
+      vertex 0.5 25.2833 1.8
+      vertex 0.883883 25.0239 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.883883 25.0239 1.8
+      vertex 0.5 25.2833 1.8
+      vertex 0.694463 25.1793 1.8
+    endloop
+  endfacet
+  facet normal -0.956946 0.290267 0
+    outer loop
+      vertex 1.15485 21.1216 0
+      vertex 1.22598 21.3561 1.8
+      vertex 1.22598 21.3561 0
+    endloop
+  endfacet
+  facet normal -0.956946 0.290267 0
+    outer loop
+      vertex 1.22598 21.3561 1.8
+      vertex 1.15485 21.1216 0
+      vertex 1.15485 21.1216 1.8
+    endloop
+  endfacet
+  facet normal -0.881918 0.471404 0
+    outer loop
+      vertex 1.03934 20.9055 0
+      vertex 1.15485 21.1216 1.8
+      vertex 1.15485 21.1216 0
+    endloop
+  endfacet
+  facet normal -0.881918 0.471404 0
+    outer loop
+      vertex 1.15485 21.1216 1.8
+      vertex 1.03934 20.9055 0
+      vertex 1.03934 20.9055 1.8
+    endloop
+  endfacet
+  facet normal -0.956946 -0.290267 0
+    outer loop
+      vertex 1.22598 24.3839 0
+      vertex 1.15485 24.6184 1.8
+      vertex 1.15485 24.6184 0
+    endloop
+  endfacet
+  facet normal -0.956946 -0.290267 0
+    outer loop
+      vertex 1.15485 24.6184 1.8
+      vertex 1.22598 24.3839 0
+      vertex 1.22598 24.3839 1.8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 1.25 21.6 0
+      vertex 1.25 24.14 1.8
+      vertex 1.25 24.14 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 1.25 24.14 1.8
+      vertex 1.25 21.6 0
+      vertex 1.25 21.6 1.8
+    endloop
+  endfacet
+  facet normal -0.995186 -0.0980088 0
+    outer loop
+      vertex 1.25 24.14 0
+      vertex 1.22598 24.3839 1.8
+      vertex 1.22598 24.3839 0
+    endloop
+  endfacet
+  facet normal -0.995186 -0.0980088 0
+    outer loop
+      vertex 1.22598 24.3839 1.8
+      vertex 1.25 24.14 0
+      vertex 1.25 24.14 1.8
+    endloop
+  endfacet
+  facet normal -0.471599 0.881813 0
+    outer loop
+      vertex 0.694463 20.5607 0
+      vertex 0.5 20.4567 1.8
+      vertex 0.694463 20.5607 1.8
+    endloop
+  endfacet
+  facet normal -0.471599 0.881813 0
+    outer loop
+      vertex 0.5 20.4567 1.8
+      vertex 0.694463 20.5607 0
+      vertex 0.5 20.4567 0
+    endloop
+  endfacet
+  facet normal -0.634264 0.773116 0
+    outer loop
+      vertex 0.883883 20.7161 0
+      vertex 0.694463 20.5607 1.8
+      vertex 0.883883 20.7161 1.8
+    endloop
+  endfacet
+  facet normal -0.634264 0.773116 0
+    outer loop
+      vertex 0.694463 20.5607 1.8
+      vertex 0.883883 20.7161 0
+      vertex 0.694463 20.5607 0
+    endloop
+  endfacet
+  facet normal -0.77297 -0.634443 0
+    outer loop
+      vertex 1.03934 24.8345 0
+      vertex 0.883883 25.0239 1.8
+      vertex 0.883883 25.0239 0
+    endloop
+  endfacet
+  facet normal -0.77297 -0.634443 0
+    outer loop
+      vertex 0.883883 25.0239 1.8
+      vertex 1.03934 24.8345 0
+      vertex 1.03934 24.8345 1.8
+    endloop
+  endfacet
+  facet normal -0.881918 -0.471404 0
+    outer loop
+      vertex 1.15485 24.6184 0
+      vertex 1.03934 24.8345 1.8
+      vertex 1.03934 24.8345 0
+    endloop
+  endfacet
+  facet normal -0.881918 -0.471404 0
+    outer loop
+      vertex 1.03934 24.8345 1.8
+      vertex 1.15485 24.6184 0
+      vertex 1.15485 24.6184 1.8
+    endloop
+  endfacet
+  facet normal -0.995186 0.0980088 0
+    outer loop
+      vertex 1.22598 21.3561 0
+      vertex 1.25 21.6 1.8
+      vertex 1.25 21.6 0
+    endloop
+  endfacet
+  facet normal -0.995186 0.0980088 0
+    outer loop
+      vertex 1.25 21.6 1.8
+      vertex 1.22598 21.3561 0
+      vertex 1.22598 21.3561 1.8
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.5 12.79 0
+      vertex 6.5 12.79 1.8
+      vertex 0.5 12.79 1.8
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 6.5 12.79 1.8
+      vertex 0.5 12.79 0
+      vertex 6.5 12.79 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.5 7.75 1.8
+      vertex 6.5 12.79 1.8
+      vertex 6.5 7.75 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 6.5 12.79 1.8
+      vertex 0.5 7.75 1.8
+      vertex 0.5 12.79 1.8
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 6.5 7.75 0
+      vertex 0.5 7.75 1.8
+      vertex 6.5 7.75 1.8
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.5 7.75 1.8
+      vertex 6.5 7.75 0
+      vertex 0.5 7.75 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 56.49 0.5 0
+      vertex 56.49 6.5 1.8
+      vertex 56.49 6.5 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 56.49 6.5 1.8
+      vertex 56.49 0.5 0
+      vertex 56.49 0.5 1.8
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 51.45 0.5 1.8
+      vertex 51.45 6.5 0
+      vertex 51.45 6.5 1.8
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 51.45 6.5 0
+      vertex 51.45 0.5 1.8
+      vertex 51.45 0.5 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 51.45 0.5 1.8
+      vertex 56.49 6.5 1.8
+      vertex 56.49 0.5 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 56.49 6.5 1.8
+      vertex 51.45 0.5 1.8
+      vertex 51.45 6.5 1.8
+    endloop
+  endfacet
+  facet normal -0.772996 -0.63441 0
+    outer loop
+      vertex 4.63934 2.93446 0
+      vertex 4.48388 3.12388 1.8
+      vertex 4.48388 3.12388 0
+    endloop
+  endfacet
+  facet normal -0.772996 -0.63441 0
+    outer loop
+      vertex 4.48388 3.12388 1.8
+      vertex 4.63934 2.93446 0
+      vertex 4.63934 2.93446 1.8
+    endloop
+  endfacet
+  facet normal -0.995184 -0.0980248 0
+    outer loop
+      vertex 4.85 2.24 0
+      vertex 4.82598 2.48386 1.8
+      vertex 4.82598 2.48386 0
+    endloop
+  endfacet
+  facet normal -0.995184 -0.0980248 0
+    outer loop
+      vertex 4.82598 2.48386 1.8
+      vertex 4.85 2.24 0
+      vertex 4.85 2.24 1.8
+    endloop
+  endfacet
+  facet normal -0.956946 -0.290267 0
+    outer loop
+      vertex 4.82598 2.48386 0
+      vertex 4.75485 2.71836 1.8
+      vertex 4.75485 2.71836 0
+    endloop
+  endfacet
+  facet normal -0.956946 -0.290267 0
+    outer loop
+      vertex 4.75485 2.71836 1.8
+      vertex 4.82598 2.48386 0
+      vertex 4.82598 2.48386 1.8
+    endloop
+  endfacet
+  facet normal 0.47141 -0.881914 0
+    outer loop
+      vertex 0.513922 3.35865 0
+      vertex 0.581645 3.39485 1.8
+      vertex 0.513922 3.35865 1.8
+    endloop
+  endfacet
+  facet normal 0.47141 -0.881914 0
+    outer loop
+      vertex 0.581645 3.39485 1.8
+      vertex 0.513922 3.35865 0
+      vertex 0.581645 3.39485 0
+    endloop
+  endfacet
+  facet normal 0.0980232 -0.995184 0
+    outer loop
+      vertex 0.816136 3.46598 0
+      vertex 1.06 3.49 1.8
+      vertex 0.816136 3.46598 1.8
+    endloop
+  endfacet
+  facet normal 0.0980232 -0.995184 0
+    outer loop
+      vertex 1.06 3.49 1.8
+      vertex 0.816136 3.46598 0
+      vertex 1.06 3.49 0
+    endloop
+  endfacet
+  facet normal -0.881918 -0.471404 0
+    outer loop
+      vertex 4.75485 2.71836 0
+      vertex 4.63934 2.93446 1.8
+      vertex 4.63934 2.93446 0
+    endloop
+  endfacet
+  facet normal -0.881918 -0.471404 0
+    outer loop
+      vertex 4.63934 2.93446 1.8
+      vertex 4.75485 2.71836 0
+      vertex 4.75485 2.71836 1.8
+    endloop
+  endfacet
+  facet normal 0.290277 -0.956943 0
+    outer loop
+      vertex 0.581645 3.39485 0
+      vertex 0.816136 3.46598 1.8
+      vertex 0.581645 3.39485 1.8
+    endloop
+  endfacet
+  facet normal 0.290277 -0.956943 0
+    outer loop
+      vertex 0.816136 3.46598 1.8
+      vertex 0.581645 3.39485 0
+      vertex 0.816136 3.46598 0
+    endloop
+  endfacet
+  facet normal -0.0980248 -0.995184 0
+    outer loop
+      vertex 3.6 3.49 0
+      vertex 3.84386 3.46598 1.8
+      vertex 3.6 3.49 1.8
+    endloop
+  endfacet
+  facet normal -0.0980248 -0.995184 -0
+    outer loop
+      vertex 3.84386 3.46598 1.8
+      vertex 3.6 3.49 0
+      vertex 3.84386 3.46598 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 1.06 3.49 0
+      vertex 3.6 3.49 1.8
+      vertex 1.06 3.49 1.8
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 3.6 3.49 1.8
+      vertex 1.06 3.49 0
+      vertex 3.6 3.49 0
+    endloop
+  endfacet
+  facet normal -0.63441 -0.772996 0
+    outer loop
+      vertex 4.29446 3.27934 0
+      vertex 4.48388 3.12388 1.8
+      vertex 4.29446 3.27934 1.8
+    endloop
+  endfacet
+  facet normal -0.63441 -0.772996 -0
+    outer loop
+      vertex 4.48388 3.12388 1.8
+      vertex 4.29446 3.27934 0
+      vertex 4.48388 3.12388 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 3.5 0.5 1.8
+      vertex 4.85 2.24 1.8
+      vertex 4.85 0.5 1.8
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex 3.6 3.49 1.8
+      vertex 4.85 2.24 1.8
+      vertex 3.5 0.5 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.85 2.24 1.8
+      vertex 3.6 3.49 1.8
+      vertex 4.82598 2.48386 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.82598 2.48386 1.8
+      vertex 3.6 3.49 1.8
+      vertex 4.75485 2.71836 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.75485 2.71836 1.8
+      vertex 3.6 3.49 1.8
+      vertex 4.63934 2.93446 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.63934 2.93446 1.8
+      vertex 3.6 3.49 1.8
+      vertex 4.48388 3.12388 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.48388 3.12388 1.8
+      vertex 3.6 3.49 1.8
+      vertex 4.29446 3.27934 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.29446 3.27934 1.8
+      vertex 3.6 3.49 1.8
+      vertex 4.07835 3.39485 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 4.07835 3.39485 1.8
+      vertex 3.6 3.49 1.8
+      vertex 3.84386 3.46598 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.91473 0.557644 1.8
+      vertex 3.6 3.49 1.8
+      vertex 3.5 0.5 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2.35195 0.728361 1.8
+      vertex 3.6 3.49 1.8
+      vertex 2.91473 0.557644 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.83329 1.00559 1.8
+      vertex 3.6 3.49 1.8
+      vertex 2.35195 0.728361 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.37868 1.37868 1.8
+      vertex 3.6 3.49 1.8
+      vertex 1.83329 1.00559 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.00559 1.83329 1.8
+      vertex 3.6 3.49 1.8
+      vertex 1.37868 1.37868 1.8
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 3.6 3.49 1.8
+      vertex 1.00559 1.83329 1.8
+      vertex 1.06 3.49 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.728361 2.35195 1.8
+      vertex 1.06 3.49 1.8
+      vertex 1.00559 1.83329 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.557644 2.91473 1.8
+      vertex 1.06 3.49 1.8
+      vertex 0.728361 2.35195 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.06 3.49 1.8
+      vertex 0.557644 2.91473 1.8
+      vertex 0.816136 3.46598 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.816136 3.46598 1.8
+      vertex 0.557644 2.91473 1.8
+      vertex 0.581645 3.39485 1.8
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.581645 3.39485 1.8
+      vertex 0.557644 2.91473 1.8
+      vertex 0.513922 3.35865 1.8
+    endloop
+  endfacet
+  facet normal -0.290278 -0.956942 0
+    outer loop
+      vertex 3.84386 3.46598 0
+      vertex 4.07835 3.39485 1.8
+      vertex 3.84386 3.46598 1.8
+    endloop
+  endfacet
+  facet normal -0.290278 -0.956942 -0
+    outer loop
+      vertex 4.07835 3.39485 1.8
+      vertex 3.84386 3.46598 0
+      vertex 4.07835 3.39485 0
+    endloop
+  endfacet
+  facet normal -0.471387 -0.881927 0
+    outer loop
+      vertex 4.07835 3.39485 0
+      vertex 4.29446 3.27934 1.8
+      vertex 4.07835 3.39485 1.8
+    endloop
+  endfacet
+  facet normal -0.471387 -0.881927 -0
+    outer loop
+      vertex 4.29446 3.27934 1.8
+      vertex 4.07835 3.39485 0
+      vertex 4.29446 3.27934 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 4.85 0.5 0
+      vertex 4.85 2.24 1.8
+      vertex 4.85 2.24 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 4.85 2.24 1.8
+      vertex 4.85 0.5 0
+      vertex 4.85 0.5 1.8
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 18.5 23.5 1.1
+      vertex 18.5 29.5 2
+      vertex 18.5 29.5 1.1
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 18.5 29.5 2
+      vertex 18.5 23.5 1.1
+      vertex 18.5 23.5 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 6.5 29.5 1.1
+      vertex 18.5 23.5 1.1
+      vertex 18.5 29.5 1.1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 18.5 23.5 1.1
+      vertex 6.5 29.5 1.1
+      vertex 6.5 23.5 1.1
+    endloop
+  endfacet
+  facet normal -0.097938 0.995193 0
+    outer loop
+      vertex 59.6951 10.5192 2.7
+      vertex 59.5 10.5 3.3
+      vertex 59.6951 10.5192 3.3
+    endloop
+  endfacet
+  facet normal -0.097938 0.995193 0
+    outer loop
+      vertex 59.5 10.5 3.3
+      vertex 59.6951 10.5192 2.7
+      vertex 59.5 10.5 2.7
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 58.5 15.5 2.7
+      vertex 59.5 15.5 3.3
+      vertex 58.5 15.5 3.3
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 59.5 15.5 3.3
+      vertex 58.5 15.5 2.7
+      vertex 59.5 15.5 2.7
+    endloop
+  endfacet
+  facet normal -0.471329 0.881957 0
+    outer loop
+      vertex 60.0556 10.6685 2.7
+      vertex 59.8827 10.5761 3.3
+      vertex 60.0556 10.6685 3.3
+    endloop
+  endfacet
+  facet normal -0.471329 0.881957 0
+    outer loop
+      vertex 59.8827 10.5761 3.3
+      vertex 60.0556 10.6685 2.7
+      vertex 59.8827 10.5761 2.7
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 60.5 11.5 2.7
+      vertex 60.5 14.5 3.3
+      vertex 60.5 14.5 2.7
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 60.5 14.5 3.3
+      vertex 60.5 11.5 2.7
+      vertex 60.5 11.5 3.3
+    endloop
+  endfacet
+  facet normal -0.956951 0.290248 0
+    outer loop
+      vertex 60.4239 11.1173 2.7
+      vertex 60.4808 11.3049 3.3
+      vertex 60.4808 11.3049 2.7
+    endloop
+  endfacet
+  facet normal -0.956951 0.290248 0
+    outer loop
+      vertex 60.4808 11.3049 3.3
+      vertex 60.4239 11.1173 2.7
+      vertex 60.4239 11.1173 3.3
+    endloop
+  endfacet
+  facet normal -0.772842 0.634598 0
+    outer loop
+      vertex 60.2071 10.7929 2.7
+      vertex 60.3315 10.9444 3.3
+      vertex 60.3315 10.9444 2.7
+    endloop
+  endfacet
+  facet normal -0.772842 0.634598 0
+    outer loop
+      vertex 60.3315 10.9444 3.3
+      vertex 60.2071 10.7929 2.7
+      vertex 60.2071 10.7929 3.3
+    endloop
+  endfacet
+  facet normal -0.881957 0.471329 0
+    outer loop
+      vertex 60.3315 10.9444 2.7
+      vertex 60.4239 11.1173 3.3
+      vertex 60.4239 11.1173 2.7
+    endloop
+  endfacet
+  facet normal -0.881957 0.471329 0
+    outer loop
+      vertex 60.4239 11.1173 3.3
+      vertex 60.3315 10.9444 2.7
+      vertex 60.3315 10.9444 3.3
+    endloop
+  endfacet
+  facet normal -0.634598 0.772842 0
+    outer loop
+      vertex 60.2071 10.7929 2.7
+      vertex 60.0556 10.6685 3.3
+      vertex 60.2071 10.7929 3.3
+    endloop
+  endfacet
+  facet normal -0.634598 0.772842 0
+    outer loop
+      vertex 60.0556 10.6685 3.3
+      vertex 60.2071 10.7929 2.7
+      vertex 60.0556 10.6685 2.7
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 59.5 10.5 2.7
+      vertex 58.5 10.5 3.3
+      vertex 59.5 10.5 3.3
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 58.5 10.5 3.3
+      vertex 59.5 10.5 2.7
+      vertex 58.5 10.5 2.7
+    endloop
+  endfacet
+  facet normal -0.995193 -0.097938 0
+    outer loop
+      vertex 60.5 14.5 2.7
+      vertex 60.4808 14.6951 3.3
+      vertex 60.4808 14.6951 2.7
+    endloop
+  endfacet
+  facet normal -0.995193 -0.097938 0
+    outer loop
+      vertex 60.4808 14.6951 3.3
+      vertex 60.5 14.5 2.7
+      vertex 60.5 14.5 3.3
+    endloop
+  endfacet
+  facet normal -0.995193 0.097938 0
+    outer loop
+      vertex 60.4808 11.3049 2.7
+      vertex 60.5 11.5 3.3
+      vertex 60.5 11.5 2.7
+    endloop
+  endfacet
+  facet normal -0.995193 0.097938 0
+    outer loop
+      vertex 60.5 11.5 3.3
+      vertex 60.4808 11.3049 2.7
+      vertex 60.4808 11.3049 3.3
+    endloop
+  endfacet
+  facet normal -0.772842 -0.634598 0
+    outer loop
+      vertex 60.3315 15.0556 2.7
+      vertex 60.2071 15.2071 3.3
+      vertex 60.2071 15.2071 2.7
+    endloop
+  endfacet
+  facet normal -0.772842 -0.634598 0
+    outer loop
+      vertex 60.2071 15.2071 3.3
+      vertex 60.3315 15.0556 2.7
+      vertex 60.3315 15.0556 3.3
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5 15.5 2.7
+      vertex 60.5 14.5 2.7
+      vertex 60.4808 14.6951 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5 14.5 2.7
+      vertex 58.5 15.5 2.7
+      vertex 60.5 11.5 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5 15.5 2.7
+      vertex 60.4808 14.6951 2.7
+      vertex 60.4239 14.8827 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 58.5 10.5 2.7
+      vertex 60.5 11.5 2.7
+      vertex 58.5 15.5 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5 15.5 2.7
+      vertex 60.4239 14.8827 2.7
+      vertex 60.3315 15.0556 2.7
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 59.5 10.5 2.7
+      vertex 60.5 11.5 2.7
+      vertex 58.5 10.5 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5 15.5 2.7
+      vertex 60.3315 15.0556 2.7
+      vertex 60.2071 15.2071 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5 11.5 2.7
+      vertex 59.5 10.5 2.7
+      vertex 60.4808 11.3049 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5 15.5 2.7
+      vertex 60.2071 15.2071 2.7
+      vertex 60.0556 15.3315 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.5 14.5 2.7
+      vertex 59.5 15.5 2.7
+      vertex 58.5 15.5 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5 15.5 2.7
+      vertex 60.0556 15.3315 2.7
+      vertex 59.8827 15.4239 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4808 11.3049 2.7
+      vertex 59.5 10.5 2.7
+      vertex 60.4239 11.1173 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.5 15.5 2.7
+      vertex 59.8827 15.4239 2.7
+      vertex 59.6951 15.4808 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.2071 10.7929 2.7
+      vertex 59.5 10.5 2.7
+      vertex 60.0556 10.6685 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.0556 10.6685 2.7
+      vertex 59.5 10.5 2.7
+      vertex 59.8827 10.5761 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 59.8827 10.5761 2.7
+      vertex 59.5 10.5 2.7
+      vertex 59.6951 10.5192 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.4239 11.1173 2.7
+      vertex 59.5 10.5 2.7
+      vertex 60.3315 10.9444 2.7
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 60.3315 10.9444 2.7
+      vertex 59.5 10.5 2.7
+      vertex 60.2071 10.7929 2.7
+    endloop
+  endfacet
+  facet normal -0.881957 -0.471329 0
+    outer loop
+      vertex 60.4239 14.8827 2.7
+      vertex 60.3315 15.0556 3.3
+      vertex 60.3315 15.0556 2.7
+    endloop
+  endfacet
+  facet normal -0.881957 -0.471329 0
+    outer loop
+      vertex 60.3315 15.0556 3.3
+      vertex 60.4239 14.8827 2.7
+      vertex 60.4239 14.8827 3.3
+    endloop
+  endfacet
+  facet normal -0.471329 -0.881957 0
+    outer loop
+      vertex 59.8827 15.4239 2.7
+      vertex 60.0556 15.3315 3.3
+      vertex 59.8827 15.4239 3.3
+    endloop
+  endfacet
+  facet normal -0.471329 -0.881957 -0
+    outer loop
+      vertex 60.0556 15.3315 3.3
+      vertex 59.8827 15.4239 2.7
+      vertex 60.0556 15.3315 2.7
+    endloop
+  endfacet
+  facet normal -0.290248 0.956951 0
+    outer loop
+      vertex 59.8827 10.5761 2.7
+      vertex 59.6951 10.5192 3.3
+      vertex 59.8827 10.5761 3.3
+    endloop
+  endfacet
+  facet normal -0.290248 0.956951 0
+    outer loop
+      vertex 59.6951 10.5192 3.3
+      vertex 59.8827 10.5761 2.7
+      vertex 59.6951 10.5192 2.7
+    endloop
+  endfacet
+  facet normal -0.634598 -0.772842 0
+    outer loop
+      vertex 60.0556 15.3315 2.7
+      vertex 60.2071 15.2071 3.3
+      vertex 60.0556 15.3315 3.3
+    endloop
+  endfacet
+  facet normal -0.634598 -0.772842 -0
+    outer loop
+      vertex 60.2071 15.2071 3.3
+      vertex 60.0556 15.3315 2.7
+      vertex 60.2071 15.2071 2.7
+    endloop
+  endfacet
+  facet normal -0.290248 -0.956951 0
+    outer loop
+      vertex 59.6951 15.4808 2.7
+      vertex 59.8827 15.4239 3.3
+      vertex 59.6951 15.4808 3.3
+    endloop
+  endfacet
+  facet normal -0.290248 -0.956951 -0
+    outer loop
+      vertex 59.8827 15.4239 3.3
+      vertex 59.6951 15.4808 2.7
+      vertex 59.8827 15.4239 2.7
+    endloop
+  endfacet
+  facet normal -0.956951 -0.290248 0
+    outer loop
+      vertex 60.4808 14.6951 2.7
+      vertex 60.4239 14.8827 3.3
+      vertex 60.4239 14.8827 2.7
+    endloop
+  endfacet
+  facet normal -0.956951 -0.290248 0
+    outer loop
+      vertex 60.4239 14.8827 3.3
+      vertex 60.4808 14.6951 2.7
+      vertex 60.4808 14.6951 3.3
+    endloop
+  endfacet
+  facet normal -0.097938 -0.995193 0
+    outer loop
+      vertex 59.5 15.5 2.7
+      vertex 59.6951 15.4808 3.3
+      vertex 59.5 15.5 3.3
+    endloop
+  endfacet
+  facet normal -0.097938 -0.995193 -0
+    outer loop
+      vertex 59.6951 15.4808 3.3
+      vertex 59.5 15.5 2.7
+      vertex 59.6951 15.4808 2.7
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
The HDMI port slightly interferes with the original frame design, I would have edited the SCAD if it existed, but per https://github.com/prusa3d/Original-Prusa-i3/issues/132 it may have been lost, so I re-coded it fresh.