### PR TITLE
correct some warnings in the OpenSCAD code

### DIFF
--- a/Printed-Parts/SCAD/Einsy-base.scad
+++ b/Printed-Parts/SCAD/Einsy-base.scad
@@ -675,7 +675,7 @@ translate([-5.6,-0.4,0.35])  cube([15,4,0.75]);
 
 
     translate([115,68,1.5]) rotate([0,0,90]) linear_extrude(height = 0.8) 
-    { text("R3",font = "helvetica:style=Bold", size=6, center=true); }   
+    { text("R3",font = "helvetica:style=Bold", size=6); }   
        
 }
 

--- a/Printed-Parts/SCAD/Einsy-doors.scad
+++ b/Printed-Parts/SCAD/Einsy-doors.scad
@@ -42,11 +42,11 @@ module ventilation_holes()
         translate([40 + (i*6),10.5+25,-1]) cube([3.65,19,10]);
         translate([40 + (i*6),10.5+50,-1]) cube([3.65,19,10]);
     }
-    for ( i = [0 : -4] )
+    for ( i = [-4 : 0] )
     {
       translate([40 + (i*6),10.5,-1]) cube([3.65,19+50,1.2]);
     }
-    for ( i = [-6 : -7] )
+    for ( i = [-7 : -6] )
     {
       translate([46 + (i*6),20.5,-1]) cube([3.65,19+40,1.2]);
     }
@@ -112,7 +112,7 @@ difference()
     translate( [0 , -20, -3] ) rotate([0,45,45]) cube( [ 30, 30 , 20 ] );  
 
     translate([30,79,1]) rotate([0,0,-90]) linear_extrude(height = 0.8) 
-    { text("R1",font = "helvetica:style=Bold", size=6, center=true); }    
+    { text("R1",font = "helvetica:style=Bold", size=6); }    
 }
 }
  

--- a/Printed-Parts/SCAD/LCD-cover-ORIGINAL-MK3.scad
+++ b/Printed-Parts/SCAD/LCD-cover-ORIGINAL-MK3.scad
@@ -148,13 +148,13 @@ difference()
     translate( [ 72.5 , 43.2 , 3 ] ) cylinder( h = 20, r = 1.4, $fn=30);  
     translate( [ -72.5 , 42.7 , 3 ] ) cylinder( h = 20, r = 1.4, $fn=30); 
     translate( [ 72.5 , 43.2 , 11.7 ] ) cylinder( h = 3, r1 = 1.4, r2=2.2, $fn=30);  
-    translate( [ -72.5 , 42.7 , 11.7 ] ) cylinder( h = 3, r = 1.4, r2=2.2, $fn=30); 
+    translate( [ -72.5 , 42.7 , 11.7 ] ) cylinder( h = 3, r1 = 1.4, r2=2.2, $fn=30); 
 
     // ORIGINAL PRUSA text
     translate([-67,51,0.6]) rotate([180,0,0]) linear_extrude(height = 2) 
-    { text("ORIGINAL",font = "helvetica:style=Bold", size=7, center=true); }
+    { text("ORIGINAL",font = "helvetica:style=Bold", size=7); }
     translate([-18,51,0.6]) rotate([180,0,0]) linear_extrude(height = 2) 
-    { text("PRUSA",font = "helvetica:style=Bold", size=11, center=true); }
+    { text("PRUSA",font = "helvetica:style=Bold", size=11); }
     translate( [ -66 , 40.5 , -0.4 ] )  cube( [ 45 , 1.6 , 1 ] );  
     translate( [ -66 , 41.3 , -0.4 ] ) cylinder( h = 1, r = 0.8, $fn=30);  
     translate( [ -21 , 41.3 , -0.4 ] ) cylinder( h = 1, r = 0.8, $fn=30);  

--- a/Printed-Parts/SCAD/PSU-cover-MK3.scad
+++ b/Printed-Parts/SCAD/PSU-cover-MK3.scad
@@ -200,7 +200,7 @@ module upper_part()
         
         //version
         translate([73,7.5,1.5]) rotate([0,0,0]) linear_extrude(height = 0.6) 
-        { text("R1",font = "helvetica:style=Bold", size=6, center=true); }   
+        { text("R1",font = "helvetica:style=Bold", size=6); }   
     }
 
 
@@ -295,7 +295,7 @@ module lower_part()
     
     //version
     translate([10,3.6,20]) rotate([90,-90,180]) linear_extrude(height = 0.8) 
-    { text("R1",font = "helvetica:style=Bold", size=6, center=true); }    
+    { text("R1",font = "helvetica:style=Bold", size=6); }    
     }
 
 

--- a/Printed-Parts/SCAD/lcd-supports.scad
+++ b/Printed-Parts/SCAD/lcd-supports.scad
@@ -80,7 +80,7 @@ module support()
      
         // version
         translate([-20,2,9.5]) rotate([0,0,0]) linear_extrude(height = 0.6) 
-        { text("R1",font = "helvetica:style=Bold", size=5, center=true); }   
+        { text("R1",font = "helvetica:style=Bold", size=5); }   
     }
 }
 

--- a/Printed-Parts/SCAD/x-carriage.scad
+++ b/Printed-Parts/SCAD/x-carriage.scad
@@ -207,7 +207,7 @@ module final_cutout()
         union() 
         {
         translate([-14.199,9.05,0]) rotate([-5,0,22.5]) cylinder(r=1.62, h=40, $fn=8);    
-        translate([-14.5,9.7,8]) rotate([-5,0,22.5]) cylinder(r=1.62,r2=3, h=8, $fn=8);  
+        translate([-14.5,9.7,8]) rotate([-5,0,22.5]) cylinder(r1=1.62,r2=3, h=8, $fn=8);  
         }
     }
     

--- a/Printed-Parts/SCAD/x-end-idler.scad
+++ b/Printed-Parts/SCAD/x-end-idler.scad
@@ -42,7 +42,7 @@ module waste_pocket()
     translate([-15,-1,6]) rotate([90,0,0]) cylinder( h=5, r=5, $fn=30);     
     translate([-15,-1,51]) rotate([90,0,0]) cylinder( h=5, r=5, $fn=30);    
     translate([-15,-5.9,6]) rotate([90,0,0]) cylinder( h=3, r1=5, r2=4.3, $fn=30);     
-    translate([-15,-5.9,51]) rotate([90,0,0]) cylinder( h=3, r=5, r2=4.3, $fn=30);      
+    translate([-15,-5.9,51]) rotate([90,0,0]) cylinder( h=3, r1=5, r2=4.3, $fn=30);      
 
     // opening window
     translate([-17,-1,51]) rotate([90,0,0]) cube([4,15,4]);

--- a/Printed-Parts/SCAD/z-axis-bottom.scad
+++ b/Printed-Parts/SCAD/z-axis-bottom.scad
@@ -128,10 +128,10 @@ module z_bottom_right()
             z_bottom_holes();
         }
         translate([7.3,24,14]) rotate([90,180,90]) linear_extrude(height = 0.6) 
-        { text("R5",font = "helvetica:style=Bold", size=5, center=true); }
+        { text("R5",font = "helvetica:style=Bold", size=5); }
         
         translate([7,24,25]) rotate([90,180,90]) linear_extrude(height = 0.9) 
-        { text("R",font = "helvetica:style=Bold", size=8, center=true); }
+        { text("R",font = "helvetica:style=Bold", size=8); }
         
     }
 }
@@ -148,10 +148,10 @@ module z_bottom_left()
             z_bottom_holes();
         }
         translate([7.3,-28.5,14]) rotate([90,180,90]) linear_extrude(height = 0.6) 
-        { text("R5",font = "helvetica:style=Bold", size=5, center=true); }
+        { text("R5",font = "helvetica:style=Bold", size=5); }
         
         translate([7,-29,25]) rotate([90,180,90]) linear_extrude(height = 0.9) 
-        { text("L",font = "helvetica:style=Bold", size=8, center=true); }
+        { text("L",font = "helvetica:style=Bold", size=8); }
         
     }
 }

--- a/Printed-Parts/SCAD/z-axis-top.scad
+++ b/Printed-Parts/SCAD/z-axis-top.scad
@@ -84,7 +84,7 @@ module z_top_right(){
         z_top_holes();
          //version
         translate([12,-1.5,10]) rotate([90,180,180]) linear_extrude(height = 0.6) 
-        { text("R2",font = "helvetica:style=Bold", size=4, center=true); }
+        { text("R2",font = "helvetica:style=Bold", size=4); }
     }
 }
 
@@ -97,7 +97,7 @@ module z_top_left(){
         z_top_holes();
         //version
         translate([19,-1,10]) rotate([90,180,0]) linear_extrude(height = 0.6) 
-        { text("R2",font = "helvetica:style=Bold", size=4, center=true); }
+        { text("R2",font = "helvetica:style=Bold", size=4); }
     }
 }
 


### PR DESCRIPTION
The following issues are corrected by this change:
1. The text module does not have a "center" parameter, therefore
   there is no point in specifying it.
2. In some places for cylinders "r" and "r2" where specified instead
   of "r1" and "r2".
3. In some places the start value was larger than the end value in
   ranges.