### PR TITLE
Increase the R6 version number

### DIFF
--- a/Printed-Parts/SCAD/x-end-idler.scad
+++ b/Printed-Parts/SCAD/x-end-idler.scad
@@ -146,6 +146,9 @@ module x_end_idler()
 
         translate(v=[-8,-15.5,30.25]) rotate(a=[0,-90,0]) cylinder(h = 20, r=1.55, $fn=30);
         translate([-25,7.5,-1]) rotate([0,0,45])  cube([10,10,100]);
+	//version
+        translate([-23.7,-25,2]) rotate([90,0,90]) linear_extrude(height = 0.6) 
+        { text("R6",font = "helvetica:style=Bold", size=4, center=true); }   
     }
     
     // bearings stop

--- a/Printed-Parts/SCAD/x-end-motor.scad
+++ b/Printed-Parts/SCAD/x-end-motor.scad
@@ -100,6 +100,10 @@ module x_end_motor()
             translate([-17,3,55]) cube([4,4,10]);
             translate([-17,3,-8]) cube([4,4,10]);
             translate([-30,-30,58]) cube([30,30,10]);
+	                
+            // version
+            translate([-23.2,-20,2]) rotate([90,0,270]) linear_extrude(height = 0.6) 
+            { text("R6",font = "helvetica:style=Bold", size=4, center=true); }   
             
         }
 


### PR DESCRIPTION
Dear,
x-end-motor and x-end-idler scad file no version numbe.
The stl file has the version number of R6, I added the R6 version number to it.