### PR TITLE
Update LCD-cover-ORIGINAL-MK3.scad

### DIFF
--- a/Printed-Parts/SCAD/LCD-cover-ORIGINAL-MK3.scad
+++ b/Printed-Parts/SCAD/LCD-cover-ORIGINAL-MK3.scad
@@ -152,13 +152,13 @@ difference()
     translate( [ 72.5 , 43.2 , 3 ] ) cylinder( h = 20, r = 1.4, $fn=30);  
     translate( [ -72.5 , 42.7 , 3 ] ) cylinder( h = 20, r = 1.4, $fn=30); 
     translate( [ 72.5 , 43.2 , 11.7 ] ) cylinder( h = 3, r1 = 1.4, r2=2.2, $fn=30);  
-    translate( [ -72.5 , 42.7 , 11.7 ] ) cylinder( h = 3, r = 1.4, r2=2.2, $fn=30); 
+    translate( [ -72.5 , 42.7 , 11.7 ] ) cylinder( h = 3, r1 = 1.4, r2=2.2, $fn=30); //OpenSCAD flagging as "cylinder parameters ambiguous" with r= and r2=
 
     // ORIGINAL PRUSA text
     translate([-67,51,0.6]) rotate([180,0,0]) linear_extrude(height = 2) 
-    { text("ORIGINAL",font = "helvetica:style=Bold", size=7, center=true); }
+    { text("ORIGINAL",font = "helvetica:style=Bold", size=7); } //OpenSCAD flagging "varible center not specified" (there is no center=true on text())
     translate([-18,51,0.6]) rotate([180,0,0]) linear_extrude(height = 2) 
-    { text("PRUSA",font = "helvetica:style=Bold", size=11, center=true); }
+    { text("PRUSA",font = "helvetica:style=Bold", size=11); } //OpenSCAD flagging "varible center not specified" (there is no center=true on text())
     translate( [ -66 , 40.5 , -0.4 ] )  cube( [ 45 , 1.6 , 1 ] );  
     translate( [ -66 , 41.3 , -0.4 ] ) cylinder( h = 1, r = 0.8, $fn=30);  
     translate( [ -21 , 41.3 , -0.4 ] ) cylinder( h = 1, r = 0.8, $fn=30);  
@@ -189,7 +189,7 @@ difference()
 
     // version
     translate([-73,15,4]) rotate([90,0,90]) linear_extrude(height = 2) 
-    { text("R2",font = "helvetica:style=Bold", size=7, center=true); }
+    { text("R2",font = "helvetica:style=Bold", size=7); } //OpenSCAD flagging "varible center not specified" (there is no center=true on text())
     
     
 }


### PR DESCRIPTION
removed "center=true" from text(), throws OpenSCAD error.  There is a way to align text using valign and halign if desired.

changed r to r1 on line 155, (typo?) OpenSCAD throwing error indicating cylinder parameters are ambiguous.